### PR TITLE
[Backport] [Oracle GraalVM] [GR-72665] Backport to 25.0: TruffleString: Fix wrong assertion in TransCodeIntlNode.

### DIFF
--- a/truffle/CHANGELOG.md
+++ b/truffle/CHANGELOG.md
@@ -33,6 +33,7 @@ This changelog summarizes major changes between Truffle versions relevant to lan
 * GR-65616 Added `ExactMath.truncateToUnsignedInt(float)` and `ExactMath.truncateToUnsignedLong(double)` methods that remove the decimal part (round toward zero) of a floating point (float or double) value and convert it to a saturated unsigned integer (int or long) value. These methods are intrinsic candidates.
 * GR-65616 Added `ExactMath.unsignedToFloat(long)` and `ExactMath.unsignedToDouble(long)` methods to convert an unsigned `long` to the closest `float` and `double` value, respectively. These methods are intrinsic candidates.
 * GR-67821: `TruffleLanguage.Env#createSystemThread` is now allowed to be be called from a system thread now without an explicitly entered context.
+* GR-44829: `TruffleString` nodes no longer profile the `expectedEncoding` parameter for interpreter performance reasons. Languages with non-constant string encodings should profile the encoding before passing it to `TruffleString` nodes.
 
 ## Version 24.2.0
 * GR-60636 Truffle now stops compiling when the code cache fills up on HotSpot. A warning is printed when that happens.

--- a/truffle/docs/TruffleStrings.md
+++ b/truffle/docs/TruffleStrings.md
@@ -275,8 +275,10 @@ Every `TruffleString` is encoded in a specific internal encoding, which is set d
 `TruffleString` is fully optimized for the following encodings:
 
 * `UTF-8`
-* `UTF-16`
-* `UTF-32`
+* `UTF-16LE`
+* `UTF-16BE`
+* `UTF-32LE`
+* `UTF-32BE`
 * `US-ASCII`
 * `ISO-8859-1`
 * `BYTES`
