### PR TITLE
[Backport] Fix resource bundle registration for java.xml.crypto TransformService

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/xml/JavaxXmlClassAndResourcesLoaderFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/xml/JavaxXmlClassAndResourcesLoaderFeature.java
@@ -33,6 +33,7 @@ import static com.oracle.svm.hosted.xml.XMLParsersRegistration.SAXParserClasses;
 import static com.oracle.svm.hosted.xml.XMLParsersRegistration.SchemaDVFactoryClasses;
 import static com.oracle.svm.hosted.xml.XMLParsersRegistration.StAXParserClasses;
 import static com.oracle.svm.hosted.xml.XMLParsersRegistration.TransformerClassesAndResources;
+import static com.oracle.svm.hosted.xml.XMLParsersRegistration.XMLCryptoTransformServiceClassesAndResources;
 
 import org.graalvm.nativeimage.hosted.FieldValueTransformer;
 
@@ -57,6 +58,10 @@ public class JavaxXmlClassAndResourcesLoaderFeature extends JNIRegistrationUtil 
 
         access.registerReachabilityHandler(new TransformerClassesAndResources()::registerConfigs,
                         method(access, "javax.xml.transform.FactoryFinder", "find", Class.class, String.class));
+
+        // TransformService of java.xml.crypto module
+        optionalMethod(access, "com.sun.org.apache.xml.internal.security.utils.I18n", "init", String.class, String.class)
+                        .ifPresent(method -> access.registerReachabilityHandler(new XMLCryptoTransformServiceClassesAndResources()::registerConfigs, method));
 
         access.registerReachabilityHandler(new DOMImplementationRegistryClasses()::registerConfigs,
                         method(access, "org.w3c.dom.bootstrap.DOMImplementationRegistry", "newInstance"));

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/xml/XMLParsersRegistration.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/xml/XMLParsersRegistration.java
@@ -154,4 +154,23 @@ public abstract class XMLParsersRegistration extends JNIRegistrationUtil {
             return Collections.singletonList("com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl");
         }
     }
+
+    static class XMLCryptoTransformServiceClassesAndResources extends XMLParsersRegistration {
+
+        @Override
+        void registerResources() {
+            /*
+             * To allow register new resource bundle classes during analysis phase
+             */
+            ClassInitializationSupport classInitializationSupport = (ClassInitializationSupport) ImageSingletons.lookup(RuntimeClassInitializationSupport.class);
+            classInitializationSupport.withUnsealedConfiguration(() -> {
+                ResourcesRegistry.singleton().addResourceBundles(ConfigurationCondition.alwaysTrue(), "com.sun.org.apache.xml.internal.security/resource/xmlsecurity");
+            });
+        }
+
+        @Override
+        List<String> xmlParserClasses() {
+            return Collections.emptyList();
+        }
+    }
 }


### PR DESCRIPTION
**Differences to graal/master PR**:

In class `XMLCryptoTransformServiceClassesAndResources` the condition changed to the GraalVM 25 variant `ConfigurationCondition.alwaysTrue()` from `AccessCondition.unconditional()` in graal/master.

**Testing**:

Reproducer from the original issue with `Mandrel-25.0.2.0-Final` (fails/unexpected):
```
$ ./testxmlsigtransform 
Exception in thread "main" java.lang.ExceptionInInitializerError
	at java.base@25.0.2/java.lang.Class.ensureInitialized(DynamicHub.java:778)
	at java.xml.crypto@25.0.2/org.jcp.xml.dsig.internal.dom.XMLDSigRI$ProviderService.newInstance(XMLDSigRI.java:124)
	at java.xml.crypto@25.0.2/javax.xml.crypto.dsig.TransformService.getInstance(TransformService.java:246)
	at java.xml.crypto@25.0.2/org.jcp.xml.dsig.internal.dom.DOMXMLSignatureFactory.newTransform(DOMXMLSignatureFactory.java:377)
	at TestXMLSigTransform.main(TestXMLSigTransform.java:11)
	at java.base@25.0.2/java.lang.invoke.LambdaForm$DMH/sa346b79c.invokeStaticInit(LambdaForm$DMH)
Caused by: java.util.MissingResourceException: Can't find bundle for base name com.sun.org.apache.xml.internal.security/resource/xmlsecurity, locale en_US
	at java.base@25.0.2/java.util.ResourceBundle.throwMissingResourceException(ResourceBundle.java:2012)
	at java.base@25.0.2/java.util.ResourceBundle.getBundleImpl(ResourceBundle.java:1664)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.localization.substitutions.Target_java_util_ResourceBundle$1.get(Target_java_util_ResourceBundle.java:123)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.localization.substitutions.Target_java_util_ResourceBundle$1.get(Target_java_util_ResourceBundle.java:120)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.MissingRegistrationUtils.runIgnoringMissingRegistrations(MissingRegistrationUtils.java:143)
	at java.base@25.0.2/java.util.ResourceBundle.getBundleImpl(ResourceBundle.java:120)
	at java.base@25.0.2/java.util.ResourceBundle.getBundleImpl(ResourceBundle.java:1529)
	at java.base@25.0.2/java.util.ResourceBundle.getBundle(ResourceBundle.java:921)
	at java.xml.crypto@25.0.2/com.sun.org.apache.xml.internal.security.utils.I18n.init(I18n.java:161)
	at java.xml.crypto@25.0.2/com.sun.org.apache.xml.internal.security.Init.dynamicInit(Init.java:121)
	at java.xml.crypto@25.0.2/com.sun.org.apache.xml.internal.security.Init.init(Init.java:100)
	at java.xml.crypto@25.0.2/org.jcp.xml.dsig.internal.dom.ApacheTransform.<clinit>(ApacheTransform.java:61)
	... 6 more

```

Reproducer from the original issue with this patch (expected):
```
$ ./testxmlsigtransform 
org.jcp.xml.dsig.internal.dom.DOMTransform@d130cf06
```

Closes: #4