### PR TITLE
[Backport] [Oracle GraalVM] [GR-73639] Backport to 25.0: Prevent constant folding of elements that should not be reflectively accessible

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/RuntimeMetadataEncoderImpl.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/RuntimeMetadataEncoderImpl.java
@@ -402,11 +402,11 @@ public class RuntimeMetadataEncoderImpl implements RuntimeMetadataEncoder {
         if (classes == null) {
             return null;
         }
-        AnalysisMetaAccess aMetaAccess = (AnalysisMetaAccess) ((HostedMetaAccess) metaAccess).getWrapped();
+        SubstitutionReflectivityFilter reflectivityFilter = SubstitutionReflectivityFilter.singleton();
         Set<Class<?>> reachableClasses = new HashSet<>();
         for (Class<?> clazz : classes) {
             try {
-                if (!SubstitutionReflectivityFilter.shouldExclude(clazz, aMetaAccess, aMetaAccess.getUniverse())) {
+                if (!reflectivityFilter.shouldExclude(clazz)) {
                     metaAccess.lookupJavaType(clazz);
                     reachableClasses.add(clazz);
                 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jni/JNIAccessFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jni/JNIAccessFeature.java
@@ -176,6 +176,8 @@ public class JNIAccessFeature implements Feature {
 
     private int loadedConfigurations;
 
+    private SubstitutionReflectivityFilter reflectivityFilter;
+
     private final Set<Class<?>> newClasses = Collections.newSetFromMap(new ConcurrentHashMap<>());
     private final Set<String> newNegativeClassLookups = Collections.newSetFromMap(new ConcurrentHashMap<>());
     private final Set<Executable> newMethods = Collections.newSetFromMap(new ConcurrentHashMap<>());
@@ -220,6 +222,8 @@ public class JNIAccessFeature implements Feature {
                         access.getImageClassLoader());
         loadedConfigurations += ConfigurationParserUtils.parseAndRegisterConfigurations(legacyParser, access.getImageClassLoader(), "JNI",
                         ConfigurationFiles.Options.JNIConfigurationFiles, ConfigurationFiles.Options.JNIConfigurationResources, ConfigurationFile.JNI.getFileName());
+
+        reflectivityFilter = SubstitutionReflectivityFilter.singleton();
     }
 
     private final class JNIRuntimeAccessibilitySupportImpl extends ConditionalConfigurationRegistry
@@ -416,11 +420,11 @@ public class JNIAccessFeature implements Feature {
         access.requireAnalysisIteration();
     }
 
-    private static JNIAccessibleClass addClass(Class<?> classObj, DuringAnalysisAccessImpl access) {
+    private JNIAccessibleClass addClass(Class<?> classObj, DuringAnalysisAccessImpl access) {
         if (classObj.isPrimitive()) {
             return null; // primitives cannot be looked up by name and have no methods or fields
         }
-        if (SubstitutionReflectivityFilter.shouldExclude(classObj, access.getMetaAccess(), access.getUniverse())) {
+        if (reflectivityFilter.shouldExclude(classObj)) {
             return null;
         }
         return JNIReflectionDictionary.currentLayer().addClassIfAbsent(classObj, c -> {
@@ -435,7 +439,7 @@ public class JNIAccessFeature implements Feature {
     }
 
     public void addMethod(Executable method, DuringAnalysisAccessImpl access) {
-        if (SubstitutionReflectivityFilter.shouldExclude(method, access.getMetaAccess(), access.getUniverse())) {
+        if (reflectivityFilter.shouldExclude(method)) {
             return;
         }
         JNIAccessibleClass jniClass = addClass(method.getDeclaringClass(), access);
@@ -479,7 +483,7 @@ public class JNIAccessFeature implements Feature {
         });
     }
 
-    private static void addNegativeMethodLookup(Class<?> declaringClass, String methodName, Class<?>[] parameterTypes, DuringAnalysisAccessImpl access) {
+    private void addNegativeMethodLookup(Class<?> declaringClass, String methodName, Class<?>[] parameterTypes, DuringAnalysisAccessImpl access) {
         JNIAccessibleClass jniClass = addClass(declaringClass, access);
         JNIAccessibleMethodDescriptor descriptor = JNIAccessibleMethodDescriptor.of(methodName, parameterTypes);
         jniClass.addMethodIfAbsent(descriptor, d -> JNIAccessibleMethod.negativeMethodQuery(jniClass));
@@ -505,8 +509,8 @@ public class JNIAccessFeature implements Feature {
         });
     }
 
-    private static void addField(Field reflField, boolean writable, DuringAnalysisAccessImpl access) {
-        if (SubstitutionReflectivityFilter.shouldExclude(reflField, access.getMetaAccess(), access.getUniverse())) {
+    private void addField(Field reflField, boolean writable, DuringAnalysisAccessImpl access) {
+        if (reflectivityFilter.shouldExclude(reflField)) {
             return;
         }
         JNIAccessibleClass jniClass = addClass(reflField.getDeclaringClass(), access);
@@ -531,7 +535,7 @@ public class JNIAccessFeature implements Feature {
         bb.registerAsJNIAccessed(field, writable);
     }
 
-    private static void addNegativeFieldLookup(Class<?> declaringClass, String fieldName, DuringAnalysisAccessImpl access) {
+    private void addNegativeFieldLookup(Class<?> declaringClass, String fieldName, DuringAnalysisAccessImpl access) {
         JNIAccessibleClass jniClass = addClass(declaringClass, access);
         jniClass.addFieldIfAbsent(fieldName, d -> JNIAccessibleField.negativeFieldQuery(jniClass));
     }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionDataBuilder.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reflect/ReflectionDataBuilder.java
@@ -113,6 +113,7 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
     private final SubstrateAnnotationExtractor annotationExtractor;
     private BeforeAnalysisAccessImpl analysisAccess;
     private final ClassForNameSupport classForNameSupport;
+    private SubstitutionReflectivityFilter reflectivityFilter;
 
     private boolean sealed;
 
@@ -175,6 +176,7 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
             registerConditionalConfiguration(conditionalTask.condition, (cnd) -> universe.getBigbang().postTask(debug -> conditionalTask.task.accept(cnd)));
         }
         pendingConditionalTasks.clear();
+        reflectivityFilter = SubstitutionReflectivityFilter.singleton();
     }
 
     public void beforeAnalysis(BeforeAnalysisAccessImpl beforeAnalysisAccess) {
@@ -444,7 +446,7 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
     }
 
     private void registerMethod(ConfigurationCondition cnd, boolean queriedOnly, Executable reflectExecutable) {
-        if (SubstitutionReflectivityFilter.shouldExclude(reflectExecutable, metaAccess, universe)) {
+        if (reflectivityFilter.shouldExclude(reflectExecutable)) {
             return;
         }
 
@@ -605,7 +607,7 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
     }
 
     private void registerField(ConfigurationCondition cnd, boolean queriedOnly, Field reflectField) {
-        if (SubstitutionReflectivityFilter.shouldExclude(reflectField, metaAccess, universe)) {
+        if (reflectivityFilter.shouldExclude(reflectField)) {
             return;
         }
 
@@ -1051,7 +1053,7 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
             return false;
         }
         for (Class<?> type : annotationValue.getTypes()) {
-            if (type == null || SubstitutionReflectivityFilter.shouldExclude(type, metaAccess, universe)) {
+            if (type == null || reflectivityFilter.shouldExclude(type)) {
                 return false;
             }
         }
@@ -1092,7 +1094,7 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
         if (clazz.isPrimitive()) {
             return true; // primitives cannot be looked up by name and have no methods or fields
         }
-        return SubstitutionReflectivityFilter.shouldExclude(clazz, metaAccess, universe);
+        return reflectivityFilter.shouldExclude(clazz);
     }
 
     private static <T> T queryGenericInfo(Callable<T> callable) {
@@ -1126,7 +1128,7 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
             Method[] accessors = RecordUtils.getRecordComponentAccessorMethods(clazz);
             Set<Method> unregisteredAccessors = ConcurrentHashMap.newKeySet();
             for (Method accessor : accessors) {
-                if (SubstitutionReflectivityFilter.shouldExclude(accessor, metaAccess, universe)) {
+                if (reflectivityFilter.shouldExclude(accessor)) {
                     return;
                 }
                 unregisteredAccessors.add(accessor);
@@ -1236,7 +1238,7 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
             if (sealed) {
                 throw new UnsupportedFeatureException("Registering new class for reflection when the image heap is already sealed: " + javaClass);
             }
-            if (!SubstitutionReflectivityFilter.shouldExclude(javaClass, metaAccess, universe)) {
+            if (!reflectivityFilter.shouldExclude(javaClass)) {
                 registerTypesForClass(metaAccess.lookupJavaType(javaClass), javaClass);
             }
         }
@@ -1255,7 +1257,7 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
             if (sealed) {
                 throw new UnsupportedFeatureException("Registering new field for reflection when the image heap is already sealed: " + reflectField);
             }
-            if (!SubstitutionReflectivityFilter.shouldExclude(reflectField, metaAccess, universe)) {
+            if (!reflectivityFilter.shouldExclude(reflectField)) {
                 registerTypesForField(analysisField, reflectField, false);
                 if (analysisField.getDeclaringClass().isAnnotation()) {
                     processAnnotationField(ConfigurationCondition.alwaysTrue(), reflectField);
@@ -1280,7 +1282,7 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
             if (sealed) {
                 throw new UnsupportedFeatureException("Registering new method for reflection when the image heap is already sealed: " + reflectExecutable);
             }
-            if (!SubstitutionReflectivityFilter.shouldExclude(reflectExecutable, metaAccess, universe)) {
+            if (!reflectivityFilter.shouldExclude(reflectExecutable)) {
                 registerTypesForMethod(analysisMethod, reflectExecutable);
                 if (reflectExecutable instanceof Method && reflectExecutable.getDeclaringClass().isAnnotation()) {
                     processAnnotationMethod(false, (Method) reflectExecutable);

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/snippets/ReflectionPlugins.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/snippets/ReflectionPlugins.java
@@ -30,7 +30,6 @@ import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Constructor;
-import java.lang.reflect.Executable;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -48,9 +47,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.oracle.svm.core.TrackDynamicAccessEnabled;
-import com.oracle.svm.hosted.DynamicAccessDetectionFeature;
-import com.oracle.svm.hosted.NativeImageSystemClassLoader;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.hosted.RuntimeReflection;
 import org.graalvm.nativeimage.impl.RuntimeClassInitializationSupport;
@@ -59,20 +55,22 @@ import com.oracle.graal.pointsto.infrastructure.OriginalClassProvider;
 import com.oracle.graal.pointsto.meta.AnalysisUniverse;
 import com.oracle.svm.core.MissingRegistrationUtils;
 import com.oracle.svm.core.ParsingReason;
-import com.oracle.svm.core.annotate.Delete;
+import com.oracle.svm.core.TrackDynamicAccessEnabled;
 import com.oracle.svm.core.hub.ClassForNameSupport;
 import com.oracle.svm.core.hub.PredefinedClassesSupport;
 import com.oracle.svm.core.hub.RuntimeClassLoading;
 import com.oracle.svm.core.jdk.StackTraceUtils;
 import com.oracle.svm.core.option.HostedOptionKey;
 import com.oracle.svm.core.util.VMError;
+import com.oracle.svm.hosted.DynamicAccessDetectionFeature;
 import com.oracle.svm.hosted.ExceptionSynthesizer;
 import com.oracle.svm.hosted.FallbackFeature;
 import com.oracle.svm.hosted.ImageClassLoader;
+import com.oracle.svm.hosted.NativeImageSystemClassLoader;
 import com.oracle.svm.hosted.ReachabilityRegistrationNode;
 import com.oracle.svm.hosted.classinitialization.ClassInitializationSupport;
 import com.oracle.svm.hosted.substitute.AnnotationSubstitutionProcessor;
-import com.oracle.svm.hosted.substitute.DeletedElementException;
+import com.oracle.svm.hosted.substitute.SubstitutionReflectivityFilter;
 import com.oracle.svm.util.ModuleSupport;
 import com.oracle.svm.util.ReflectionUtil;
 import com.oracle.svm.util.TypeResult;
@@ -90,7 +88,6 @@ import jdk.graal.compiler.nodes.graphbuilderconf.InvocationPlugins.Registration;
 import jdk.graal.compiler.options.Option;
 import jdk.vm.ci.meta.JavaConstant;
 import jdk.vm.ci.meta.JavaKind;
-import jdk.vm.ci.meta.MetaAccessProvider;
 import jdk.vm.ci.meta.ResolvedJavaField;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.ResolvedJavaType;
@@ -127,6 +124,7 @@ public final class ReflectionPlugins {
     private final ClassInitializationSupport classInitializationSupport;
     private final boolean trackDynamicAccess;
     private final DynamicAccessDetectionFeature dynamicAccessDetectionFeature;
+    private final SubstitutionReflectivityFilter reflectivityFilter;
 
     private ReflectionPlugins(ImageClassLoader imageClassLoader, AnnotationSubstitutionProcessor annotationSubstitutions,
                     ClassInitializationPlugin classInitializationPlugin, AnalysisUniverse aUniverse, ParsingReason reason, FallbackFeature fallbackFeature) {
@@ -141,6 +139,8 @@ public final class ReflectionPlugins {
         dynamicAccessDetectionFeature = trackDynamicAccess ? DynamicAccessDetectionFeature.instance() : null;
 
         this.classInitializationSupport = (ClassInitializationSupport) ImageSingletons.lookup(RuntimeClassInitializationSupport.class);
+
+        this.reflectivityFilter = SubstitutionReflectivityFilter.singleton();
     }
 
     public static void registerInvocationPlugins(ImageClassLoader imageClassLoader, AnnotationSubstitutionProcessor annotationSubstitutions,
@@ -709,12 +709,12 @@ public final class ReflectionPlugins {
      * compilation, not a lossy copy of it.
      */
     @SuppressWarnings("unchecked")
-    private <T> T getIntrinsic(GraphBuilderContext context, T element) {
+    private <T> T getIntrinsic(T element) {
         if (reason == ParsingReason.AutomaticUnsafeTransformation || reason == ParsingReason.EarlyClassInitializerAnalysis) {
             /* We are analyzing the static initializers and should always intrinsify. */
             return element;
         }
-        if (isDeleted(element, context.getMetaAccess())) {
+        if (element instanceof AnnotatedElement annotatedElement && reflectivityFilter.shouldExcludeElement(annotatedElement)) {
             /*
              * Should not intrinsify. Will fail during the reflective lookup at runtime. @Delete-ed
              * elements are ignored by the reflection plugins regardless of the value of
@@ -733,7 +733,7 @@ public final class ReflectionPlugins {
             /* We are analyzing the static initializers and should always intrinsify. */
             return context.getSnippetReflection().forObject(element);
         }
-        if (isDeleted(element, context.getMetaAccess())) {
+        if (element instanceof AnnotatedElement annotatedElement && reflectivityFilter.shouldExcludeElement(annotatedElement)) {
             /*
              * Should not intrinsify. Will fail during the reflective lookup at runtime. @Delete-ed
              * elements are ignored by the reflection plugins regardless of the value of
@@ -744,31 +744,9 @@ public final class ReflectionPlugins {
         return aUniverse.replaceObjectWithConstant(element, context.getSnippetReflection()::forObject);
     }
 
-    private static <T> boolean isDeleted(T element, MetaAccessProvider metaAccess) {
-        AnnotatedElement annotated = null;
-        try {
-            if (element instanceof Executable) {
-                annotated = metaAccess.lookupJavaMethod((Executable) element);
-            } else if (element instanceof Field) {
-                annotated = metaAccess.lookupJavaField((Field) element);
-            }
-        } catch (DeletedElementException ex) {
-            /*
-             * If ReportUnsupportedElementsAtRuntime is *not* set looking up a @Delete-ed element
-             * will result in a DeletedElementException.
-             */
-            return true;
-        }
-        /*
-         * If ReportUnsupportedElementsAtRuntime is set looking up a @Delete-ed element will return
-         * a substitution method that has the @Delete annotation.
-         */
-        return annotated != null && annotated.isAnnotationPresent(Delete.class);
-    }
-
     private JavaConstant pushConstant(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Supplier<String> targetParameters, JavaKind returnKind, Object returnValue,
                     boolean allowNullReturnValue) {
-        Object intrinsicValue = getIntrinsic(b, returnValue == null && allowNullReturnValue ? NULL_MARKER : returnValue);
+        Object intrinsicValue = getIntrinsic(returnValue == null && allowNullReturnValue ? NULL_MARKER : returnValue);
         if (intrinsicValue == null) {
             return null;
         }
@@ -793,7 +771,7 @@ public final class ReflectionPlugins {
         if (exceptionMethod == null) {
             return false;
         }
-        Method intrinsic = getIntrinsic(b, exceptionMethod);
+        Method intrinsic = getIntrinsic(exceptionMethod);
         if (intrinsic == null) {
             return false;
         }

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/ReflectionRegistrationTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/ReflectionRegistrationTest.java
@@ -25,16 +25,16 @@
  */
 package com.oracle.svm.test;
 
-import com.oracle.svm.hosted.FeatureImpl;
-import com.oracle.svm.hosted.substitute.SubstitutionReflectivityFilter;
+import java.lang.reflect.Executable;
+import java.lang.reflect.Field;
+
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.hosted.RuntimeReflection;
 import org.graalvm.nativeimage.impl.RuntimeReflectionSupport;
 import org.junit.Test;
 
-import java.lang.reflect.Executable;
-import java.lang.reflect.Field;
+import com.oracle.svm.hosted.substitute.SubstitutionReflectivityFilter;
 
 /**
  * Tests the {@link RuntimeReflection}.
@@ -90,21 +90,21 @@ public class ReflectionRegistrationTest {
                 assert e.getMessage().startsWith("Cannot use null value");
             }
 
-            FeatureImpl.BeforeAnalysisAccessImpl impl = (FeatureImpl.BeforeAnalysisAccessImpl) access;
+            var reflectivityFilter = SubstitutionReflectivityFilter.singleton();
             try {
-                SubstitutionReflectivityFilter.shouldExclude((Class<?>) null, impl.getMetaAccess(), impl.getUniverse());
+                reflectivityFilter.shouldExclude((Class<?>) null);
                 assert false;
             } catch (NullPointerException e) {
                 // expected
             }
             try {
-                SubstitutionReflectivityFilter.shouldExclude((Executable) null, impl.getMetaAccess(), impl.getUniverse());
+                reflectivityFilter.shouldExclude((Executable) null);
                 assert false;
             } catch (NullPointerException e) {
                 // expected
             }
             try {
-                SubstitutionReflectivityFilter.shouldExclude((Field) null, impl.getMetaAccess(), impl.getUniverse());
+                reflectivityFilter.shouldExclude((Field) null);
                 assert false;
             } catch (NullPointerException e) {
                 // expected


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/12190

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** 
```
<<<<<<< HEAD

    private boolean sealed;
=======
    private LayeredReflectionDataBuilder layeredReflectionDataBuilder;
    private SubstitutionReflectivityFilter reflectivityFilter;
>>>>>>> 8faf4bb9fd5 (Ensure elements that should not be reflectively accessible are not constant folded in the ReflectionPlugins)
```
- resolution: just adding a new field as in the change:
`  +    private SubstitutionReflectivityFilter reflectivityFilter;`
- why conflict: reflectivityFilter on oracle is a part of https://github.com/oracle/graal/commit/2b07fbfc change

```
<<<<<<< HEAD
        pendingConditionalTasks.clear();
=======
        reflectivityFilter = SubstitutionReflectivityFilter.singleton();
>>>>>>> 8faf4bb9fd5 (Ensure elements that should not be reflectively accessible are not constant folded in the ReflectionPlugins)
```
- resolution: apply both changes: `reflectivityFilter` initialization and leave `pendingConditionalTasks.clear()`

```
<<<<<<< HEAD
=======
    private final DynamicAccessInferenceLog inferenceLog;
    private final SubstitutionReflectivityFilter reflectivityFilter;
>>>>>>> 8faf4bb9fd5 (Ensure elements that should not be reflectively accessible are not constant folded in the ReflectionPlugins)
```
- resolution: add only reflectivityFilter field:
  `+   private final SubstitutionReflectivityFilter reflectivityFilter`
- inferenceLog comes in oracle with: https://github.com/oracle/graal/commit/63e4d072

```
<<<<<<< HEAD
=======

        this.inferenceLog = DynamicAccessInferenceLog.singletonOrNull();

        this.reflectivityFilter = SubstitutionReflectivityFilter.singleton();
>>>>>>> 8faf4bb9fd5 (Ensure elements that should not be reflectively accessible are not constant folded in the ReflectionPlugins)
```
- just add reflectivityFilter initalization. inferenceLog is not a part of the change
  `+        this.reflectivityFilter = SubstitutionReflectivityFilter.singleton();`

```
<<<<<<< HEAD
    private static <T> boolean isDeleted(T element, MetaAccessProvider metaAccess) {
        AnnotatedElement annotated = null;
        try {
            if (element instanceof Executable) {
                annotated = metaAccess.lookupJavaMethod((Executable) element);
            } else if (element instanceof Field) {
                annotated = metaAccess.lookupJavaField((Field) element);
            }
        } catch (DeletedElementException ex) {
            /*
             * If ReportUnsupportedElementsAtRuntime is *not* set looking up a @Delete-ed element
             * will result in a DeletedElementException.
             */
            return true;
        }
        /*
         * If ReportUnsupportedElementsAtRuntime is set looking up a @Delete-ed element will return
         * a substitution method that has the @Delete annotation.
         */
        return annotated != null && annotated.isAnnotationPresent(Delete.class);
    }

    private JavaConstant pushConstant(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Supplier<String> targetParameters, JavaKind returnKind, Object returnValue,
                    boolean allowNullReturnValue) {
        Object intrinsicValue = getIntrinsic(b, returnValue == null && allowNullReturnValue ? NULL_MARKER : returnValue);
=======
    private JavaConstant pushConstant(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Object receiver, Object[] arguments, JavaKind returnKind, Object returnValue,
                    boolean allowNullReturnValue, boolean subjectToStrictDynamicAccessInference) {
        Object intrinsicValue = getIntrinsic(returnValue == null && allowNullReturnValue ? NULL_MARKER : returnValue);
>>>>>>> 8faf4bb9fd5 (Ensure elements that should not be reflectively accessible are not constant folded in the ReflectionPlugins)
```
- follow the change: delete isDeleted method, apply getIntrinsic params update


<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk25u/issues/22