@@ -351,6 +353,9 @@ abstract static class SomeNode extends Node {
     }
 }
 ```
+
+For optimal performance, the `expectedEncoding` parameter of `TruffleString` nodes should be partial-evaluation-constant whenever possible. `TruffleString` nodes don't profile this parameter, since most languages use a single constant encoding.
+
 
 ### String Properties
 

--- a/truffle/src/com.oracle.truffle.api.strings/src/com/oracle/truffle/api/strings/TStringInternalNodes.java
+++ b/truffle/src/com.oracle.truffle.api.strings/src/com/oracle/truffle/api/strings/TStringInternalNodes.java
@@ -2392,7 +2392,7 @@ final class TStringInternalNodes {
             assert !is7Bit(codeRangeA);
             TruffleStringIterator it = AbstractTruffleString.forwardIterator(a, arrayA, offsetA, codeRangeA, sourceEncoding);
             boolean allowUTF16Surrogates = errorHandler == TranscodingErrorHandler.DEFAULT_KEEP_SURROGATES_IN_UTF8;
-            DecodingErrorHandler decodingErrorHandler = getDecodingErrorHandler(errorHandler);
+            DecodingErrorHandler decodingErrorHandler = getDecodingErrorHandler(errorHandler, codeRangeA);
             byte[] buffer = new byte[isLarge ? TStringConstants.MAX_ARRAY_SIZE : codePointLengthA * 4];
             int codeRange = TSCodeRange.get7Bit();
             int length = 0;
@@ -2567,7 +2567,7 @@ final class TStringInternalNodes {
             int codePointLength = codePointLengthA;
             int length = 0;
             int codeRange = TSCodeRange.get7Bit();
-            DecodingErrorHandler decodingErrorHandler = getDecodingErrorHandler(errorHandler);
+            DecodingErrorHandler decodingErrorHandler = getDecodingErrorHandler(errorHandler, codeRangeA);
             while (it.hasNext()) {
                 int curIndex = it.getRawIndex();
                 int codepoint = iteratorNextNode.execute(node, it, sourceEncoding, decodingErrorHandler);
@@ -2660,7 +2660,7 @@ final class TStringInternalNodes {
             int codePointLength = 0;
             int length = 0;
             int codeRange = TSCodeRange.getValidMultiByte();
-            DecodingErrorHandler decodingErrorHandler = getDecodingErrorHandler(errorHandler);
+            DecodingErrorHandler decodingErrorHandler = getDecodingErrorHandler(errorHandler, codeRangeA);
             int loopCount = 0;
             while (it.hasNext()) {
                 int codepoint = iteratorNextNode.execute(node, it, sourceEncoding, decodingErrorHandler);
@@ -2710,7 +2710,7 @@ final class TStringInternalNodes {
                         @Cached @Shared("iteratorNextNode") TruffleStringIterator.InternalNextNode iteratorNextNode) {
             assert containsSurrogates(a);
             boolean allowUTF16Surrogates = isAllowUTF16SurrogatesUTF16Or32(errorHandler);
-            DecodingErrorHandler decodingErrorHandler = getDecodingErrorHandler(errorHandler);
+            DecodingErrorHandler decodingErrorHandler = getDecodingErrorHandler(errorHandler, codeRangeA);
             TruffleStringIterator it = AbstractTruffleString.forwardIterator(a, arrayA, offsetA, codeRangeA, sourceEncoding);
             byte[] buffer = new byte[codePointLengthA << 2];
             int length = 0;
@@ -2735,7 +2735,7 @@ final class TStringInternalNodes {
                         TruffleStringIterator.InternalNextNode iteratorNextNode) {
             assert TStringGuards.isValidOrBrokenMultiByte(codeRangeA);
             TruffleStringIterator it = AbstractTruffleString.forwardIterator(a, arrayA, offsetA, codeRangeA, sourceEncoding);
-            DecodingErrorHandler decodingErrorHandler = getDecodingErrorHandler(errorHandler);
+            DecodingErrorHandler decodingErrorHandler = getDecodingErrorHandler(errorHandler, codeRangeA);
             byte[] buffer = new byte[codePointLengthA];
             int offsetBuf = byteArrayBaseOffset();
             int length = 0;
@@ -2818,7 +2818,7 @@ final class TStringInternalNodes {
                         TranscodingErrorHandler errorHandler,
                         TruffleStringIterator.InternalNextNode iteratorNextNode) {
             TruffleStringIterator it = AbstractTruffleString.forwardIterator(a, arrayA, offsetA, codeRangeA, sourceEncoding);
-            DecodingErrorHandler decodingErrorHandler = getDecodingErrorHandler(errorHandler);
+            DecodingErrorHandler decodingErrorHandler = getDecodingErrorHandler(errorHandler, codeRangeA);
             byte[] buffer = new byte[codePointLengthA << 2];
             int length = 0;
             int codeRange = TSCodeRange.getValidMultiByte();
@@ -2852,8 +2852,8 @@ final class TStringInternalNodes {
             return array;
         }
 
-        private static DecodingErrorHandler getDecodingErrorHandler(TranscodingErrorHandler errorHandler) {
-            assert errorHandler == TranscodingErrorHandler.DEFAULT || errorHandler == TranscodingErrorHandler.DEFAULT_KEEP_SURROGATES_IN_UTF8;
+        private static DecodingErrorHandler getDecodingErrorHandler(TranscodingErrorHandler errorHandler, int codeRangeA) {
+            assert errorHandler == TranscodingErrorHandler.DEFAULT || errorHandler == TranscodingErrorHandler.DEFAULT_KEEP_SURROGATES_IN_UTF8 || !TSCodeRange.isBroken(codeRangeA);
             CompilerAsserts.partialEvaluationConstant(errorHandler);
             DecodingErrorHandler decodingErrorHandler = errorHandler == TranscodingErrorHandler.DEFAULT ? DecodingErrorHandler.DEFAULT_UTF8_INCOMPLETE_SEQUENCES
                             : DecodingErrorHandler.DEFAULT_KEEP_SURROGATES_IN_UTF8;


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/12745
  - commit#1: https://github.com/oracle/graal/pull/12745/changes/140ca8b4

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:**

```
<<<<<<< HEAD
            int codeRange = TSCodeRange.getValidMultiByte();
            DecodingErrorHandler decodingErrorHandler = getDecodingErrorHandler(errorHandler);
