### PR TITLE
[CI] Enable dependabot and pin github actions to commit IDs instead of tags 

### DIFF
--- a/.github/actions/build-graalvm/action.yml
+++ b/.github/actions/build-graalvm/action.yml
@@ -30,13 +30,13 @@ runs:
         # Workaround testsuite locale issue
         echo "LANG=en_US.UTF-8" >> ${GITHUB_ENV}
     - name: Checkout graalvm/mx
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         repository: graalvm/mx
         ref: ${{ env.MX_VERSION }}
         path: ${{ env.MX_PATH }}
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '3.8'
     - name: Fetch LabsJDK
@@ -53,7 +53,7 @@ runs:
         ${GRAALVM_HOME}/bin/native-image --version
     - name: Set up JAVA_HOME
       if: ${{ inputs.java-version }} != ''
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
       with:
         distribution: 'temurin'
         java-version: '${{ inputs.java-version }}'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly" # Options: daily, weekly, monthly
+    groups:
+      # Group updates to avoid PR spam
+      actions-updates:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "[CI] Update GitHub Actions"
+      include: "scope"

--- a/.github/workflows/cdt-inspect.yml
+++ b/.github/workflows/cdt-inspect.yml
@@ -64,11 +64,11 @@ jobs:
 
     steps:
     - name: Checkout oracle/graal
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         path: ${{ github.workspace }}/graal
     - name: Checkout oracle/graaljs
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         repository: oracle/graaljs
         ref: 'release/graal-vm/25.0'
@@ -77,13 +77,13 @@ jobs:
           benchmarks
         path: ${{ github.workspace }}/js
     - name: Checkout graalvm/mx
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         repository: graalvm/mx.git
         ref: master
         path: ${{ env.MX_PATH }}
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '3.8'
     - name: Get OpenJDK with static libs and jmods

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -170,20 +170,20 @@ jobs:
       MX_RUNS_STYLE: ${{ contains(matrix.env.GATE_TAGS, 'style') || matrix.env.GATE_TAGS == '' }}
     steps:
     - name: Checkout graalvm-community-25u/master
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         ref: ${{ github.ref }} # Lock ref to current branch to avoid fetching others
         fetch-depth: "${{ env.MX_RUNS_STYLE && '0' || '1' }}" # The style gate needs the full commit history for checking copyright years
     - name: Determine mx version
       run: echo "MX_VERSION=$(jq -r '.mx_version' common.json)" >> ${GITHUB_ENV}
     - name: Checkout graalvm/mx
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         repository: graalvm/mx.git
         ref: ${{ env.MX_VERSION }}
         path: ${{ env.MX_PATH }}
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '3.8'
     - name: Get OpenJDK with static libs and jmods
@@ -253,20 +253,20 @@ jobs:
       PYTHONIOENCODING: 'utf-8'
     steps:
     - name: Checkout graalvm-community-jdk25u/master
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         ref: ${{ github.ref }} # Lock ref to current branch to avoid fetching others
     - name: Determine mx version
       shell: bash
       run: echo "MX_VERSION=$(jq -r '.mx_version' common.json)" >> ${GITHUB_ENV}
     - name: Checkout graalvm/mx
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         repository: graalvm/mx.git
         ref: ${{ env.MX_VERSION }}
         path: ${{ env.MX_PATH }}
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '3.8'
     - name: Get OpenJDK with static libs and jmods

--- a/.github/workflows/micronaut.yml
+++ b/.github/workflows/micronaut.yml
@@ -63,7 +63,7 @@ jobs:
     if: (github.event_name == 'schedule' && github.repository == 'graalvm/graalvm-community-jdk25u') || (github.event_name != 'schedule')
     steps:
     - name: Checkout oracle/graal
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Build GraalVM JDK
       uses: ./.github/actions/build-graalvm
       with:

--- a/.github/workflows/ni-layers.yml
+++ b/.github/workflows/ni-layers.yml
@@ -63,7 +63,7 @@ jobs:
         matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
     - name: Checkout oracle/graal
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Build GraalVM JDK
       uses: ./.github/actions/build-graalvm
       with:
@@ -74,12 +74,12 @@ jobs:
       shell: bash
       run: tar -czvhf graalvm.tgz -C $(dirname ${GRAALVM_HOME}) $(basename ${GRAALVM_HOME})
     - name: Persist GraalVM JDK build
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: graalvm
         path: graalvm.tgz
     - name: Setup python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '${{ env.PYTHON_VERSION }}'
     - name: Populate matrix
