### PR TITLE
Mark suite files for 25.0.3 release

### DIFF
--- a/compiler/mx.compiler/suite.py
+++ b/compiler/mx.compiler/suite.py
@@ -5,7 +5,7 @@ suite = {
 
   "groupId" : "org.graalvm.compiler",
   "version" : "25.0.3",
-  "release" : False,
+  "release" : True,
   "url" : "http://www.graalvm.org/",
   "developer" : {
     "name" : "GraalVM Development",

--- a/espresso-compiler-stub/mx.espresso-compiler-stub/suite.py
+++ b/espresso-compiler-stub/mx.espresso-compiler-stub/suite.py
@@ -25,7 +25,7 @@ suite = {
     "mxversion": "7.33.0",
     "name": "espresso-compiler-stub",
     "version": "25.0.3",
-    "release": False,
+    "release": True,
     "groupId": "org.graalvm.espresso",
     "url": "https://www.graalvm.org/reference-manual/java-on-truffle/",
     "developer": {

--- a/espresso-shared/mx.espresso-shared/suite.py
+++ b/espresso-shared/mx.espresso-shared/suite.py
@@ -26,7 +26,7 @@ suite = {
     "mxversion": "7.38.0",
     "name": "espresso-shared",
     "version" : "25.0.3",
-    "release" : False,
+    "release" : True,
     "groupId" : "org.graalvm.espresso",
     "url" : "https://www.graalvm.org/reference-manual/java-on-truffle/",
     "developer" : {

--- a/espresso/mx.espresso/suite.py
+++ b/espresso/mx.espresso/suite.py
@@ -25,7 +25,7 @@ suite = {
     "mxversion": "7.46.0",
     "name": "espresso",
     "version" : "25.0.3",
-    "release" : False,
+    "release" : True,
     "groupId" : "org.graalvm.espresso",
     "url" : "https://www.graalvm.org/reference-manual/java-on-truffle/",
     "developer" : {

--- a/regex/mx.regex/suite.py
+++ b/regex/mx.regex/suite.py
@@ -44,7 +44,7 @@ suite = {
   "name" : "regex",
 
   "version" : "25.0.3",
-  "release" : False,
+  "release" : True,
   "groupId" : "org.graalvm.regex",
   "url" : "http://www.graalvm.org/",
   "developer" : {

--- a/sdk/mx.sdk/suite.py
+++ b/sdk/mx.sdk/suite.py
@@ -42,7 +42,7 @@ suite = {
   "mxversion": "7.54.5",
   "name" : "sdk",
   "version" : "25.0.3",
-  "release" : False,
+  "release" : True,
   "sourceinprojectwhitelist" : [],
   "url" : "https://github.com/oracle/graal",
   "groupId" : "org.graalvm.sdk",

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -3,7 +3,7 @@ suite = {
     "mxversion": "7.38.0",
     "name": "substratevm",
     "version" : "25.0.3",
-    "release" : False,
+    "release" : True,
     "url" : "https://github.com/oracle/graal/tree/master/substratevm",
 
     "groupId" : "org.graalvm.nativeimage",

--- a/sulong/mx.sulong/suite.py
+++ b/sulong/mx.sulong/suite.py
@@ -2,7 +2,7 @@ suite = {
   "mxversion": "7.48.0",
   "name" : "sulong",
   "version" : "25.0.3",
-  "release" : False,
+  "release" : True,
   "versionConflictResolution" : "latest",
   "groupId": "org.graalvm.llvm",
   "url": "http://www.graalvm.org/",

--- a/tools/mx.tools/suite.py
+++ b/tools/mx.tools/suite.py
@@ -27,7 +27,7 @@ suite = {
 
     "groupId" : "org.graalvm.tools",
     "version" : "25.0.3",
-    "release" : False,
+    "release" : True,
     "url" : "http://openjdk.java.net/projects/graal",
     "developer" : {
         "name" : "GraalVM Development",

--- a/truffle/mx.truffle/suite.py
+++ b/truffle/mx.truffle/suite.py
@@ -42,7 +42,7 @@ suite = {
   "mxversion": "7.33.0",
   "name" : "truffle",
   "version" : "25.0.3",
-  "release" : False,
+  "release" : True,
   "groupId" : "org.graalvm.truffle",
   "sourceinprojectwhitelist" : [],
   "url" : "http://openjdk.java.net/projects/graal",

--- a/vm/mx.vm/suite.py
+++ b/vm/mx.vm/suite.py
@@ -2,7 +2,7 @@ suite = {
     "name": "vm",
     "version" : "25.0.3",
     "mxversion": "7.34.1",
-    "release" : False,
+    "release" : True,
     "groupId" : "org.graalvm",
 
     "url" : "http://www.graalvm.org/",

--- a/wasm/mx.wasm/suite.py
+++ b/wasm/mx.wasm/suite.py
@@ -43,7 +43,7 @@ suite = {
   "name" : "wasm",
   "groupId" : "org.graalvm.wasm",
   "version" : "25.0.3",
-  "release" : False,
+  "release" : True,
   "versionConflictResolution" : "latest",
   "url" : "http://graalvm.org/webassembly",
   "developer" : {


### PR DESCRIPTION
This is in preparation for the `25.0.3` release in April so that the tree can get tagged and a release cut downstream.

Note: The [web-image suite](https://github.com/graalvm/graalvm-community-jdk25u/blob/22a4e45693f68c14e93631a2252f008bad9f86fe/web-image/mx.web-image/suite.py#L6) file was already set `release: True` in the corresponding `suite.py` file. This should probably change for the next dev cycle for `25.0.4`.