=======
            int codeRange = TSCodeRange.get7Bit();
            DecodingErrorHandler decodingErrorHandler = getDecodingErrorHandler(errorHandler, codeRangeA);
>>>>>>> 140ca8b4d23 (TruffleString: Fix wrong assertion in TransCodeIntlNode)
```

- conflict is caused by extra commit on oracle https://github.com/oracle/graal/commit/5dbb9dc9bc07e7f1e3e903bfd8da64dd3941399e:
`    TruffleStrings: Full CodeRange support for foreign endian UTF-16 and UTF-32 variants.`:
`-            int codeRange = TSCodeRange.getValidMultiByte();`
`+            int codeRange = TSCodeRange.get7Bit();`
- resolution: follow the change, update only getDecodingErrorHandler call

```
<<<<<<< HEAD
            DecodingErrorHandler decodingErrorHandler = getDecodingErrorHandler(errorHandler);
            TruffleStringIterator it = AbstractTruffleString.forwardIterator(a, arrayA, offsetA, codeRangeA, sourceEncoding);
=======
            DecodingErrorHandler decodingErrorHandler = getDecodingErrorHandler(errorHandler, codeRangeA);
            TruffleStringIterator it = AbstractTruffleString.forwardIterator(a, arrayA, offsetA, lengthA, strideA, codeRangeA, sourceEncoding);
>>>>>>> 140ca8b4d23 (TruffleString: Fix wrong assertion in TransCodeIntlNode)

<<<<<<< HEAD
            TruffleStringIterator it = AbstractTruffleString.forwardIterator(a, arrayA, offsetA, codeRangeA, sourceEncoding);
            DecodingErrorHandler decodingErrorHandler = getDecodingErrorHandler(errorHandler);
=======
            TruffleStringIterator it = AbstractTruffleString.forwardIterator(a, arrayA, offsetA, lengthA, strideA, codeRangeA, sourceEncoding);
            DecodingErrorHandler decodingErrorHandler = getDecodingErrorHandler(errorHandler, codeRangeA);
>>>>>>> 140ca8b4d23 (TruffleString: Fix wrong assertion in TransCodeIntlNode)

<<<<<<< HEAD
            TruffleStringIterator it = AbstractTruffleString.forwardIterator(a, arrayA, offsetA, codeRangeA, sourceEncoding);
            DecodingErrorHandler decodingErrorHandler = getDecodingErrorHandler(errorHandler);
=======
            TruffleStringIterator it = AbstractTruffleString.forwardIterator(a, arrayA, offsetA, lengthA, strideA, codeRangeA, sourceEncoding);
            DecodingErrorHandler decodingErrorHandler = getDecodingErrorHandler(errorHandler, codeRangeA);
>>>>>>> 140ca8b4d23 (TruffleString: Fix wrong assertion in TransCodeIntlNode)
```

- conflict is caused by extra commit on oracle https://github.com/oracle/graal/commit/9576ccc4dfb6786bb3acd509bb07aa6eedc4c202:
`    TruffleString: preparatory internal refactorings for object layout optimizations.`
`-            TruffleStringIterator it = AbstractTruffleString.forwardIterator(a, arrayA, offsetA, codeRangeA, sourceEncoding);`
`+            TruffleStringIterator it = AbstractTruffleString.forwardIterator(a, arrayA, offsetA, lengthA, strideA, codeRangeA, sourceEncoding);`
- resolution: follow the change, update only getDecodingErrorHandler call


<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk25u/issues/31