### PR TITLE
GHA: GraalJS paths for CDTInspectorTest

### DIFF
--- a/.github/workflows/cdt-inspect.yml
+++ b/.github/workflows/cdt-inspect.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023, 2023, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # The Universal Permissive License (UPL), Version 1.0
@@ -38,16 +38,20 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# Intergation test of CDT with Inspector backend.
+# Integration test of CDT with Inspector backend.
 name: Weekly CDT Inspector
 
 on:
   schedule:
     - cron: "30 2 * * 2,5" # Tuesday and Friday at 2:30
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/cdt-inspect.yml'
 
 env:
   JAVA_HOME: ${{ github.workspace }}/jdk
-  JDK_VERSION: "latest"
+  JDK_VERSION: "25"
   MX_PATH: ${{ github.workspace }}/mx
   SE_SKIP_DRIVER_IN_PATH: "true"
 
@@ -67,8 +71,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: oracle/graaljs
+        ref: 'release/graal-vm/25.0'
         sparse-checkout: |
           graal-js
+          benchmarks
         path: ${{ github.workspace }}/js
     - name: Checkout graalvm/mx
       uses: actions/checkout@v4
@@ -80,11 +86,20 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.8'
-    - name: Fetch LabsJDK
+    - name: Get OpenJDK with static libs and jmods
       run: |
-        mkdir jdk-dl
-        ${MX_PATH}/mx --java-home= fetch-jdk --jdk-id labsjdk-ce-${JDK_VERSION} --to jdk-dl --alias ${JAVA_HOME}
-    - run: |
+        mkdir -p ${JAVA_HOME}
+        curl -sL https://api.adoptium.net/v3/binary/latest/${JDK_VERSION}/ea/linux/x64/jdk/hotspot/normal/eclipse -o jdk.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/${JDK_VERSION}/ea/linux/x64/staticlibs/hotspot/normal/eclipse -o jdk-static-libs.tar.gz
+        curl -sL https://api.adoptium.net/v3/binary/latest/${JDK_VERSION}/ea/linux/x64/jmods/hotspot/normal/eclipse -o jdk-jmods.tar.gz
+        tar xf jdk.tar.gz -C ${JAVA_HOME} --strip-components=1
+        tar xf jdk-static-libs.tar.gz -C ${JAVA_HOME} --strip-components=1
+        mkdir -p ${JAVA_HOME}/jmods
+        tar xf jdk-jmods.tar.gz -C ${JAVA_HOME}/jmods --strip-components=1
+        echo "JAVA_HOME is ${JAVA_HOME}"
+        ${JAVA_HOME}/bin/java -version
+    - name: Build and Test
+      run: |
         cd ${{ github.workspace }}/graal/vm
         ${MX_PATH}/mx --dy /tools,graal-js build
         cd tests/gh_workflows/CDTInspectorTest


### PR DESCRIPTION
fixes: #16 

* switched to compatible GraalJS https://github.com/oracle/graaljs/tree/release/graal-vm/25.0
* switched this flow to Temurin 25

The test runs in GHA and doesn't crash now:

```
E.g. in Chrome open: devtools://devtools/bundled/js_app.html?ws=127.0.0.1:38687/InspectCDT
[OUT] Opened file: StepTest.js
[OUT] Stack (1)
[OUT] :program StepTest.js:28
[OUT] Scope (3)
[OUT] Local
[OUT] this :  Object global{Object: function Object() {
[OUT] global Global
[OUT] Stack (1)
[OUT] :program StepTest.js:47
[OUT] Scope (3)
[OUT] Local
[OUT] this :  Object global{Object: function Object() {
[OUT] global Global
[OUT] Stack (1)
[OUT] :program StepTest.js:49
[OUT] Scope (3)
[OUT] Local
```

Given the component affected, I'd like to kindly ask @simonis for an opinion on the PR and on the usefulness of having this GHA weekly run.  If it's not useful, we can remove it altogether. 