@@ -99,7 +99,7 @@ jobs:
         coordinates: ${{ fromJson(needs. build-graalvm-and-populate-matrix.outputs.matrix).coordinates }}
     steps:
       - name: Checkout oracle/graal
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Download GraalVM JDK build
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
@@ -108,12 +108,12 @@ jobs:
       - name: Extract GraalVM JDK build
         run: tar -xzvf graalvm.tgz -C $(dirname ${GRAALVM_HOME})
       - name: "Setup JAVA_HOME"
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '${{ env.PYTHON_VERSION }}'
       - name: Build layer

--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -70,7 +70,7 @@ jobs:
       matrix: ${{ steps.read.outputs.matrix }}
     steps:
     - name: Checkout oracle/graal
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Build GraalVM JDK
       uses: ./.github/actions/build-graalvm
       with:
@@ -82,7 +82,7 @@ jobs:
         curl --output quarkus.tgz -sL https://api.github.com/repos/quarkusio/quarkus/tarball/$QUARKUS_VERSION
         mkdir ${QUARKUS_PATH}
         tar xf quarkus.tgz -C ${QUARKUS_PATH} --strip-components=1
-    - uses: actions/cache@v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -92,7 +92,7 @@ jobs:
       shell: bash
       run: tar -czvhf graalvm.tgz -C $(dirname ${GRAALVM_HOME}) $(basename ${GRAALVM_HOME})
     - name: Persist GraalVM JDK build
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: graalvm
         path: graalvm.tgz
@@ -110,7 +110,7 @@ jobs:
       shell: bash
       run: tar -czvf maven-repo.tgz -C ~ .m2/repository
     - name: Persist Maven Repo
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: maven-repo
         path: maven-repo.tgz
@@ -159,7 +159,7 @@ jobs:
         if: startsWith(matrix.os-name, 'ubuntu')
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -176,7 +176,7 @@ jobs:
         shell: bash
         run: find . -type d -name '*-reports' -o -wholename '*/build/reports/tests/functionalTest' | tar -czf test-reports.tgz -T -
       - name: Upload failure Archive (if maven failed)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: test-reports-native-${{matrix.category}}

--- a/.github/workflows/reachability-metadata.yml
+++ b/.github/workflows/reachability-metadata.yml
@@ -64,7 +64,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
     - name: Checkout oracle/graal
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Build GraalVM JDK
       uses: ./.github/actions/build-graalvm
       with:
@@ -75,12 +75,12 @@ jobs:
       shell: bash
       run: tar -czvhf graalvm.tgz -C $(dirname ${GRAALVM_HOME}) $(basename ${GRAALVM_HOME})
     - name: Persist GraalVM JDK build
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: graalvm
         path: graalvm.tgz
     - name: Checkout oracle/graalvm-reachability-metadata
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         repository: oracle/graalvm-reachability-metadata
         path: ${{ env.REACHABILITY_METADATA_PATH }}
@@ -105,7 +105,7 @@ jobs:
           coordinates: ${{fromJson(needs.build-graalvm-and-populate-matrix.outputs.matrix).coordinates}}
     steps:
       - name: "Checkout oracle/graalvm-reachability-metadata"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: oracle/graalvm-reachability-metadata
           # https://github.com/oracle/graalvm-reachability-metadata/issues/1071
@@ -118,7 +118,7 @@ jobs:
       - name: Extract GraalVM JDK build
         run: tar -xzvf graalvm.tgz -C $(dirname ${GRAALVM_HOME})
       - name: "Setup JAVA_HOME"
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'temurin'
           java-version: ${{ env.MINIMUM_METADATA_JAVA_VERSION }}

--- a/.github/workflows/spring.yml
+++ b/.github/workflows/spring.yml
@@ -63,13 +63,13 @@ jobs:
     if: (github.event_name == 'schedule' && github.repository == 'graalvm/graalvm-community-jdk25u') || (github.event_name != 'schedule')
     steps:
     - name: Checkout oracle/graal
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Build GraalVM JDK
       uses: ./.github/actions/build-graalvm
       with:
         java-version: ${{ env.SPRING_JAVA_VERSION }}
     - name: Checkout spring-projects/spring-petclinic
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         repository: spring-projects/spring-petclinic
         path: ${{ env.SPRING_PETCLINIC_PATH }}


