### PR TITLE
[Backport] [Oracle GraalVM] [GR-73372] Backport to 25.0: Don't translate UnsupportedOperationException to UnsupportedMessageException for ProxyExecutable.

### DIFF
--- a/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/polyglot/ProxyAPITest.java
+++ b/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/polyglot/ProxyAPITest.java
@@ -275,6 +275,19 @@ public class ProxyAPITest {
         assertValue(value, Trait.PROXY_OBJECT, Trait.EXECUTABLE);
     }
 
+    @Test
+    public void testProxyExecutableException() {
+        Value executable = context.asValue(new ProxyExecutable() {
+            @Override
+            public Object execute(Value... arguments) {
+                throw new UnsupportedOperationException();
+            }
+        });
+        PolyglotException exception = Assert.assertThrows(PolyglotException.class, () -> executable.execute());
+        assertTrue(exception.isHostException());
+        assertTrue(exception.asHostException() instanceof UnsupportedOperationException);
+    }
+
     static class ProxyInstantiableTest implements ProxyInstantiable {
 
         Function<Value[], Object> newInstance;

--- a/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/GuestToHostCodeCache.java
+++ b/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/GuestToHostCodeCache.java
@@ -122,11 +122,7 @@ final class GuestToHostCodeCache extends GuestToHostCodeCacheBase {
         @Override
         @TruffleBoundary
         protected Object executeImpl(Object proxy, Object[] arguments) throws UnsupportedMessageException {
-            try {
-                return api.callProxyExecutableExecute(proxy, (Object[]) arguments[ARGUMENT_OFFSET]);
-            } catch (UnsupportedOperationException e) {
-                throw UnsupportedMessageException.create();
-            }
+            return api.callProxyExecutableExecute(proxy, (Object[]) arguments[ARGUMENT_OFFSET]);
         }
     }.getCallTarget();
 


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/12947

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** There were no conflicts.

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk25u/issues/26