### PR TITLE
Backport [GR-73283] Fix JCMD Thread.dump_to_file

### DIFF
--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -672,6 +672,7 @@ def _native_junit(native_image, unittest_args, build_args=None, run_args=None, b
         build_args.append("-D" + key + "=" + value)
 
     build_args.append('--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED')
+    build_args.append('--add-exports=java.base/jdk.internal.vm=ALL-UNNAMED')
     run_args = run_args or ['--verbose']
     junit_native_dir = join(svmbuild_dir(), platform_name(), 'junit')
     mx_util.ensure_dir_exists(junit_native_dir)

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -1129,6 +1129,7 @@ suite = {
             "requiresConcealed" : {
                 "java.base" : [
                     "jdk.internal.misc",
+                    "jdk.internal.vm",
                     "sun.security.jca",
                 ],
             },

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/dcmd/Target_jdk_internal_vm_ThreadSnapshot.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/dcmd/Target_jdk_internal_vm_ThreadSnapshot.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, 2026, IBM Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.dcmd;
+
+import java.lang.Thread.State;
+import java.util.concurrent.locks.LockSupport;
+
+import com.oracle.svm.core.SubstrateUtil;
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Delete;
+import com.oracle.svm.core.annotate.Inject;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import com.oracle.svm.core.heap.VMOperationInfos;
+import com.oracle.svm.core.monitor.JavaMonitor;
+import com.oracle.svm.core.monitor.JavaMonitorQueuedSynchronizer;
+import com.oracle.svm.core.thread.JavaThreads;
+import com.oracle.svm.core.thread.JavaVMOperation;
+import com.oracle.svm.core.thread.Target_java_lang_VirtualThread;
+import com.oracle.svm.core.thread.VMOperation;
+import com.oracle.svm.core.util.BasedOnJDKFile;
+
+@TargetClass(className = "jdk.internal.vm.ThreadSnapshot")
+final class Target_jdk_internal_vm_ThreadSnapshot {
+    @Alias //
+    String name;
+    /** Replaces {@link #threadStatus}, to avoid unnecessary conversions. */
+    @Inject //
+    State state;
+    @Delete //
+    private int threadStatus;
+    @Alias //
+    Thread carrierThread;
+    @Alias //
+    StackTraceElement[] stackTrace;
+    @Alias //
+    int blockerTypeOrdinal;
+    @Alias //
+    Object blockerObject;
+
+    @Alias //
+    Target_jdk_internal_vm_ThreadSnapshot() {
+    }
+
+    @Substitute
+    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25+26/src/java.base/share/native/libjava/ThreadSnapshot.c#L32-L36")
+    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25+36/src/hotspot/share/prims/jvm.cpp#L2964-L2971")
+    private static Target_jdk_internal_vm_ThreadSnapshot create(Thread thread) {
+        return ThreadSnapshotUtil.create(thread);
+    }
+
+    @Substitute
+    State threadState() {
+        return state;
+    }
+}
+
+@TargetClass(className = "jdk.internal.vm.ThreadSnapshot", innerClass = "BlockerLockType")
+final class Target_jdk_internal_vm_ThreadSnapshot_BlockerLockType {
+    // Checkstyle: stop
+    @Alias //
+    static Target_jdk_internal_vm_ThreadSnapshot_BlockerLockType PARK_BLOCKER;
+    // Checkstyle: resume
+}
+
+final class ThreadSnapshotUtil {
+    /**
+     * At the moment, this method only computes the most relevant data, i.e., the blocker
+     * information is incomplete and owned monitors are not supported. It is also slow because it
+     * often needs a VM operation.
+     */
+    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25+36/src/hotspot/share/services/threadService.cpp#L1437-L1554")
+    public static Target_jdk_internal_vm_ThreadSnapshot create(Thread thread) {
+        if (thread == Thread.currentThread()) {
+            /* No VM operation needed. */
+            return createSnapshot(thread);
+        }
+
+        /*
+         * Enqueue a VM operation to get a consistent state. Could use a thread-local handshake in
+         * the future (see GR-60270).
+         */
+        CreateThreadSnapshotOperation op = new CreateThreadSnapshotOperation(thread);
+        op.enqueue();
+        return op.result;
+    }
+
+    private static Target_jdk_internal_vm_ThreadSnapshot createSnapshot(Thread thread) {
+        assert thread == Thread.currentThread() || VMOperation.isInProgressAtSafepoint();
+
+        Target_jdk_internal_vm_ThreadSnapshot snapshot = new Target_jdk_internal_vm_ThreadSnapshot();
+        snapshot.stackTrace = thread.getStackTrace();
+        snapshot.name = thread.getName();
+        snapshot.state = thread.getState();
+
+        if (JavaThreads.isVirtual(thread)) {
+            Target_java_lang_VirtualThread vthread = SubstrateUtil.cast(thread, Target_java_lang_VirtualThread.class);
+            snapshot.carrierThread = JavaThreads.getVirtualThreadCarrier(vthread);
+        }
+
+        /* Setting the blocker info in cases other than PARK_BLOCKER is non-trivial. */
+        Object blocker = LockSupport.getBlocker(thread);
+        if (blocker != null && !(blocker instanceof JavaMonitor) && !(blocker instanceof JavaMonitorQueuedSynchronizer.JavaMonitorConditionObject)) {
+            snapshot.blockerTypeOrdinal = SubstrateUtil.cast(Target_jdk_internal_vm_ThreadSnapshot_BlockerLockType.PARK_BLOCKER, Enum.class).ordinal();
+            snapshot.blockerObject = blocker;
+        }
+
+        return snapshot;
+    }
+
+    private static class CreateThreadSnapshotOperation extends JavaVMOperation {
+        private final Thread thread;
+        Target_jdk_internal_vm_ThreadSnapshot result;
+
+        CreateThreadSnapshotOperation(Thread thread) {
+            super(VMOperationInfos.get(CreateThreadSnapshotOperation.class, "Create ThreadSnapshot", SystemEffect.SAFEPOINT));
+            this.thread = thread;
+        }
+
+        @Override
+        protected void operate() {
+            result = createSnapshot(thread);
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/monitor/JavaMonitorQueuedSynchronizer.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/monitor/JavaMonitorQueuedSynchronizer.java
@@ -60,7 +60,7 @@ import jdk.internal.misc.Unsafe;
  * </ul>
  */
 @BasedOnJDKClass(AbstractQueuedLongSynchronizer.class)
-abstract class JavaMonitorQueuedSynchronizer {
+public abstract class JavaMonitorQueuedSynchronizer {
     // Node status bits, also used as argument and return values
     static final int WAITING = 1; // must be 1
     static final int CANCELLED = 0x80000000; // must be negative

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/JavaThreads.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/JavaThreads.java
@@ -214,6 +214,15 @@ public final class JavaThreads {
         return carrier != null && carrier.vthread != null && Target_jdk_internal_vm_Continuation.isPinned(carrier.cont.getScope());
     }
 
+    /**
+     * Returns the carrier thread. Note that this method may only be called for the current thread
+     * or during a VM operation. Otherwise, the result could be stale.
+     */
+    public static Thread getVirtualThreadCarrier(Target_java_lang_VirtualThread thread) {
+        assert SubstrateUtil.cast(thread, Thread.class) == Thread.currentThread() || VMOperation.isInProgressAtSafepoint() : "otherwise, this information could change at any time";
+        return thread.carrierThread;
+    }
+
     @SuppressFBWarnings(value = "BC", justification = "Cast for @TargetClass")
     static Target_java_lang_ThreadGroup toTarget(ThreadGroup threadGroup) {
         return Target_java_lang_ThreadGroup.class.cast(threadGroup);


### PR DESCRIPTION
This is a backport of https://github.com/oracle/graal/pull/12926
Original PR with description: https://github.com/oracle/graal/pull/12905

**Testing**
- manual testing with jcmd to ensure no crashes when issuing: `jcmd <PID> Thread.dump_to_file test.txt`
- `mx native-unittest` 
