### PR TITLE
Add an inlining stage for single callsite methods

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, 2026, IBM Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -910,7 +911,11 @@ public class SubstrateOptions {
     @Option(help = "Perform trivial method inlining in the AOT compiled native image")//
     public static final HostedOptionKey<Boolean> AOTTrivialInline = new HostedOptionKey<>(true);
 
-    @LayerVerifiedOption(kind = Kind.Removed, severity = Severity.Error, positional = false)//
+    @LayerVerifiedOption(kind = Kind.Changed, severity = Severity.Error)//
+    @Option(help = "Perform single callsite method inlining in the AOT compiled native image")//
+    public static final HostedOptionKey<Boolean> AOTSingleCallsiteInline = new HostedOptionKey<>(true);
+
+    @LayerVerifiedOption(kind = Kind.Removed, severity = Severity.Error, positional = false)
     @Option(help = "file:doc-files/NeverInlineHelp.txt", type = OptionType.Debug)//
     public static final HostedOptionKey<AccumulatingLocatableMultiOptionValue.Strings> NeverInline = new HostedOptionKey<>(AccumulatingLocatableMultiOptionValue.Strings.build());
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -915,7 +915,7 @@ public class SubstrateOptions {
     @Option(help = "Perform single callsite method inlining in the AOT compiled native image")//
     public static final HostedOptionKey<Boolean> AOTSingleCallsiteInline = new HostedOptionKey<>(true);
 
-    @LayerVerifiedOption(kind = Kind.Removed, severity = Severity.Error, positional = false)
+    @LayerVerifiedOption(kind = Kind.Removed, severity = Severity.Error, positional = false)//
     @Option(help = "file:doc-files/NeverInlineHelp.txt", type = OptionType.Debug)//
     public static final HostedOptionKey<AccumulatingLocatableMultiOptionValue.Strings> NeverInline = new HostedOptionKey<>(AccumulatingLocatableMultiOptionValue.Strings.build());
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -912,8 +912,8 @@ public class SubstrateOptions {
     public static final HostedOptionKey<Boolean> AOTTrivialInline = new HostedOptionKey<>(true);
 
     @LayerVerifiedOption(kind = Kind.Changed, severity = Severity.Error)//
-    @Option(help = "Perform single callsite method inlining in the AOT compiled native image")//
-    public static final HostedOptionKey<Boolean> AOTSingleCallsiteInline = new HostedOptionKey<>(true);
+    @Option(help = "Perform single callsite method inlining in the AOT compiled native image", stability = OptionStability.EXPERIMENTAL)//
+    public static final HostedOptionKey<Boolean> AOTSingleCallsiteInline = new HostedOptionKey<>(false);
 
     @LayerVerifiedOption(kind = Kind.Removed, severity = Severity.Error, positional = false)//
     @Option(help = "file:doc-files/NeverInlineHelp.txt", type = OptionType.Debug)//

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/CompilationInfo.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/CompilationInfo.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, 2026, IBM Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +26,7 @@
 package com.oracle.svm.hosted.code;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import jdk.graal.compiler.core.common.CompilationIdentifier;
@@ -45,6 +47,9 @@ import com.oracle.svm.hosted.code.CompileQueue.ParseHooks;
 import com.oracle.svm.hosted.meta.HostedMethod;
 
 public class CompilationInfo {
+    int sizeLastRound;
+
+    AtomicInteger callsites = new AtomicInteger();
 
     protected final HostedMethod method;
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/CompileQueue.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/CompileQueue.java
@@ -788,7 +788,7 @@ public class CompileQueue {
     protected void inlineSingleCallsiteMethods(DebugContext debug) throws InterruptedException {
         inliningRound = 0;
         // First count callsites
-        try (Indent _ = debug.logAndIndent("==== Single Callsite Inlining: counting callsites")) {
+        try (Indent ignored = debug.logAndIndent("==== Single Callsite Inlining: counting callsites")) {
             runOnExecutor(() -> {
                 universe.getMethods().forEach(method -> {
                     assert method.isOriginalMethod();
@@ -805,7 +805,7 @@ public class CompileQueue {
         // Inline single callsite methods
         do {
             beginRound();
-            try (Indent _ = debug.logAndIndent("==== Single Callsite Inlining  round %n")) {
+            try (Indent ignored = debug.logAndIndent("==== Single Callsite Inlining  round %n")) {
                 runOnExecutor(() -> {
                     universe.getMethods().forEach(method -> {
                         assert method.isOriginalMethod();
@@ -979,10 +979,11 @@ public class CompileQueue {
         }
     }
 
+    @SuppressWarnings("try")
     private void doInlineSingleCallsite(DebugContext debug, HostedMethod method) {
         var providers = runtimeConfig.lookupBackend(method).getProviders();
         var graph = method.compilationInfo.createGraph(debug, getCustomizedOptions(method, debug), CompilationIdentifier.INVALID_COMPILATION_ID, false);
-        try (var _ = debug.scope("InlineSingleCallsites", graph, method, this)) {
+        try (var ignored = debug.scope("InlineSingleCallsites", graph, method, this)) {
             var inliningPlugin = new SingleCallsiteInliningPlugin();
             var decoder = new InliningGraphDecoder(graph, providers, inliningPlugin);
             new InlinePhase(decoder, method, "SingleCallsiteInline").apply(graph);
@@ -1016,7 +1017,7 @@ public class CompileQueue {
     }
 
     private boolean makeSingleCallsiteInlineDecision(HostedMethod caller, HostedMethod callee) {
-        if (!isCalleeGraphAvailable(caller, callee)) {
+        if (!isCalleeGraphAvailable(caller, callee) || !callee.getWrapped().canBeInlined()) {
             return false;
         }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/CompileQueue.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/CompileQueue.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, 2026, IBM Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +42,6 @@ import java.util.concurrent.ConcurrentMap;
 import org.graalvm.nativeimage.ImageSingletons;
 
 import com.oracle.graal.pointsto.api.PointstoOptions;
-import com.oracle.graal.pointsto.flow.AnalysisParsedGraph;
 import com.oracle.graal.pointsto.meta.HostedProviders;
 import com.oracle.graal.pointsto.util.CompletionExecutor;
 import com.oracle.graal.pointsto.util.CompletionExecutor.DebugContextRunnable;
@@ -81,7 +81,6 @@ import com.oracle.svm.util.ImageBuildStatistics;
 
 import jdk.graal.compiler.api.replacements.Fold;
 import jdk.graal.compiler.asm.Assembler;
-import jdk.graal.compiler.bytecode.BytecodeProvider;
 import jdk.graal.compiler.code.CompilationResult;
 import jdk.graal.compiler.core.GraalCompiler;
 import jdk.graal.compiler.core.common.CompilationIdentifier;
@@ -104,7 +103,6 @@ import jdk.graal.compiler.lir.framemap.FrameMap;
 import jdk.graal.compiler.lir.phases.LIRSuites;
 import jdk.graal.compiler.nodes.CallTargetNode;
 import jdk.graal.compiler.nodes.ConstantNode;
-import jdk.graal.compiler.nodes.EncodedGraph;
 import jdk.graal.compiler.nodes.FrameState;
 import jdk.graal.compiler.nodes.GraphEncoder;
 import jdk.graal.compiler.nodes.GraphState.StageFlag;
@@ -119,6 +117,7 @@ import jdk.graal.compiler.nodes.graphbuilderconf.InlineInvokePlugin;
 import jdk.graal.compiler.nodes.java.MethodCallTargetNode;
 import jdk.graal.compiler.nodes.spi.CoreProviders;
 import jdk.graal.compiler.options.OptionValues;
+import jdk.graal.compiler.phases.contract.NodeCostUtil;
 import jdk.graal.compiler.phases.OptimisticOptimizations;
 import jdk.graal.compiler.phases.Phase;
 import jdk.graal.compiler.phases.PhaseSuite;
@@ -160,6 +159,12 @@ public class CompileQueue {
         }
     }
 
+    /*
+     * Use the same fallback as
+     * "An Optimization-Driven Incremental Inline Substitution Algorithm for Just-in-Time Compilers"
+     */
+    private static final int FALLBACK_SIZE = 50000;
+
     protected final HostedUniverse universe;
     private final Boolean deoptimizeAll;
     protected final List<Policy> policies;
@@ -182,12 +187,20 @@ public class CompileQueue {
     private final boolean printMethodHistogram = NativeImageOptions.PrintMethodHistogram.getValue();
     private final boolean optionAOTTrivialInline = SubstrateOptions.AOTTrivialInline.getValue();
 
-    public record UnpublishedTrivialMethods(CompilationGraph unpublishedGraph, boolean newlyTrivial) {
+    public record UnpublishedMethodInfo(CompilationGraph unpublishedGraph, boolean newlyTrivial) {
     }
 
-    private final ConcurrentMap<HostedMethod, UnpublishedTrivialMethods> unpublishedTrivialMethods = new ConcurrentHashMap<>();
+    private final ConcurrentMap<HostedMethod, UnpublishedMethodInfo> unpublishedMethods = new ConcurrentHashMap<>();
+
+    /*
+     * Edge case handling: For each method, track that last round that Single Callsite Inlining was
+     * unsuccessful
+     */
+    private final ConcurrentMap<HostedMethod, Integer> sciLastRoundFailed = new ConcurrentHashMap<>();
 
     private final LayeredDispatchTableFeature layeredDispatchTableSupport = ImageLayerBuildingSupport.buildingSharedLayer() ? LayeredDispatchTableFeature.singleton() : null;
+
+    private int inliningRound = 0;
 
     public abstract static class CompileReason {
         /**
@@ -343,6 +356,27 @@ public class CompileQueue {
         }
     }
 
+    protected class SingleCallsiteInlineTask implements Task {
+
+        private final HostedMethod method;
+        private final Description description;
+
+        SingleCallsiteInlineTask(HostedMethod method) {
+            this.method = method;
+            this.description = new Description(method, method.getName());
+        }
+
+        @Override
+        public void run(DebugContext debug) {
+            doInlineSingleCallsite(debug, method);
+        }
+
+        @Override
+        public Description getDescription() {
+            return description;
+        }
+    }
+
     public class ParseTask implements Task {
 
         protected final CompileReason reason;
@@ -433,7 +467,11 @@ public class CompileQueue {
                 ImageSingletons.lookup(HostedHeapDumpFeature.class).beforeInlining();
             }
             try (ProgressReporter.ReporterClosable ac = reporter.printInlining()) {
+                // The trivial stage must be run to handle any forced inlining due to annotations
                 inlineTrivialMethods(debug);
+                if (SubstrateOptions.AOTSingleCallsiteInline.getValue()) {
+                    inlineSingleCallsiteMethods(debug);
+                }
             }
             if (ImageSingletons.contains(HostedHeapDumpFeature.class)) {
                 ImageSingletons.lookup(HostedHeapDumpFeature.class).afterInlining();
@@ -709,12 +747,10 @@ public class CompileQueue {
 
     @SuppressWarnings("try")
     protected void inlineTrivialMethods(DebugContext debug) throws InterruptedException {
-        int round = 0;
+        inliningRound = 0;
         do {
-            ProgressReporter.singleton().reportStageProgress();
-            inliningProgress = false;
-            round++;
-            try (Indent ignored = debug.logAndIndent("==== Trivial Inlining  round %d%n", round)) {
+            beginRound();
+            try (Indent ignored = debug.logAndIndent("==== Trivial Inlining  round %d%n", inliningRound)) {
                 runOnExecutor(() -> {
                     universe.getMethods().forEach(method -> {
                         assert method.isOriginalMethod();
@@ -727,15 +763,102 @@ public class CompileQueue {
                     });
                 });
             }
-            for (Map.Entry<HostedMethod, UnpublishedTrivialMethods> entry : unpublishedTrivialMethods.entrySet()) {
+            for (Map.Entry<HostedMethod, UnpublishedMethodInfo> entry : unpublishedMethods.entrySet()) {
                 entry.getKey().compilationInfo.setCompilationGraph(entry.getValue().unpublishedGraph);
                 if (entry.getValue().newlyTrivial) {
                     inliningProgress = true;
                     entry.getKey().compilationInfo.setTrivialMethod();
                 }
             }
-            unpublishedTrivialMethods.clear();
+            unpublishedMethods.clear();
         } while (inliningProgress);
+    }
+
+    /**
+     * Single callsite methods should be able to be inlined without duplicating code area. Single
+     * callsite inlining happens after trivial inlining to maximize the amount of trivial inlining
+     * possible.
+     *
+     * Say M1 is trivial and M2 has a single callsite, with M1 as the caller. If we inline M2 first,
+     * then M1 will likely no longer be trivial. If we inline M1 first, then M2 will no longer have
+     * a single callsite. It's preferable to miss out on a single instance of inlining rather than
+     * many - so trivial methods are inlined first.
+     */
+    @SuppressWarnings("try")
+    protected void inlineSingleCallsiteMethods(DebugContext debug) throws InterruptedException {
+        inliningRound = 0;
+        // First count callsites
+        try (Indent _ = debug.logAndIndent("==== Single Callsite Inlining: counting callsites")) {
+            runOnExecutor(() -> {
+                universe.getMethods().forEach(method -> {
+                    assert method.isOriginalMethod();
+                    for (MultiMethod multiMethod : method.getAllMultiMethods()) {
+                        HostedMethod hMethod = (HostedMethod) multiMethod;
+                        if (hMethod.compilationInfo.getCompilationGraph() != null) {
+                            executor.execute(new SingleCallsiteInlineTask(hMethod));
+                        }
+                    }
+                });
+            });
+        }
+
+        // Inline single callsite methods
+        do {
+            beginRound();
+            try (Indent _ = debug.logAndIndent("==== Single Callsite Inlining  round %n")) {
+                runOnExecutor(() -> {
+                    universe.getMethods().forEach(method -> {
+                        assert method.isOriginalMethod();
+                        for (MultiMethod multiMethod : method.getAllMultiMethods()) {
+                            HostedMethod hMethod = (HostedMethod) multiMethod;
+                            if (shouldEvaluateRootForSingleCallsiteInlining(hMethod)) {
+                                executor.execute(new SingleCallsiteInlineTask(hMethod));
+                            }
+                        }
+                    });
+                });
+            }
+            // Publish modified graphs
+            for (Map.Entry<HostedMethod, UnpublishedMethodInfo> entry : unpublishedMethods.entrySet()) {
+                entry.getKey().compilationInfo.setCompilationGraph(entry.getValue().unpublishedGraph);
+                inliningProgress = true;
+            }
+            unpublishedMethods.clear();
+        } while (inliningProgress);
+    }
+
+    private boolean shouldEvaluateRootForSingleCallsiteInlining(HostedMethod root) {
+        if (root.compilationInfo.getCompilationGraph() == null) {
+            return false;
+        }
+
+        if (inliningRound == 1) {
+            /*
+             * Skip roots that are themselves single callsite methods. Otherwise, it's possible that
+             * the root and some of its callees are both single callsite methods. In such cases, the
+             * root becomes unreachable and we wasted effort inlining its callees.
+             */
+            if (root.compilationInfo.callsites.get() != 1) {
+                return true;
+            }
+        } else {
+            /*
+             * After the first round, we must visit roots that are single callsite methods which
+             * failed the inlining threshold last round. Otherwise, their callees will never get
+             * evaluated.
+             */
+            Integer lastRoundFailed = sciLastRoundFailed.get(root);
+            if (lastRoundFailed != null && lastRoundFailed.equals(inliningRound - 1)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void beginRound() {
+        ProgressReporter.singleton().reportStageProgress();
+        inliningProgress = false;
+        inliningRound++;
     }
 
     class TrivialInliningPlugin implements InlineInvokePlugin {
@@ -757,35 +880,35 @@ public class CompileQueue {
         }
     }
 
-    class InliningGraphDecoder extends PEGraphDecoder {
+    /** This plugin will allow inlining methods that have a single callsite. */
+    class SingleCallsiteInliningPlugin implements InlineInvokePlugin {
+        boolean inlinedDuringDecoding;
 
-        InliningGraphDecoder(StructuredGraph graph, Providers providers, TrivialInliningPlugin inliningPlugin) {
-            super(AnalysisParsedGraph.HOST_ARCHITECTURE, graph, providers, null,
-                            null,
-                            new InlineInvokePlugin[]{inliningPlugin},
-                            null, null, null, null,
-                            new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), true, false);
+        @Override
+        public InlineInfo shouldInlineInvoke(GraphBuilderContext b, ResolvedJavaMethod method, ValueNode[] args) {
+            if (makeSingleCallsiteInlineDecision((HostedMethod) b.getMethod(), (HostedMethod) method) && b.recursiveInliningDepth(method) == 0) {
+                return InlineInfo.createStandardInlineInfo(method);
+            } else {
+                return InlineInfo.DO_NOT_INLINE_WITH_EXCEPTION;
+            }
         }
 
         @Override
-        protected EncodedGraph lookupEncodedGraph(ResolvedJavaMethod method, BytecodeProvider intrinsicBytecodeProvider) {
-            return ((HostedMethod) method).compilationInfo.getCompilationGraph().getEncodedGraph();
-        }
-
-        @Override
-        protected LoopScope trySimplifyInvoke(PEMethodScope methodScope, LoopScope loopScope, InvokeData invokeData, MethodCallTargetNode callTarget) {
-            return super.trySimplifyInvoke(methodScope, loopScope, invokeData, callTarget);
+        public void notifyAfterInline(ResolvedJavaMethod methodToInline) {
+            inlinedDuringDecoding = true;
         }
     }
 
     // Wrapper to clearly identify phase
-    class TrivialInlinePhase extends Phase {
-        final InliningGraphDecoder decoder;
+    class InlinePhase extends Phase {
+        final PEGraphDecoder decoder;
         final HostedMethod method;
+        final String name;
 
-        TrivialInlinePhase(InliningGraphDecoder decoder, HostedMethod method) {
+        InlinePhase(PEGraphDecoder decoder, HostedMethod method, String name) {
             this.decoder = decoder;
             this.method = method;
+            this.name = name;
         }
 
         @Override
@@ -795,7 +918,7 @@ public class CompileQueue {
 
         @Override
         public CharSequence getName() {
-            return "TrivialInline";
+            return name;
         }
     }
 
@@ -823,7 +946,7 @@ public class CompileQueue {
         try (var s = debug.scope("InlineTrivial", graph, method, this)) {
             var inliningPlugin = new TrivialInliningPlugin();
             var decoder = new InliningGraphDecoder(graph, providers, inliningPlugin);
-            new TrivialInlinePhase(decoder, method).apply(graph);
+            new InlinePhase(decoder, method, "TrivialInline").apply(graph);
 
             if (inliningPlugin.inlinedDuringDecoding) {
                 CanonicalizerPhase.create().apply(graph, providers);
@@ -848,7 +971,7 @@ public class CompileQueue {
                      * non-deterministic. This is why we are saving graphs to be published at the
                      * end of each round.
                      */
-                    unpublishedTrivialMethods.put(method, new UnpublishedTrivialMethods(CompilationGraph.encode(graph), checkNewlyTrivial(method, graph)));
+                    unpublishedMethods.put(method, new UnpublishedMethodInfo(CompilationGraph.encode(graph), checkNewlyTrivial(method, graph)));
                 }
             }
         } catch (Throwable ex) {
@@ -856,13 +979,28 @@ public class CompileQueue {
         }
     }
 
+    private void doInlineSingleCallsite(DebugContext debug, HostedMethod method) {
+        var providers = runtimeConfig.lookupBackend(method).getProviders();
+        var graph = method.compilationInfo.createGraph(debug, getCustomizedOptions(method, debug), CompilationIdentifier.INVALID_COMPILATION_ID, false);
+        try (var _ = debug.scope("InlineSingleCallsites", graph, method, this)) {
+            var inliningPlugin = new SingleCallsiteInliningPlugin();
+            var decoder = new InliningGraphDecoder(graph, providers, inliningPlugin);
+            new InlinePhase(decoder, method, "SingleCallsiteInline").apply(graph);
+
+            if (inliningPlugin.inlinedDuringDecoding) {
+                CanonicalizerPhase.create().apply(graph, providers);
+                unpublishedMethods.put(method, new UnpublishedMethodInfo(CompilationGraph.encode(graph), true));
+            }
+            if (inliningPlugin.inlinedDuringDecoding || inliningRound == 0) {
+                method.compilationInfo.sizeLastRound = NodeCostUtil.computeGraphSize(graph);
+            }
+        } catch (Throwable ex) {
+            throw debug.handle(ex);
+        }
+    }
+
     private boolean makeInlineDecision(HostedMethod method, HostedMethod callee) {
-        if (!SubstrateOptions.UseSharedLayerStrengthenedGraphs.getValue() && callee.compilationInfo.getCompilationGraph() == null) {
-            /*
-             * We have compiled this method in a prior layer, but don't have the graph available
-             * here.
-             */
-            assert callee.isCompiledInPriorLayer() : method;
+        if (!isCalleeGraphAvailable(method, callee)) {
             return false;
         }
         if (universe.hostVM().neverInlineTrivial(method.getWrapped(), callee.getWrapped())) {
@@ -875,6 +1013,40 @@ public class CompileQueue {
             return true;
         }
         return false;
+    }
+
+    private boolean makeSingleCallsiteInlineDecision(HostedMethod caller, HostedMethod callee) {
+        if (!isCalleeGraphAvailable(caller, callee)) {
+            return false;
+        }
+
+        // During the preliminary single callsite inlining round we must count callsites
+        if (inliningRound == 0) {
+            callee.compilationInfo.callsites.incrementAndGet();
+            return false;
+        }
+
+        if (callee.compilationInfo.callsites.get() != 1) {
+            return false;
+        }
+
+        if (caller.compilationInfo.sizeLastRound + callee.compilationInfo.sizeLastRound >= FALLBACK_SIZE) {
+            sciLastRoundFailed.put(callee, inliningRound);
+            return false;
+        }
+        return true;
+    }
+
+    private static boolean isCalleeGraphAvailable(HostedMethod caller, HostedMethod callee) {
+        if (!SubstrateOptions.UseSharedLayerStrengthenedGraphs.getValue() && callee.compilationInfo.getCompilationGraph() == null) {
+            /*
+             * We have compiled this method in a prior layer, but don't have the graph available
+             * here.
+             */
+            assert callee.isCompiledInPriorLayer() : caller;
+            return false;
+        }
+        return true;
     }
 
     private static boolean mustNotAllocateCallee(HostedMethod method) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/CompileQueue.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/CompileQueue.java
@@ -187,10 +187,10 @@ public class CompileQueue {
     private final boolean printMethodHistogram = NativeImageOptions.PrintMethodHistogram.getValue();
     private final boolean optionAOTTrivialInline = SubstrateOptions.AOTTrivialInline.getValue();
 
-    public record UnpublishedMethodInfo(CompilationGraph unpublishedGraph, boolean newlyTrivial) {
+    public record UnpublishedTrivialMethods(CompilationGraph unpublishedGraph, boolean newlyTrivial) {
     }
 
-    private final ConcurrentMap<HostedMethod, UnpublishedMethodInfo> unpublishedMethods = new ConcurrentHashMap<>();
+    private final ConcurrentMap<HostedMethod, UnpublishedTrivialMethods> unpublishedTrivialMethods = new ConcurrentHashMap<>();
 
     /*
      * Edge case handling: For each method, track that last round that Single Callsite Inlining was
@@ -763,14 +763,14 @@ public class CompileQueue {
                     });
                 });
             }
-            for (Map.Entry<HostedMethod, UnpublishedMethodInfo> entry : unpublishedMethods.entrySet()) {
+            for (Map.Entry<HostedMethod, UnpublishedTrivialMethods> entry : unpublishedTrivialMethods.entrySet()) {
                 entry.getKey().compilationInfo.setCompilationGraph(entry.getValue().unpublishedGraph);
                 if (entry.getValue().newlyTrivial) {
                     inliningProgress = true;
                     entry.getKey().compilationInfo.setTrivialMethod();
                 }
             }
-            unpublishedMethods.clear();
+            unpublishedTrivialMethods.clear();
         } while (inliningProgress);
     }
 
@@ -819,11 +819,11 @@ public class CompileQueue {
                 });
             }
             // Publish modified graphs
-            for (Map.Entry<HostedMethod, UnpublishedMethodInfo> entry : unpublishedMethods.entrySet()) {
+            for (Map.Entry<HostedMethod, UnpublishedTrivialMethods> entry : unpublishedTrivialMethods.entrySet()) {
                 entry.getKey().compilationInfo.setCompilationGraph(entry.getValue().unpublishedGraph);
                 inliningProgress = true;
             }
-            unpublishedMethods.clear();
+            unpublishedTrivialMethods.clear();
         } while (inliningProgress);
     }
 
@@ -971,7 +971,7 @@ public class CompileQueue {
                      * non-deterministic. This is why we are saving graphs to be published at the
                      * end of each round.
                      */
-                    unpublishedMethods.put(method, new UnpublishedMethodInfo(CompilationGraph.encode(graph), checkNewlyTrivial(method, graph)));
+                    unpublishedTrivialMethods.put(method, new UnpublishedTrivialMethods(CompilationGraph.encode(graph), checkNewlyTrivial(method, graph)));
                 }
             }
         } catch (Throwable ex) {
@@ -990,7 +990,7 @@ public class CompileQueue {
 
             if (inliningPlugin.inlinedDuringDecoding) {
                 CanonicalizerPhase.create().apply(graph, providers);
-                unpublishedMethods.put(method, new UnpublishedMethodInfo(CompilationGraph.encode(graph), true));
+                unpublishedTrivialMethods.put(method, new UnpublishedTrivialMethods(CompilationGraph.encode(graph), true));
             }
             if (inliningPlugin.inlinedDuringDecoding || inliningRound == 0) {
                 method.compilationInfo.sizeLastRound = NodeCostUtil.computeGraphSize(graph);

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/InliningGraphDecoder.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/InliningGraphDecoder.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, 2026, IBM Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.hosted.code;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.oracle.graal.pointsto.flow.AnalysisParsedGraph;
+import com.oracle.svm.hosted.meta.HostedMethod;
+
+import jdk.graal.compiler.bytecode.BytecodeProvider;
+import jdk.graal.compiler.nodes.EncodedGraph;
+import jdk.graal.compiler.nodes.StructuredGraph;
+import jdk.graal.compiler.nodes.graphbuilderconf.InlineInvokePlugin;
+import jdk.graal.compiler.phases.util.Providers;
+import jdk.graal.compiler.replacements.PEGraphDecoder;
+
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+
+/**
+ * This is a general inlining decoder that is used for both trivial inlining and single callsite
+ * inlining. Different plugins allow for different functionality.
+ */
+class InliningGraphDecoder extends PEGraphDecoder {
+
+    InliningGraphDecoder(StructuredGraph graph, Providers providers, InlineInvokePlugin inliningPlugin) {
+        super(AnalysisParsedGraph.HOST_ARCHITECTURE, graph, providers, null,
+                        null,
+                        new InlineInvokePlugin[]{inliningPlugin},
+                        null, null, null, null,
+                        new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), true, false);
+    }
+
+    @Override
+    protected EncodedGraph lookupEncodedGraph(ResolvedJavaMethod method, BytecodeProvider intrinsicBytecodeProvider) {
+        return ((HostedMethod) method).compilationInfo.getCompilationGraph().getEncodedGraph();
+    }
+}


### PR DESCRIPTION
### Summary

This PR is based on https://github.com/oracle/graal/pull/12899. If inliner improvements are eventually merged upstream, we can decide whether to walk back this PR or keep it.  

This PR adds a new inlining stage for single callsite methods. We should be able to benefit from aggressively inlining single callsite methods without paying the code area price. This stage is done completely independently of the normal Trivial inlining stage. It can be turned off using the `AOTSingleCallsiteInline` hosted option, similar to the existing `AOTTrivialInline` option. 

This inlining stage works by first counting the callsites for each method in the universe, then inlining those methods specifically.  Similar to the Trivial inlining stage, rounds are used. However, usually only 1 or 2 rounds will ever execute. An additional round will execute only when an inlining candidate exceeds the fallback threshold (rare).

-----
### Results


#### Using [**Renaissance**](https://renaissance.dev/):
Test details:
 - Tested on Linux amd64
 - For stability during the build and during benchmark execution
   - Intel turbo boost disabled
   - CPU frequency pinned to 2400000kHz with cpupower
   - `cpupower frequency-set --governor performance`
   - Caches dropped before building with `sh -c 'echo 3 >/proc/sys/vm/drop_caches'`
   - Build with `--parallelism=1`
   - Each benchmark was run multiple times. The first few runs are discounted as warm-up. 
  
Definitions:
 - _new_ : The inliner with single callsite inlining implemented
 - _old_ : The old inliner with default settings. 
 - _duration_: Execution time of the Renaissance benchmark
 - _% improvement_ : Calculated as 100 * (old duration - new duration)/ old duration
 - _STDEV_ Standard deviation in benchmark run duration
 - _inline time_ : time taken only by the inlining operations
 - _build time_ : total time taken by the image builder
 - _Peak Build RSS_ : Peak RSS reported by the image builder.

Benchmark | Duration (ms) [old] | Duration (ms) [new] | Duration % improvement | STDEV (ms) [old] | STDEV (ms) [new] | Total runs | Warm up runs
-- | -- | -- | -- | -- | -- | -- | --
mnemonics | 11759.25 | 11339.42 | 3.57 | 80.52 | 36.125 | 16. | 6.
reactors | 30198.075 | 29679.01 | 1.719 | 2919.29 | 1595.93 | 15. | 8.
future-genetic | 3642.73 | 3565.03 | 2.133 | 34.7 | 20.27 | 25. | 5.
par-mnemonics | 9589.91 | 9265.41 | 3.384 | 49.74 | 66.55 | 16. | 6.
philosophers | 5810.615 | 5701.19 | 1.883 | 208.24 | 249.265 | 30. | 10.
scala-doku | 6450.25 | 6481.69 | -0.487 | 41.83 | 32.46 | 20. | 10.
fj-kmeans | 5272. | 5292.33 | -0.386 | 89.83 | 54.72 | 30. | 20.
akka-uct | 33107.66 | 32743.24 | 1.101 | 816.56 | 601.81 | 10. | 5.
scala-kmeans | 779.66 | 694.7 | 10.897 | 3.47 | 5.37 | 25. | 5.
finagle-http | 10324.43 | 9785.93 | 5.216 | 7.11 | 16.61 | 17. | 5.
finagle-chirper | 10591.475 | 9056.48 | 14.493 | 462.28 | 98.735 | 110. | 90.
dotty | 1884.23 | 1805.3 | 4.189 | 27.98 | 30.67 | 70. | 20.


Benchmark | Code Area (MB) [old] | Code Area (MB) [new] | File Size (MB) [old] | File Size (MB) [new] | Inline Time (s) [old] | Inline Time (s) [new] | Build Time (s) [old] | Build Time (s) [new] | Peak Build RSS (GB) [old] | Peak Build RSS (GB) [new]
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
mnemonics | 8.77 | 8.89 | 21.37 | 21.43 | 1.8 | 3.2 | 63. | 64. | 1.82 | 1.86
reactors | 9.26 | 9.39 | 22.48 | 22.61 | 2. | 3.4 | 66. | 69. | 1.9 | 1.94
future-genetic | 8.91 | 9.03 | 21.5 | 21.63 | 1.9 | 3.2 | 63. | 65. | 1.79 | 1.87
par-mnemonics | 8.79 | 8.9 | 21.37 | 21.43 | 1.9 | 3.2 | 63. | 64. | 1.76 | 1.86
philosophers | 8.88 | 9. | 21.43 | 21.56 | 2. | 3.4 | 64. | 65. | 1.8 | 1.88
scala-doku | 8.83 | 8.94 | 21.43 | 21.5 | 1.9 | 3.3 | 63. | 65. | 1.79 | 1.88
fj-kmeans | 8.72 | 8.85 | 21.3 | 21.37 | 1.9 | 3.2 | 62. | 64. | 1.82 | 1.85
akka-uct | 11.35 | 11.49 | 26.68 | 26.81 | 2.4 | 4.1 | 77. | 79. | 2.07 | 2.2
scala-kmeans | 8.7 | 8.84 | 21.24 | 21.37 | 1.8 | 3.3 | 62. | 64. | 1.8 | 1.85
finagle-http | 26.73 | 27.15 | 58.2 | 59.18 | 5. | 9. | 158. | 164. | 3.14 | 3.41
finagle-chirper | 26.82 | 27.29 | 59.44 | 59.9 | 5.1 | 8.8 | 160. | 164. | 3.18 | 3.28
dotty | 36.48 | 36.54 | 72.55 | 73.08 | 8.1 | 13.9 | 214. | 220. | 4.42 | 4.61

---------------


#### Using a [Quarkus hello-world rest benchmark](https://github.com/franz1981/quarkus-reactive-beer):
This benchmark has 2 endpoints: "greeting" and "beer". Both return plaintext, but "beer" does a little more work. 

Test details:
 - Tested on Linux amd64
 - For stability during the build and during benchmark execution
   - Intel turbo boost disabled
   - CPU frequency pinned to 2400000kHz with cpupower
   - `cpupower frequency-set --governor performance`
   - Caches dropped before building and running with `sh -c 'echo 3 >/proc/sys/vm/drop_caches'`
   - Pinned the load driver (Hyperfoil) to 4 CPUs and the Quarkus app to 2 other CPUs
  
New Definitions:
 -  _Req/s_ : Quarkus app throughput in requests per second
 - _% improvement_ : Calculated as 100 * (new throughput - old throughput)/ old throughput

Benchmark | Throughput (req/s) [old] | Throughput (req/s)  [new] | % improvement | Code Area (MB) [old] | Code Area (MB) [new] | File Size (MB) [old] | File Size (MB) [new] | Inline Time (s) [old] | Inline Time (s) [new] | Build Time (s) [old] | Build Time (s) [new] | Peak Build RSS (GB) [old] | Peak Build RSS (GB) [new]
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
greeting endpoint | 31,746.415 | 33,329.615 | 4.987 | 24.13 | 24.76 | 51.25 | 51.91 | 4.2 | 7.7 | 140. | 146.5 | 2.83 | 2.86
beer endpoint | 16,490.475 | 18,042.985 | 9.415 | Same as above | Same as above | Same as above | Same as above | Same as above | Same as above | Same as above | Same as above | Same as above | Same as above