### PR DESCRIPTION
Increase security by avoiding the use of mutable tags and by having dependabot open PRs for updates.

tags mapped to IDs using the following script and manually verified:

```bash

set -euo pipefail

declare -A sha_cache

get_sha() {
    local repo="$1" tag="$2"
    local key="${repo}@${tag}"

    if [[ -n "${sha_cache[$key]+x}" ]]; then
        echo "${sha_cache[$key]}"
        return 0
    fi

    local sha
    if sha=$(gh api "repos/${repo}/commits/${tag}" --jq '.sha' 2>/dev/null); then
        sha_cache[$key]="$sha"
        echo "$sha"
    else
        return 1
    fi
}

if [[ $# -gt 0 ]]; then
    mapfile -t files < <(printf '%s\n' "$@")
else
    mapfile -t files < <(find .github -type f \( -name "*.yml" -o -name "*.yaml" \) | sort)
fi

if [[ ${#files[@]} -eq 0 ]]; then
    echo "No workflow files found." >&2
    exit 1
fi

for file in "${files[@]}"; do
    mapfile -t actions < <(
        grep -oP 'uses:\s+\Kactions/[^@\s]+@v[0-9][^\s#]*' "$file" 2>/dev/null | sort -u
    )

    [[ ${#actions[@]} -eq 0 ]] && continue

    echo "Processing: $file"

    for action in "${actions[@]}"; do
        repo="${action%@*}"
        tag="${action#*@}"

        sha=$(get_sha "$repo" "$tag") || {
            echo "  ⚠ Could not fetch SHA for ${action}" >&2
            continue
        }

        echo "  ${action} → ${sha}"
        sed -i "s|${action}|${repo}@${sha} # ${tag}|g" "$file"
    done
done

echo "Done."
```

Script output was

```
Processing: .github/actions/build-graalvm/action.yml
  actions/checkout@v4 → 34e114876b0b11c390a56381ad16ebd13914f8d5
  actions/setup-java@v4 → c1e323688fd81a25caa38c78aa6df2d33d3e20d9
  actions/setup-python@v5 → a26af69be951a213d495a4c3e4e4022e16d87065
Processing: .github/workflows/cdt-inspect.yml
  actions/checkout@v4 → 34e114876b0b11c390a56381ad16ebd13914f8d5
  actions/setup-python@v5 → a26af69be951a213d495a4c3e4e4022e16d87065
Processing: .github/workflows/main.yml
  actions/checkout@v4 → 34e114876b0b11c390a56381ad16ebd13914f8d5
  actions/setup-python@v5 → a26af69be951a213d495a4c3e4e4022e16d87065
Processing: .github/workflows/micronaut.yml
  actions/checkout@v4 → 34e114876b0b11c390a56381ad16ebd13914f8d5
Processing: .github/workflows/ni-layers.yml
  actions/checkout@v4 → 34e114876b0b11c390a56381ad16ebd13914f8d5
  actions/setup-java@v4 → c1e323688fd81a25caa38c78aa6df2d33d3e20d9
  actions/setup-python@v5 → a26af69be951a213d495a4c3e4e4022e16d87065
  actions/upload-artifact@v4 → ea165f8d65b6e75b540449e92b4886f43607fa02
Processing: .github/workflows/quarkus.yml
  actions/cache@v4 → 0057852bfaa89a56745cba8c7296529d2fc39830
  actions/checkout@v4 → 34e114876b0b11c390a56381ad16ebd13914f8d5
  actions/setup-java@v4 → c1e323688fd81a25caa38c78aa6df2d33d3e20d9
  actions/upload-artifact@v4 → ea165f8d65b6e75b540449e92b4886f43607fa02
Processing: .github/workflows/reachability-metadata.yml
  actions/checkout@v4 → 34e114876b0b11c390a56381ad16ebd13914f8d5
  actions/setup-java@v4 → c1e323688fd81a25caa38c78aa6df2d33d3e20d9
  actions/upload-artifact@v4 → ea165f8d65b6e75b540449e92b4886f43607fa02
Processing: .github/workflows/spring.yml
  actions/checkout@v4 → 34e114876b0b11c390a56381ad16ebd13914f8d5
Done.
```