### PR TITLE
[Backport] [Oracle GraalVM] [GR-72639] Backport to 25.0: Implement ByteArrayWasmMemory#asByteBuffer.

### DIFF
--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/memory/ByteArrayWasmMemory.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/memory/ByteArrayWasmMemory.java
@@ -48,6 +48,7 @@ import static org.graalvm.wasm.constants.Sizes.MEMORY_PAGE_SIZE;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 import org.graalvm.wasm.api.Vector128;
@@ -1070,6 +1071,12 @@ final class ByteArrayWasmMemory extends WasmMemory {
     @ExportMessage
     public void close() {
         dynamicBuffer = null;
+    }
+
+    @ExportMessage
+    @TruffleBoundary
+    public ByteBuffer asByteBuffer() {
+        return ByteBuffer.wrap(dynamicBuffer, 0, (int) byteSize());
     }
 
     @ExportMessage


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/12798

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** There were no conflicts.

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk25u/issues/35