### PR TITLE
[AAarch64] Adapt to JDK-8364936 new in 25.0.3+1

### DIFF
--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/GraalHotSpotVMConfig.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/GraalHotSpotVMConfig.java
@@ -630,14 +630,12 @@ public class GraalHotSpotVMConfig extends GraalHotSpotVMConfigAccess {
                     osArch.equals("aarch64") && zgcSupport);
     public final int NMethodPatchingType_stw_instruction_and_data_patch = getConstant("NMethodPatchingType::stw_instruction_and_data_patch", Integer.class, -1, osArch.equals("aarch64"));
     public final int NMethodPatchingType_conc_instruction_and_data_patch = getConstant("NMethodPatchingType::conc_instruction_and_data_patch", Integer.class, -1, osArch.equals("aarch64"));
-    public final int NMethodPatchingType_conc_data_patch = getConstant("NMethodPatchingType::conc_data_patch", Integer.class, -1, osArch.equals("aarch64"));
     // @formatter:on
 
     {
         if (osArch.equals("aarch64")) {
             if (BarrierSetAssembler_nmethod_patching_type != NMethodPatchingType_stw_instruction_and_data_patch &&
-                            BarrierSetAssembler_nmethod_patching_type != NMethodPatchingType_conc_instruction_and_data_patch &&
-                            BarrierSetAssembler_nmethod_patching_type != NMethodPatchingType_conc_data_patch) {
+                            BarrierSetAssembler_nmethod_patching_type != NMethodPatchingType_conc_instruction_and_data_patch) {
                 throw new IllegalArgumentException("unsupported barrier sequence " + BarrierSetAssembler_nmethod_patching_type);
             }
         }

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/aarch64/AArch64HotSpotBackend.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/aarch64/AArch64HotSpotBackend.java
@@ -338,10 +338,6 @@ public class AArch64HotSpotBackend extends HotSpotHostBackend implements LIRGene
 
                 } else {
 
-                    if (config.BarrierSetAssembler_nmethod_patching_type == config.NMethodPatchingType_conc_data_patch) {
-                        masm.dmb(AArch64Assembler.BarrierKind.LOAD_ANY);
-                    }
-
                     AArch64Address threadDisarmedAddr = masm.makeAddress(32, thread, config.threadDisarmedOffset, scratch2);
                     masm.ldr(32, scratch2, threadDisarmedAddr);
                     masm.cmp(32, scratch1, scratch2);


### PR DESCRIPTION
JDK-8364936 removes support for `conc_data_patch` type. In the Graal compiler the only difference to `stw_instruction_and_data_patch` is a `dmb` instruction. With JDK-8364936 removing `conc_data_patch` type, the extra difference to `stw_instruction_and_data_patch` can be removed.

Closes: #10