### PR TITLE
[Backport] [Oracle GraalVM] [GR-72449] [GR-72435] [GR-72438] [GR-72432] [GR-72629] [GR-72963] Backports : bulk native image fixes and optimizations.

### DIFF
--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/replacements/HotSpotAllocationSnippets.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/replacements/HotSpotAllocationSnippets.java
@@ -142,18 +142,19 @@ public class HotSpotAllocationSnippets extends AllocationSnippets {
     @Snippet
     protected Object allocateInstance(KlassPointer hub,
                     @ConstantParameter long size,
-                    @ConstantParameter boolean forceSlowPath,
+                    @ConstantParameter boolean useTLAB,
                     @ConstantParameter FillContent fillContents,
                     @ConstantParameter boolean emitMemoryBarrier,
                     @ConstantParameter HotSpotAllocationProfilingData profilingData,
                     @ConstantParameter boolean withException) {
-        Object result = allocateInstanceImpl(hub.asWord(), Word.unsigned(size), forceSlowPath, fillContents, emitMemoryBarrier, true, profilingData, withException);
+        Object result = allocateInstanceImpl(hub.asWord(), Word.unsigned(size), useTLAB, fillContents, emitMemoryBarrier, true, profilingData, withException);
         return piCastToSnippetReplaceeStamp(result);
     }
 
     @Snippet
     public Object allocateArray(KlassPointer hub,
                     int length,
+                    @ConstantParameter boolean useTLAB,
                     @ConstantParameter int arrayBaseOffset,
                     @ConstantParameter int log2ElementSize,
                     @ConstantParameter FillContent fillContents,
@@ -164,7 +165,7 @@ public class HotSpotAllocationSnippets extends AllocationSnippets {
                     @ConstantParameter boolean supportsOptimizedFilling,
                     @ConstantParameter HotSpotAllocationProfilingData profilingData,
                     @ConstantParameter boolean withException) {
-        Object result = allocateArrayImpl(hub.asWord(), length, false, arrayBaseOffset, log2ElementSize, fillContents, fillStartOffset, emitMemoryBarrier, maybeUnroll, supportsBulkZeroing,
+        Object result = allocateArrayImpl(hub.asWord(), length, useTLAB, arrayBaseOffset, log2ElementSize, fillContents, fillStartOffset, emitMemoryBarrier, maybeUnroll, supportsBulkZeroing,
                         supportsOptimizedFilling, profilingData, withException);
         return piArrayCastToSnippetReplaceeStamp(result, length);
     }
@@ -216,6 +217,7 @@ public class HotSpotAllocationSnippets extends AllocationSnippets {
     public Object allocateArrayDynamic(Class<?> elementType,
                     Class<?> voidClass,
                     int length,
+                    @ConstantParameter boolean useTLAB,
                     @ConstantParameter FillContent fillContents,
                     @ConstantParameter boolean emitMemoryBarrier,
                     @ConstantParameter JavaKind knownElementKind,
@@ -271,7 +273,7 @@ public class HotSpotAllocationSnippets extends AllocationSnippets {
         int arrayBaseOffset = (layoutHelper >> layoutHelperHeaderSizeShift(INJECTED_VMCONFIG)) & layoutHelperHeaderSizeMask(INJECTED_VMCONFIG);
         int log2ElementSize = (layoutHelper >> layoutHelperLog2ElementSizeShift(INJECTED_VMCONFIG)) & layoutHelperLog2ElementSizeMask(INJECTED_VMCONFIG);
         Object result;
-        result = allocateArrayImpl(nonNullKlass.asWord(), length, false, arrayBaseOffset, log2ElementSize, fillContents, arrayBaseOffset, emitMemoryBarrier, false,
+        result = allocateArrayImpl(nonNullKlass.asWord(), length, useTLAB, arrayBaseOffset, log2ElementSize, fillContents, arrayBaseOffset, emitMemoryBarrier, false,
                         supportsBulkZeroing, supportsOptimizedFilling, profilingData, withException);
         return piArrayCastToSnippetReplaceeStamp(result, length);
     }
@@ -446,11 +448,6 @@ public class HotSpotAllocationSnippets extends AllocationSnippets {
     @Override
     protected final int objectAlignment() {
         return HotSpotReplacementsUtil.objectAlignment(INJECTED_VMCONFIG);
-    }
-
-    @Override
-    public final boolean useTLAB() {
-        return HotSpotReplacementsUtil.useTLAB(INJECTED_VMCONFIG);
     }
 
     @Override
@@ -670,7 +667,7 @@ public class HotSpotAllocationSnippets extends AllocationSnippets {
             args.add("hub", hub);
             // instanceSize returns a negative number for types which should be slow path allocated
             args.add("size", NumUtil.safeAbs(size));
-            args.add("forceSlowPath", size < 0);
+            args.add("useTLAB", shouldUseTLAB(config, size));
             args.add("fillContents", FillContent.fromBoolean(node.fillContents()));
             args.add("emitMemoryBarrier", node.emitMemoryBarrier());
             args.add("profilingData", getProfilingData(localOptions, "instance", type));
@@ -693,7 +690,7 @@ public class HotSpotAllocationSnippets extends AllocationSnippets {
             args.add("hub", hub);
             // instanceSize returns a negative number for types which should be slow path allocated
             args.add("size", NumUtil.safeAbs(size));
-            args.add("forceSlowPath", size < 0);
+            args.add("useTLAB", shouldUseTLAB(config, size));
             args.add("fillContents", FillContent.fromBoolean(true));
             args.add("emitMemoryBarrier", true /* barrier */);
             args.add("profilingData", getProfilingData(localOptions, "instance", type));
@@ -721,6 +718,7 @@ public class HotSpotAllocationSnippets extends AllocationSnippets {
             args.add("hub", hub);
             ValueNode length = node.length();
             args.add("length", length.isAlive() ? length : graph.addOrUniqueWithInputs(length));
+            args.add("useTLAB", shouldUseTLAB(config));
             args.add("arrayBaseOffset", arrayBaseOffset);
             args.add("log2ElementSize", log2ElementSize);
             args.add("fillContents", FillContent.fromBoolean(node.fillContents()));
@@ -751,6 +749,7 @@ public class HotSpotAllocationSnippets extends AllocationSnippets {
             args.add("hub", hub);
             ValueNode length = node.length();
             args.add("length", length.isAlive() ? length : graph.addOrUniqueWithInputs(length));
+            args.add("useTLAB", shouldUseTLAB(config));
             args.add("arrayBaseOffset", arrayBaseOffset);
             args.add("log2ElementSize", log2ElementSize);
             args.add("fillContents", FillContent.fromBoolean(node.fillContents()));
@@ -851,6 +850,7 @@ public class HotSpotAllocationSnippets extends AllocationSnippets {
             args.add("elementType", node.getElementType());
             args.add("voidClass", voidClass);
             args.add("length", length.isAlive() ? length : graph.addOrUniqueWithInputs(length));
+            args.add("useTLAB", shouldUseTLAB(config));
             args.add("fillContents", FillContent.fromBoolean(node.fillContents()));
             args.add("emitMemoryBarrier", node.emitMemoryBarrier());
             /*
@@ -882,6 +882,7 @@ public class HotSpotAllocationSnippets extends AllocationSnippets {
             args.add("elementType", node.getElementType());
             args.add("voidClass", voidClass);
             args.add("length", length.isAlive() ? length : graph.addOrUniqueWithInputs(length));
+            args.add("useTLAB", shouldUseTLAB(config));
             args.add("fillContents", FillContent.fromBoolean(true));
             args.add("emitMemoryBarrier", true/* barriers */);
             /*
@@ -927,9 +928,16 @@ public class HotSpotAllocationSnippets extends AllocationSnippets {
             return HotSpotAllocationSnippets.lookupArrayClass(tool.getMetaAccess(), kind);
         }
 
+        public static boolean shouldUseTLAB(GraalHotSpotVMConfig config) {
+            return HotSpotReplacementsUtil.useTLAB(config);
+        }
+
+        public static boolean shouldUseTLAB(GraalHotSpotVMConfig config, long size) {
+            return shouldUseTLAB(config) && size >= 0;
+        }
     }
 
-    private static class HotSpotAllocationProfilingData extends AllocationProfilingData {
+    public static class HotSpotAllocationProfilingData extends AllocationProfilingData {
         String path;
         String typeContext;
 

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/nodes/PrefetchAllocateNode.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/nodes/PrefetchAllocateNode.java
@@ -33,10 +33,10 @@ import jdk.graal.compiler.core.common.GraalOptions;
 import jdk.graal.compiler.core.common.type.StampFactory;
 import jdk.graal.compiler.graph.NodeClass;
 import jdk.graal.compiler.nodeinfo.NodeInfo;
-import jdk.graal.compiler.nodes.spi.LIRLowerable;
-import jdk.graal.compiler.nodes.spi.NodeLIRBuilderTool;
 import jdk.graal.compiler.nodes.memory.address.AddressNode;
 import jdk.graal.compiler.nodes.memory.address.AddressNode.Address;
+import jdk.graal.compiler.nodes.spi.LIRLowerable;
+import jdk.graal.compiler.nodes.spi.NodeLIRBuilderTool;
 
 @NodeInfo(cycles = CYCLES_2, size = SIZE_2)
 public final class PrefetchAllocateNode extends FixedWithNextNode implements LIRLowerable {

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/options/ModifiableOptionValues.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/options/ModifiableOptionValues.java
@@ -106,6 +106,12 @@ public class ModifiableOptionValues extends OptionValues {
                 }
             }
         } while (!v.compareAndSet(expect, newMap));
+
+        UnmodifiableMapCursor<OptionKey<?>, Object> cursor = values.getEntries();
+        while (cursor.advance()) {
+            OptionKey<?> key = cursor.getKey();
+            key.afterValueUpdate();
+        }
     }
 
     @Override

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/replacements/AllocationSnippets.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/replacements/AllocationSnippets.java
@@ -48,7 +48,7 @@ import jdk.graal.compiler.word.Word;
 public abstract class AllocationSnippets implements Snippets {
     protected Object allocateInstanceImpl(Word hub,
                     UnsignedWord size,
-                    boolean forceSlowPath,
+                    boolean useTLAB,
                     FillContent fillContents,
                     boolean emitMemoryBarrier,
                     boolean constantSize,
@@ -59,7 +59,7 @@ public abstract class AllocationSnippets implements Snippets {
         Word top = readTlabTop(tlabInfo);
         Word end = readTlabEnd(tlabInfo);
         Word newTop = top.add(size);
-        if (!forceSlowPath && useTLAB() && probability(FAST_PATH_PROBABILITY, shouldAllocateInTLAB(size, false)) && probability(FAST_PATH_PROBABILITY, newTop.belowOrEqual(end))) {
+        if (useTLAB && probability(FAST_PATH_PROBABILITY, shouldAllocateInTLAB(size, false)) && probability(FAST_PATH_PROBABILITY, newTop.belowOrEqual(end))) {
             writeTlabTop(tlabInfo, newTop);
             emitPrefetchAllocate(newTop, false);
             result = formatObject(hub, size, top, fillContents, emitMemoryBarrier, constantSize, profilingData.snippetCounters);
@@ -73,7 +73,7 @@ public abstract class AllocationSnippets implements Snippets {
 
     public Object allocateArrayImpl(Word hub,
                     int length,
-                    boolean forceSlowPath,
+                    boolean useTLAB,
                     int arrayBaseOffset,
                     int log2ElementSize,
                     FillContent fillContents,
@@ -95,7 +95,7 @@ public abstract class AllocationSnippets implements Snippets {
         Word newTop = top.add(allocationSize);
 
         Object result;
-        if (!forceSlowPath && useTLAB() && probability(FAST_PATH_PROBABILITY, shouldAllocateInTLAB(allocationSize, true)) && probability(FAST_PATH_PROBABILITY, newTop.belowOrEqual(end))) {
+        if (useTLAB && probability(FAST_PATH_PROBABILITY, shouldAllocateInTLAB(allocationSize, true)) && probability(FAST_PATH_PROBABILITY, newTop.belowOrEqual(end))) {
             writeTlabTop(thread, newTop);
             emitPrefetchAllocate(newTop, true);
             boolean useOptimizedFilling = !withException && supportsOptimizedFilling;
@@ -343,8 +343,6 @@ public abstract class AllocationSnippets implements Snippets {
     protected abstract int getPrefetchStepSize();
 
     protected abstract int getPrefetchDistance();
-
-    public abstract boolean useTLAB();
 
     protected abstract boolean shouldAllocateInTLAB(UnsignedWord allocationSize, boolean isArray);
 

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -1557,7 +1557,7 @@ libgraal_build_args = [
 
     # Reduce image size by outlining all write barriers.
     # Benchmarking showed no performance degradation.
-    '-H:+OutlineWriteBarriers',
+    '-H:WriteBarrierOutlining=Always',
 
     # Libgraal must not change the process-wide locale settings.
     '-H:-UseSystemLocale',

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AbstractCollectionPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AbstractCollectionPolicy.java
@@ -29,28 +29,18 @@ import static com.oracle.svm.core.Uninterruptible.CALLED_FROM_UNINTERRUPTIBLE_CO
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
 import org.graalvm.nativeimage.StackValue;
-import org.graalvm.nativeimage.c.struct.RawField;
-import org.graalvm.nativeimage.c.struct.RawStructure;
-import org.graalvm.nativeimage.c.struct.SizeOf;
-import org.graalvm.word.Pointer;
-import org.graalvm.word.PointerBase;
 import org.graalvm.word.UnsignedWord;
 
 import com.oracle.svm.core.IsolateArgumentParser;
 import com.oracle.svm.core.SubstrateGCOptions;
 import com.oracle.svm.core.Uninterruptible;
-import com.oracle.svm.core.UnmanagedMemoryUtil;
 import com.oracle.svm.core.heap.PhysicalMemory;
-import com.oracle.svm.core.heap.ReferenceAccess;
 import com.oracle.svm.core.jdk.UninterruptibleUtils;
 import com.oracle.svm.core.locks.VMMutex;
-import com.oracle.svm.core.memory.NullableNativeMemory;
-import com.oracle.svm.core.nmt.NmtCategory;
 import com.oracle.svm.core.os.CommittedMemoryProvider;
 import com.oracle.svm.core.stack.StackOverflowCheck;
 import com.oracle.svm.core.thread.RecurringCallbackSupport;
 import com.oracle.svm.core.thread.VMOperation;
-import com.oracle.svm.core.thread.VMThreads;
 import com.oracle.svm.core.util.BasedOnJDKFile;
 import com.oracle.svm.core.util.UnsignedUtils;
 import com.oracle.svm.core.util.VMError;
@@ -63,7 +53,7 @@ import jdk.graal.compiler.word.Word;
  * to avoid inconsistencies between the different heap size values.
  */
 abstract class AbstractCollectionPolicy implements CollectionPolicy {
-    private static final VMMutex MUTEX = new VMMutex("AbstractCollectionPolicy.sizeParams");
+    private static final VMMutex SIZES_MUTEX = new VMMutex("AbstractCollectionPolicy.sizes");
 
     protected static final int MIN_SPACE_SIZE_AS_NUMBER_OF_ALIGNED_CHUNKS = 8;
 
@@ -167,11 +157,22 @@ abstract class AbstractCollectionPolicy implements CollectionPolicy {
         VMError.guarantee(sizes.isInitialized());
     }
 
+    /**
+     * (Re)computes and updates the {@link SizeParameters} used by this garbage collection policy to
+     * reflect the latest values derived from relevant heap size options and physical memory
+     * constraints.
+     * <p>
+     * This method is thread-safe and may be invoked concurrently by multiple threads. It is called
+     * at least once during VM startup, and is called again if the value of a relevant runtime
+     * option changes. A mutex is used to guarantee consistency of the computed parameters and
+     * prevent lost updates (note that a CAS would not be sufficient to prevent lost updates because
+     * threads could overwrite more recent values with outdated values).
+     */
     @Override
     public void updateSizeParameters() {
         StackOverflowCheck.singleton().makeYellowZoneAvailable();
         try {
-            MUTEX.lock();
+            SIZES_MUTEX.lock();
             try {
                 assert RecurringCallbackSupport.isCallbackUnsupportedOrTimerSuspended() : "recurring callbacks could trigger recursive locking, which isn't supported";
 
@@ -180,7 +181,7 @@ abstract class AbstractCollectionPolicy implements CollectionPolicy {
 
                 sizes.update(newValuesOnStack);
             } finally {
-                MUTEX.unlock();
+                SIZES_MUTEX.unlock();
             }
         } finally {
             StackOverflowCheck.singleton().protectYellowZone();
@@ -220,7 +221,7 @@ abstract class AbstractCollectionPolicy implements CollectionPolicy {
 
     @Override
     public final UnsignedWord getCurrentHeapCapacity() {
-        return sizes.getCurrentHeapCapacity();
+        return sizes.getHeapSize();
     }
 
     @Override
@@ -291,7 +292,7 @@ abstract class AbstractCollectionPolicy implements CollectionPolicy {
     @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25+21/src/hotspot/share/gc/shared/genArguments.cpp#L195-L310")
     @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25+21/src/hotspot/share/gc/parallel/psYoungGen.cpp#L104-L116")
     @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25+21/src/hotspot/share/gc/parallel/psYoungGen.cpp#L146-L168")
-    private void computeSizeParameters(RawSizeParameters newParams) {
+    private void computeSizeParameters(RawSizeParameters newParamsOnStack) {
         UnsignedWord minYoungSpaces = minSpaceSize(); // eden
         if (HeapParameters.getMaxSurvivorSpaces() > 0) {
             minYoungSpaces = minYoungSpaces.add(minSpaceSize().multiply(2)); // survivor from and to
@@ -392,7 +393,7 @@ abstract class AbstractCollectionPolicy implements CollectionPolicy {
         UnsignedWord youngSize = edenSize.add(survivorSize);
         UnsignedWord heapSize = edenSize.add(survivorSize).add(oldSize);
 
-        RawSizeParametersAccess.initialize(newParams,
+        RawSizeParametersOnStackAccess.initialize(newParamsOnStack,
                         initialEden, edenSize, maxEdenSize,
                         initialSurvivor, survivorSize, maxSurvivorSize,
                         initialOldSize, oldSize, maxOldSize,
@@ -426,432 +427,5 @@ abstract class AbstractCollectionPolicy implements CollectionPolicy {
 
     protected UnsignedWord getInitialHeapSize() {
         return AbstractCollectionPolicy.INITIAL_HEAP_SIZE;
-    }
-
-    /**
-     * Once a {@link RawSizeParameters} struct is visible to other threads (see {@link #update}), it
-     * may only be accessed by {@link Uninterruptible} code or when the VM is at a safepoint. This
-     * is necessary to prevent use-after-free errors because no longer needed
-     * {@link RawSizeParameters} structs may be freed during a GC.
-     * <p>
-     * When the VM is at a safepoint, the GC may directly update some of the values in the latest
-     * {@link RawSizeParameters} (see setters below).
-     */
-    protected static final class SizeParameters {
-        private static final String ACCESS_RAW_SIZE_PARAMETERS = "Prevent that RawSizeParameters are freed.";
-
-        private volatile RawSizeParameters sizes;
-
-        @Platforms(Platform.HOSTED_ONLY.class)
-        private SizeParameters() {
-        }
-
-        @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
-        public boolean isInitialized() {
-            /*
-             * This only checks for non-null and doesn't access any values in the struct, so
-             * inlining into interruptible code is allowed.
-             */
-            return sizes.isNonNull();
-        }
-
-        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
-        public UnsignedWord getInitialEdenSize() {
-            assert isInitialized();
-            return sizes.getInitialEdenSize();
-        }
-
-        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
-        public UnsignedWord getEdenSize() {
-            assert isInitialized();
-            return sizes.getEdenSize();
-        }
-
-        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
-        public void setEdenSize(UnsignedWord value) {
-            assert isInitialized();
-            assert VMOperation.isGCInProgress();
-
-            sizes.setEdenSize(value);
-        }
-
-        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
-        public UnsignedWord getMaxEdenSize() {
-            assert isInitialized();
-            return sizes.getMaxEdenSize();
-        }
-
-        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
-        public UnsignedWord getInitialSurvivorSize() {
-            assert isInitialized();
-            return sizes.getInitialSurvivorSize();
-        }
-
-        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
-        public UnsignedWord getSurvivorSize() {
-            assert isInitialized();
-            return sizes.getSurvivorSize();
-        }
-
-        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
-        public void setSurvivorSize(UnsignedWord value) {
-            assert isInitialized();
-            assert VMOperation.isGCInProgress();
-
-            sizes.setSurvivorSize(value);
-        }
-
-        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
-        @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25+21/src/hotspot/share/gc/parallel/psYoungGen.cpp#L104-L116")
-        UnsignedWord getMaxSurvivorSize() {
-            assert isInitialized();
-            return sizes.getMaxSurvivorSize();
-        }
-
-        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
-        UnsignedWord getInitialYoungSize() {
-            assert isInitialized();
-            return sizes.getInitialYoungSize();
-        }
-
-        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
-        public UnsignedWord getYoungSize() {
-            assert isInitialized();
-            return sizes.getYoungSize();
-        }
-
-        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
-        public UnsignedWord getMaxYoungSize() {
-            assert isInitialized();
-            return sizes.getMaxYoungSize();
-        }
-
-        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
-        UnsignedWord getInitialOldSize() {
-            assert isInitialized();
-            return sizes.getInitialOldSize();
-        }
-
-        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
-        public UnsignedWord getOldSize() {
-            assert isInitialized();
-            return sizes.getOldSize();
-        }
-
-        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
-        public void setOldSize(UnsignedWord value) {
-            assert isInitialized();
-            assert VMOperation.isGCInProgress();
-
-            sizes.setOldSize(value);
-        }
-
-        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
-        UnsignedWord getMaxOldSize() {
-            assert isInitialized();
-            return sizes.getMaxOldSize();
-        }
-
-        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
-        public UnsignedWord getPromoSize() {
-            assert isInitialized();
-            return sizes.getPromoSize();
-        }
-
-        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
-        public void setPromoSize(UnsignedWord value) {
-            assert isInitialized();
-            assert VMOperation.isGCInProgress();
-
-            sizes.setPromoSize(value);
-        }
-
-        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
-        public UnsignedWord getMinHeapSize() {
-            assert isInitialized();
-            return sizes.getMinHeapSize();
-        }
-
-        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
-        public UnsignedWord getMaxHeapSize() {
-            assert isInitialized();
-            return sizes.getMaxHeapSize();
-        }
-
-        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
-        public UnsignedWord getCurrentHeapCapacity() {
-            assert isInitialized();
-            assert VMOperation.isGCInProgress() : "use only during GC";
-
-            return sizes.getHeapSize();
-        }
-
-        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
-        private void update(RawSizeParameters newValuesOnStack) {
-            RawSizeParameters prevValues = sizes;
-            if (prevValues.isNonNull() && matches(prevValues, newValuesOnStack)) {
-                /* Nothing to do - cached params are still accurate. */
-                return;
-            }
-
-            /* Try allocating a struct on the C heap. */
-            UnsignedWord structSize = SizeOf.unsigned(RawSizeParameters.class);
-            RawSizeParameters newValuesOnHeap = NullableNativeMemory.malloc(structSize, NmtCategory.GC);
-            VMError.guarantee(newValuesOnHeap.isNonNull(), "Out-of-memory while updating GC policy sizes.");
-
-            /* Copy the values from the stack to the C heap. */
-            UnmanagedMemoryUtil.copyForward((Pointer) newValuesOnStack, (Pointer) newValuesOnHeap, structSize);
-            newValuesOnHeap.setNext(prevValues);
-
-            /*
-             * Publish the new struct via a volatile store. Once the data is published, other
-             * threads need to see a fully initialized struct right away. This is guaranteed by the
-             * implicit STORE_STORE barrier before the volatile write.
-             */
-            sizes = newValuesOnHeap;
-
-            assert isAligned(getMaxSurvivorSize()) && isAligned(getInitialYoungSize()) && isAligned(getInitialOldSize()) && isAligned(getMaxOldSize());
-            assert getMaxSurvivorSize().belowThan(getMaxYoungSize());
-            assert getMaxYoungSize().add(getMaxOldSize()).equal(getMaxHeapSize());
-            assert getInitialEdenSize().add(getInitialSurvivorSize().multiply(2)).equal(getInitialYoungSize());
-            assert getInitialYoungSize().add(getInitialOldSize()).equal(sizes.getInitialHeapSize());
-        }
-
-        /**
-         * Frees no longer needed {@link RawSizeParameters}, so that only the most recent one
-         * remains.
-         */
-        public void freeUnusedSizeParameters() {
-            assert isInitialized();
-            assert VMOperation.isGCInProgress() : "would need to be uninterruptible otherwise";
-
-            RawSizeParameters cur = sizes;
-            freeSizeParameters(cur.getNext());
-            cur.setNext(Word.nullPointer());
-        }
-
-        @Uninterruptible(reason = "Tear-down in progress.")
-        public void tearDown() {
-            assert VMThreads.isTearingDown();
-
-            freeSizeParameters(sizes);
-            sizes = Word.nullPointer();
-        }
-
-        @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
-        private static void freeSizeParameters(RawSizeParameters first) {
-            assert VMOperation.isGCInProgress() || VMThreads.isTearingDown();
-
-            RawSizeParameters cur = first;
-            while (cur.isNonNull()) {
-                RawSizeParameters next = cur.getNext();
-                NullableNativeMemory.free(cur);
-                cur = next;
-            }
-        }
-
-        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
-        private static boolean matches(RawSizeParameters a, RawSizeParameters b) {
-            return a.getInitialEdenSize() == b.getInitialEdenSize() &&
-                            a.getEdenSize() == b.getEdenSize() &&
-                            a.getMaxEdenSize() == b.getMaxEdenSize() &&
-
-                            a.getInitialSurvivorSize() == b.getInitialSurvivorSize() &&
-                            a.getSurvivorSize() == b.getSurvivorSize() &&
-                            a.getMaxSurvivorSize() == b.getMaxSurvivorSize() &&
-
-                            a.getInitialYoungSize() == b.getInitialYoungSize() &&
-                            a.getYoungSize() == b.getYoungSize() &&
-                            a.getMaxYoungSize() == b.getMaxYoungSize() &&
-
-                            a.getInitialOldSize() == b.getInitialOldSize() &&
-                            a.getOldSize() == b.getOldSize() &&
-                            a.getMaxOldSize() == b.getMaxOldSize() &&
-
-                            a.getPromoSize() == b.getPromoSize() &&
-
-                            a.getMinHeapSize() == b.getMinHeapSize() &&
-                            a.getInitialHeapSize() == b.getInitialHeapSize() &&
-                            a.getHeapSize() == b.getHeapSize() &&
-                            a.getMaxHeapSize() == b.getMaxHeapSize();
-        }
-    }
-
-    /**
-     * Struct that stores all GC-related sizes. See {@link SizeParameters} for more details on its
-     * lifecycle.
-     */
-    @RawStructure
-    private interface RawSizeParameters extends PointerBase {
-        @RawField
-        UnsignedWord getInitialEdenSize();
-
-        @RawField
-        void setInitialEdenSize(UnsignedWord value);
-
-        @RawField
-        UnsignedWord getEdenSize();
-
-        @RawField
-        void setEdenSize(UnsignedWord value);
-
-        @RawField
-        UnsignedWord getMaxEdenSize();
-
-        @RawField
-        void setMaxEdenSize(UnsignedWord value);
-
-        @RawField
-        UnsignedWord getInitialSurvivorSize();
-
-        @RawField
-        void setInitialSurvivorSize(UnsignedWord value);
-
-        @RawField
-        UnsignedWord getSurvivorSize();
-
-        @RawField
-        void setSurvivorSize(UnsignedWord value);
-
-        @RawField
-        UnsignedWord getMaxSurvivorSize();
-
-        @RawField
-        void setMaxSurvivorSize(UnsignedWord value);
-
-        @RawField
-        UnsignedWord getInitialYoungSize();
-
-        @RawField
-        void setInitialYoungSize(UnsignedWord value);
-
-        @RawField
-        UnsignedWord getYoungSize();
-
-        @RawField
-        void setYoungSize(UnsignedWord value);
-
-        @RawField
-        UnsignedWord getMaxYoungSize();
-
-        @RawField
-        void setMaxYoungSize(UnsignedWord value);
-
-        @RawField
-        UnsignedWord getInitialOldSize();
-
-        @RawField
-        void setInitialOldSize(UnsignedWord value);
-
-        @RawField
-        UnsignedWord getOldSize();
-
-        @RawField
-        void setOldSize(UnsignedWord value);
-
-        @RawField
-        UnsignedWord getMaxOldSize();
-
-        @RawField
-        void setMaxOldSize(UnsignedWord value);
-
-        @RawField
-        UnsignedWord getPromoSize();
-
-        @RawField
-        void setPromoSize(UnsignedWord value);
-
-        @RawField
-        UnsignedWord getMinHeapSize();
-
-        @RawField
-        void setMinHeapSize(UnsignedWord value);
-
-        @RawField
-        UnsignedWord getInitialHeapSize();
-
-        @RawField
-        void setInitialHeapSize(UnsignedWord value);
-
-        @RawField
-        UnsignedWord getHeapSize();
-
-        @RawField
-        void setHeapSize(UnsignedWord value);
-
-        @RawField
-        UnsignedWord getMaxHeapSize();
-
-        @RawField
-        void setMaxHeapSize(UnsignedWord value);
-
-        @RawField
-        RawSizeParameters getNext();
-
-        @RawField
-        void setNext(RawSizeParameters value);
-    }
-
-    /**
-     * The methods in this class may only be used on {@link RawSizeParameters} that are allocated on
-     * the stack and therefore not yet visible to other threads. Please keep the methods in this
-     * class to a minimum.
-     */
-    private static final class RawSizeParametersAccess {
-        static void initialize(RawSizeParameters valuesOnStack,
-                        UnsignedWord initialEdenSize, UnsignedWord edenSize, UnsignedWord maxEdenSize,
-                        UnsignedWord initialSurvivorSize, UnsignedWord survivorSize, UnsignedWord maxSurvivorSize,
-                        UnsignedWord initialOldSize, UnsignedWord oldSize, UnsignedWord maxOldSize,
-                        UnsignedWord promoSize,
-                        UnsignedWord initialYoungSize, UnsignedWord youngSize, UnsignedWord maxYoungSize,
-                        UnsignedWord minHeapSize, UnsignedWord initialHeapSize, UnsignedWord heapSize, UnsignedWord maxHeapSize) {
-            assert isAligned(maxHeapSize) && isAligned(maxYoungSize) && isAligned(initialHeapSize) && isAligned(initialEdenSize) && isAligned(initialSurvivorSize);
-
-            assert initialEdenSize.belowOrEqual(initialYoungSize);
-            assert edenSize.belowOrEqual(youngSize);
-            assert maxEdenSize.belowOrEqual(maxYoungSize);
-
-            assert initialSurvivorSize.belowOrEqual(initialYoungSize);
-            assert survivorSize.belowOrEqual(youngSize);
-            assert maxSurvivorSize.belowOrEqual(maxYoungSize);
-
-            assert initialOldSize.belowOrEqual(initialHeapSize);
-            assert oldSize.belowOrEqual(heapSize);
-            assert maxOldSize.belowOrEqual(maxHeapSize);
-
-            assert initialYoungSize.belowOrEqual(initialHeapSize);
-            assert youngSize.belowOrEqual(heapSize);
-            assert maxYoungSize.belowOrEqual(maxHeapSize);
-
-            assert minHeapSize.belowOrEqual(initialHeapSize);
-            assert initialHeapSize.belowOrEqual(maxHeapSize);
-            assert heapSize.belowOrEqual(maxHeapSize);
-            assert maxHeapSize.belowOrEqual(ReferenceAccess.singleton().getMaxAddressSpaceSize());
-
-            valuesOnStack.setInitialEdenSize(initialEdenSize);
-            valuesOnStack.setEdenSize(edenSize);
-            valuesOnStack.setMaxEdenSize(maxEdenSize);
-
-            valuesOnStack.setInitialSurvivorSize(initialSurvivorSize);
-            valuesOnStack.setSurvivorSize(survivorSize);
-            valuesOnStack.setMaxSurvivorSize(maxSurvivorSize);
-
-            valuesOnStack.setInitialYoungSize(initialYoungSize);
-            valuesOnStack.setYoungSize(youngSize);
-            valuesOnStack.setMaxYoungSize(maxYoungSize);
-
-            valuesOnStack.setInitialOldSize(initialOldSize);
-            valuesOnStack.setOldSize(oldSize);
-            valuesOnStack.setMaxOldSize(maxOldSize);
-
-            valuesOnStack.setPromoSize(promoSize);
-
-            valuesOnStack.setMinHeapSize(minHeapSize);
-            valuesOnStack.setInitialHeapSize(initialHeapSize);
-            valuesOnStack.setHeapSize(heapSize);
-            valuesOnStack.setMaxHeapSize(maxHeapSize);
-
-            valuesOnStack.setNext(Word.nullPointer());
-        }
     }
 }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AbstractCollectionPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AbstractCollectionPolicy.java
@@ -28,6 +28,7 @@ import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
 import org.graalvm.word.UnsignedWord;
 
+import com.oracle.svm.core.IsolateArgumentParser;
 import com.oracle.svm.core.SubstrateGCOptions;
 import com.oracle.svm.core.Uninterruptible;
 import com.oracle.svm.core.heap.PhysicalMemory;
@@ -359,7 +360,7 @@ abstract class AbstractCollectionPolicy implements CollectionPolicy {
         maxHeap = UnsignedUtils.clamp(alignDown(maxHeap), minAllSpaces, heapSizeLimit);
 
         UnsignedWord maxYoung;
-        long optionMaxYoung = SubstrateGCOptions.MaxNewSize.getValue();
+        long optionMaxYoung = getMaxNewSizeOptionValue();
         if (optionMaxYoung > 0L) {
             maxYoung = Word.unsigned(optionMaxYoung);
         } else if (SerialAndEpsilonGCOptions.MaximumYoungGenerationSizePercent.hasBeenSet()) {
@@ -375,7 +376,7 @@ abstract class AbstractCollectionPolicy implements CollectionPolicy {
                         (maxHeap.belowOrEqual(unadjustedMaxHeap) || unadjustedMaxHeap.belowThan(minAllSpaces)));
 
         UnsignedWord minHeap = Word.zero();
-        long optionMin = SubstrateGCOptions.MinHeapSize.getValue();
+        long optionMin = getMinHeapSizeOptionValue();
         if (optionMin > 0L) {
             minHeap = Word.unsigned(optionMin);
         }
@@ -419,7 +420,18 @@ abstract class AbstractCollectionPolicy implements CollectionPolicy {
     }
 
     protected long getMaximumHeapSizeOptionValue() {
-        return SubstrateGCOptions.MaxHeapSize.getValue();
+        int optionIndex = IsolateArgumentParser.getOptionIndex(SubstrateGCOptions.MaxHeapSize);
+        return IsolateArgumentParser.singleton().getLongOptionValue(optionIndex);
+    }
+
+    protected static long getMaxNewSizeOptionValue() {
+        int optionIndex = IsolateArgumentParser.getOptionIndex(SubstrateGCOptions.MaxNewSize);
+        return IsolateArgumentParser.singleton().getLongOptionValue(optionIndex);
+    }
+
+    protected static long getMinHeapSizeOptionValue() {
+        int optionIndex = IsolateArgumentParser.getOptionIndex(SubstrateGCOptions.MinHeapSize);
+        return IsolateArgumentParser.singleton().getLongOptionValue(optionIndex);
     }
 
     protected UnsignedWord getInitialHeapSize() {

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AbstractCollectionPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AbstractCollectionPolicy.java
@@ -24,32 +24,46 @@
  */
 package com.oracle.svm.core.genscavenge;
 
+import static com.oracle.svm.core.Uninterruptible.CALLED_FROM_UNINTERRUPTIBLE_CODE;
+
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
+import org.graalvm.nativeimage.StackValue;
+import org.graalvm.nativeimage.c.struct.RawField;
+import org.graalvm.nativeimage.c.struct.RawStructure;
+import org.graalvm.nativeimage.c.struct.SizeOf;
+import org.graalvm.word.Pointer;
+import org.graalvm.word.PointerBase;
 import org.graalvm.word.UnsignedWord;
 
 import com.oracle.svm.core.IsolateArgumentParser;
 import com.oracle.svm.core.SubstrateGCOptions;
 import com.oracle.svm.core.Uninterruptible;
+import com.oracle.svm.core.UnmanagedMemoryUtil;
 import com.oracle.svm.core.heap.PhysicalMemory;
 import com.oracle.svm.core.heap.ReferenceAccess;
 import com.oracle.svm.core.jdk.UninterruptibleUtils;
+import com.oracle.svm.core.locks.VMMutex;
+import com.oracle.svm.core.memory.NullableNativeMemory;
+import com.oracle.svm.core.nmt.NmtCategory;
 import com.oracle.svm.core.os.CommittedMemoryProvider;
-import com.oracle.svm.core.thread.JavaSpinLockUtils;
+import com.oracle.svm.core.stack.StackOverflowCheck;
+import com.oracle.svm.core.thread.RecurringCallbackSupport;
 import com.oracle.svm.core.thread.VMOperation;
+import com.oracle.svm.core.thread.VMThreads;
 import com.oracle.svm.core.util.BasedOnJDKFile;
 import com.oracle.svm.core.util.UnsignedUtils;
 import com.oracle.svm.core.util.VMError;
 
 import jdk.graal.compiler.api.replacements.Fold;
 import jdk.graal.compiler.word.Word;
-import jdk.internal.misc.Unsafe;
 
 /**
  * Note that a lot of methods in this class are final. Subclasses may only override certain methods
  * to avoid inconsistencies between the different heap size values.
  */
 abstract class AbstractCollectionPolicy implements CollectionPolicy {
+    private static final VMMutex MUTEX = new VMMutex("AbstractCollectionPolicy.sizeParams");
 
     protected static final int MIN_SPACE_SIZE_AS_NUMBER_OF_ALIGNED_CHUNKS = 8;
 
@@ -61,9 +75,6 @@ abstract class AbstractCollectionPolicy implements CollectionPolicy {
         assert userValue == null || userValue >= 0 : userValue;
         return (userValue != null) ? userValue : AbstractCollectionPolicy.MAX_TENURING_THRESHOLD;
     }
-
-    private static final Unsafe U = Unsafe.getUnsafe();
-    private static final long SIZES_UPDATE_LOCK_OFFSET = U.objectFieldOffset(AbstractCollectionPolicy.class, "sizesUpdateLock");
 
     /*
      * Constants that can be made options if desirable. These are -XX options in HotSpot, refer to
@@ -85,16 +96,10 @@ abstract class AbstractCollectionPolicy implements CollectionPolicy {
     protected static final int NEW_RATIO = 2;
 
     protected final AdaptiveWeightedAverage avgYoungGenAlignedChunkFraction = new AdaptiveWeightedAverage(ADAPTIVE_TIME_WEIGHT);
+    protected final SizeParameters sizes = new SizeParameters();
 
     private final int initialNewRatio;
-    protected UnsignedWord survivorSize;
-    protected UnsignedWord edenSize;
-    protected UnsignedWord promoSize;
-    protected UnsignedWord oldSize;
     protected int tenuringThreshold;
-
-    protected volatile SizeParameters sizes = null;
-    @SuppressWarnings("unused") private volatile int sizesUpdateLock;
 
     protected AbstractCollectionPolicy(int initialNewRatio, int initialTenuringThreshold) {
         this.initialNewRatio = initialNewRatio;
@@ -102,12 +107,16 @@ abstract class AbstractCollectionPolicy implements CollectionPolicy {
     }
 
     @Override
+    @Uninterruptible(reason = "Tear-down in progress.")
+    public void tearDown() {
+        sizes.tearDown();
+    }
+
+    @Override
     public boolean shouldCollectOnAllocation() {
-        if (sizes == null) {
-            return false; // updateSizeParameters() has never been called
-        }
+        guaranteeSizeParametersInitialized();
         UnsignedWord edenUsed = HeapImpl.getAccounting().getEdenUsedBytes();
-        return edenUsed.aboveOrEqual(edenSize);
+        return edenUsed.aboveOrEqual(sizes.getEdenSize());
     }
 
     @Override
@@ -148,155 +157,96 @@ abstract class AbstractCollectionPolicy implements CollectionPolicy {
 
     @Override
     public void ensureSizeParametersInitialized() {
-        if (sizes == null) {
+        if (!sizes.isInitialized()) {
             updateSizeParameters();
         }
     }
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     protected void guaranteeSizeParametersInitialized() {
-        VMError.guarantee(sizes != null);
+        VMError.guarantee(sizes.isInitialized());
     }
 
     @Override
     public void updateSizeParameters() {
-        /*
-         * Read the old object before computing the new values. Otherwise, we risk reusing an
-         * outdated SizeParameters object.
-         */
-        SizeParameters prevParams = sizes;
-        SizeParameters newParams = computeSizeParameters(prevParams);
-        if (prevParams != null && newParams.equal(prevParams)) {
-            return; // nothing to do
-        }
-        updateSizeParameters0(newParams, prevParams);
-        guaranteeSizeParametersInitialized(); // sanity
-    }
-
-    @Uninterruptible(reason = "Holding the spin lock at a safepoint can result in deadlocks.")
-    private void updateSizeParameters0(SizeParameters newParams, SizeParameters prevParams) {
-        /*
-         * We use a primitive spin lock because at this point, the current thread might be unable to
-         * use a Java lock (e.g. no Thread object yet), and the critical section is short, so we do
-         * not want to suspend and wake up threads for it.
-         */
-        JavaSpinLockUtils.lockNoTransition(this, SIZES_UPDATE_LOCK_OFFSET);
+        StackOverflowCheck.singleton().makeYellowZoneAvailable();
         try {
-            if (sizes != prevParams) {
-                /*
-                 * Some other thread beat us and we cannot tell if our values or their values are
-                 * newer, so back off - any newer values will be applied eventually.
-                 */
-                return;
+            MUTEX.lock();
+            try {
+                assert RecurringCallbackSupport.isCallbackUnsupportedOrTimerSuspended() : "recurring callbacks could trigger recursive locking, which isn't supported";
+
+                RawSizeParameters newValuesOnStack = StackValue.get(RawSizeParameters.class);
+                computeSizeParameters(newValuesOnStack);
+
+                sizes.update(newValuesOnStack);
+            } finally {
+                MUTEX.unlock();
             }
-            updateSizeParametersLocked(newParams, prevParams);
         } finally {
-            JavaSpinLockUtils.unlock(this, SIZES_UPDATE_LOCK_OFFSET);
+            StackOverflowCheck.singleton().protectYellowZone();
         }
-    }
-
-    @Uninterruptible(reason = "Holding the spin lock at a safepoint can result in deadlocks. Updating the size parameters must be atomic with regard to garbage collection.")
-    private void updateSizeParametersLocked(SizeParameters newParams, SizeParameters prevParams) {
-        sizes = newParams;
-
-        if (prevParams == null || gcCount() == 0) {
-            survivorSize = newParams.initialSurvivorSize;
-            edenSize = newParams.initialEdenSize;
-            oldSize = newParams.initialOldSize();
-            promoSize = UnsignedUtils.min(edenSize, oldSize);
-        }
-
-        /*
-         * NOTE: heap limits can change when options are updated at runtime or once the physical
-         * memory size becomes known. This means that we start off with sizes which can cause higher
-         * GC costs initially, and when shrinking the heap, that previously computed values such as
-         * GC costs and intervals and survived/promoted objects are likely no longer representative.
-         *
-         * We assume that such changes happen very early on and values then adapt reasonably quick,
-         * but we must still ensure that computations can handle it (for example, no overflows).
-         */
-        survivorSize = UnsignedUtils.min(survivorSize, newParams.maxSurvivorSize());
-        edenSize = UnsignedUtils.min(edenSize, getMaximumEdenSize());
-        oldSize = UnsignedUtils.min(oldSize, newParams.maxOldSize());
-        promoSize = UnsignedUtils.min(promoSize, newParams.maxOldSize());
     }
 
     @Override
     public final UnsignedWord getInitialEdenSize() {
-        guaranteeSizeParametersInitialized();
-        return sizes.initialEdenSize;
+        return sizes.getInitialEdenSize();
     }
 
     @Override
-    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25+21/src/hotspot/share/gc/parallel/psYoungGen.cpp#L104-L116")
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     public final UnsignedWord getMaximumEdenSize() {
-        guaranteeSizeParametersInitialized();
-        return alignDown(sizes.maxYoungSize.subtract(survivorSize.multiply(2)));
+        return sizes.getMaxEdenSize();
     }
 
     @Override
     public final UnsignedWord getMaximumHeapSize() {
-        guaranteeSizeParametersInitialized();
-        return sizes.maxHeapSize;
+        return sizes.getMaxHeapSize();
     }
 
     @Override
     public final UnsignedWord getMaximumYoungGenerationSize() {
-        guaranteeSizeParametersInitialized();
-        return sizes.maxYoungSize;
+        return sizes.getMaxYoungSize();
     }
 
     @Override
     public final UnsignedWord getInitialSurvivorSize() {
-        guaranteeSizeParametersInitialized();
-        return sizes.initialSurvivorSize;
+        return sizes.getInitialSurvivorSize();
     }
 
     @Override
     public final UnsignedWord getMaximumSurvivorSize() {
-        guaranteeSizeParametersInitialized();
-        return sizes.maxSurvivorSize();
+        return sizes.getMaxSurvivorSize();
     }
 
     @Override
     public final UnsignedWord getCurrentHeapCapacity() {
-        assert VMOperation.isGCInProgress() : "use only during GC";
-        guaranteeSizeParametersInitialized();
-        return edenSize.add(survivorSize).add(oldSize);
+        return sizes.getCurrentHeapCapacity();
     }
 
     @Override
-    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     public final UnsignedWord getSurvivorSpacesCapacity() {
-        assert VMOperation.isGCInProgress() : "use only during GC";
-        guaranteeSizeParametersInitialized();
-        return survivorSize;
+        return sizes.getSurvivorSize();
     }
 
     @Override
-    @Uninterruptible(reason = "Ensure reading a consistent value.")
     public final UnsignedWord getYoungGenerationCapacity() {
-        guaranteeSizeParametersInitialized();
-        return edenSize.add(survivorSize);
+        return sizes.getYoungSize();
     }
 
     @Override
     public final UnsignedWord getInitialOldSize() {
-        guaranteeSizeParametersInitialized();
-        return sizes.initialOldSize();
+        return sizes.getInitialOldSize();
     }
 
     @Override
     public final UnsignedWord getMaximumOldSize() {
-        guaranteeSizeParametersInitialized();
-        return sizes.maxOldSize();
+        return sizes.getMaxOldSize();
     }
 
     @Override
     public final UnsignedWord getOldGenerationCapacity() {
-        guaranteeSizeParametersInitialized();
-        return oldSize;
+        return sizes.getOldSize();
     }
 
     @Override
@@ -308,20 +258,22 @@ abstract class AbstractCollectionPolicy implements CollectionPolicy {
          * survivor spaces in a future collection. We could alternatively return
          * getCurrentHeapCapacity() to have chunks ready during full GCs as well.
          */
-        UnsignedWord total = edenSize.add(HeapImpl.getAccounting().getSurvivorUsedBytes());
+        UnsignedWord total = sizes.getEdenSize().add(HeapImpl.getAccounting().getSurvivorUsedBytes());
         double alignedFraction = Math.min(1, Math.max(0, avgYoungGenAlignedChunkFraction.getAverage()));
         return UnsignedUtils.fromDouble(UnsignedUtils.toDouble(total) * alignedFraction);
     }
 
     @Override
-    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     public int getTenuringAge() {
         assert VMOperation.isGCInProgress() : "use only during GC";
         return tenuringThreshold;
     }
 
     @Override
-    public void onCollectionBegin(boolean completeCollection, long requestingNanoTime) {
+    public void onCollectionBegin(boolean completeCollection, long beginNanoTime) {
+        sizes.freeUnusedSizeParameters();
+
         // Capture the fraction of bytes in aligned chunks at the start to include all allocated
         // (also dead) objects, because we use it to reserve aligned chunks for future allocations
         UnsignedWord youngChunkBytes = GCImpl.getAccounting().getYoungChunkBytesBefore();
@@ -333,15 +285,13 @@ abstract class AbstractCollectionPolicy implements CollectionPolicy {
 
     @Override
     public final UnsignedWord getMinimumHeapSize() {
-        return sizes.minHeapSize;
+        return sizes.getMinHeapSize();
     }
 
-    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    protected abstract long gcCount();
-
     @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25+21/src/hotspot/share/gc/shared/genArguments.cpp#L195-L310")
+    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25+21/src/hotspot/share/gc/parallel/psYoungGen.cpp#L104-L116")
     @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25+21/src/hotspot/share/gc/parallel/psYoungGen.cpp#L146-L168")
-    protected SizeParameters computeSizeParameters(SizeParameters existing) {
+    private void computeSizeParameters(RawSizeParameters newParams) {
         UnsignedWord minYoungSpaces = minSpaceSize(); // eden
         if (HeapParameters.getMaxSurvivorSpaces() > 0) {
             minYoungSpaces = minYoungSpaces.add(minSpaceSize().multiply(2)); // survivor from and to
@@ -392,6 +342,7 @@ abstract class AbstractCollectionPolicy implements CollectionPolicy {
             initialYoung = initialHeap.unsignedDivide(initialNewRatio + 1);
             initialYoung = UnsignedUtils.clamp(alignUp(initialYoung), minYoungSpaces, maxYoung);
         }
+
         UnsignedWord initialSurvivor = Word.zero();
         if (HeapParameters.getMaxSurvivorSpaces() > 0) {
             /*
@@ -405,10 +356,49 @@ abstract class AbstractCollectionPolicy implements CollectionPolicy {
             initialSurvivor = initialYoung.unsignedDivide(AbstractCollectionPolicy.INITIAL_SURVIVOR_RATIO);
             initialSurvivor = minSpaceSize(alignDown(initialSurvivor));
         }
+
         UnsignedWord initialEden = initialYoung.subtract(initialSurvivor.multiply(2));
         initialEden = minSpaceSize(alignDown(initialEden));
 
-        return SizeParameters.get(existing, maxHeap, maxYoung, initialHeap, initialEden, initialSurvivor, minHeap);
+        UnsignedWord maxSurvivorSize = Word.zero();
+        UnsignedWord maxEdenSize = maxYoung;
+        if (HeapParameters.getMaxSurvivorSpaces() > 0) {
+            maxSurvivorSize = maxYoung.unsignedDivide(MIN_SURVIVOR_RATIO);
+            maxSurvivorSize = minSpaceSize(alignDown(maxSurvivorSize));
+            maxEdenSize = maxYoung.subtract(minSpaceSize().multiply(2));
+        }
+
+        UnsignedWord maxOldSize = maxHeap.subtract(maxYoung);
+
+        UnsignedWord survivorSize;
+        UnsignedWord edenSize;
+        UnsignedWord oldSize;
+        UnsignedWord promoSize;
+        if (sizes.isInitialized()) {
+            /* Copy and limit existing values. */
+            survivorSize = UnsignedUtils.min(sizes.getSurvivorSize(), maxSurvivorSize);
+            edenSize = UnsignedUtils.min(sizes.getEdenSize(), maxEdenSize);
+            oldSize = UnsignedUtils.min(sizes.getOldSize(), maxOldSize);
+            promoSize = UnsignedUtils.min(sizes.getPromoSize(), maxOldSize);
+        } else {
+            /* Set initial values. */
+            survivorSize = initialSurvivor;
+            edenSize = initialEden;
+            oldSize = initialHeap.subtract(initialYoung);
+            promoSize = UnsignedUtils.min(edenSize, oldSize);
+        }
+
+        UnsignedWord initialOldSize = initialHeap.subtract(initialYoung);
+        UnsignedWord youngSize = edenSize.add(survivorSize);
+        UnsignedWord heapSize = edenSize.add(survivorSize).add(oldSize);
+
+        RawSizeParametersAccess.initialize(newParams,
+                        initialEden, edenSize, maxEdenSize,
+                        initialSurvivor, survivorSize, maxSurvivorSize,
+                        initialOldSize, oldSize, maxOldSize,
+                        promoSize,
+                        initialYoung, youngSize, maxYoung,
+                        minHeap, initialHeap, heapSize, maxHeap);
     }
 
     protected UnsignedWord getHeapSizeLimit() {
@@ -438,76 +428,430 @@ abstract class AbstractCollectionPolicy implements CollectionPolicy {
         return AbstractCollectionPolicy.INITIAL_HEAP_SIZE;
     }
 
+    /**
+     * Once a {@link RawSizeParameters} struct is visible to other threads (see {@link #update}), it
+     * may only be accessed by {@link Uninterruptible} code or when the VM is at a safepoint. This
+     * is necessary to prevent use-after-free errors because no longer needed
+     * {@link RawSizeParameters} structs may be freed during a GC.
+     * <p>
+     * When the VM is at a safepoint, the GC may directly update some of the values in the latest
+     * {@link RawSizeParameters} (see setters below).
+     */
     protected static final class SizeParameters {
-        final UnsignedWord maxHeapSize;
-        final UnsignedWord maxYoungSize;
-        final UnsignedWord initialHeapSize;
-        final UnsignedWord initialEdenSize;
-        final UnsignedWord initialSurvivorSize;
-        final UnsignedWord minHeapSize;
+        private static final String ACCESS_RAW_SIZE_PARAMETERS = "Prevent that RawSizeParameters are freed.";
 
-        static SizeParameters get(SizeParameters existing, UnsignedWord maxHeap, UnsignedWord maxYoung, UnsignedWord initialHeap,
-                        UnsignedWord initialEden, UnsignedWord initialSurvivor, UnsignedWord minHeap) {
-            if (existing != null && existing.matches(maxHeap, maxYoung, initialHeap, initialEden, initialSurvivor, minHeap)) {
-                return existing;
-            }
-            return new SizeParameters(maxHeap, maxYoung, initialHeap, initialEden, initialSurvivor, minHeap);
+        private volatile RawSizeParameters sizes;
+
+        @Platforms(Platform.HOSTED_ONLY.class)
+        private SizeParameters() {
         }
 
-        private SizeParameters(UnsignedWord maxHeapSize, UnsignedWord maxYoungSize, UnsignedWord initialHeapSize,
-                        UnsignedWord initialEdenSize, UnsignedWord initialSurvivorSize, UnsignedWord minHeapSize) {
-            this.maxHeapSize = maxHeapSize;
-            this.maxYoungSize = maxYoungSize;
-            this.initialHeapSize = initialHeapSize;
-            this.initialEdenSize = initialEdenSize;
-            this.initialSurvivorSize = initialSurvivorSize;
-            this.minHeapSize = minHeapSize;
-
-            assert isAligned(maxHeapSize) && isAligned(maxYoungSize) && isAligned(initialHeapSize) && isAligned(initialEdenSize) && isAligned(initialSurvivorSize);
-            assert isAligned(maxSurvivorSize()) && isAligned(initialYoungSize()) && isAligned(initialOldSize()) && isAligned(maxOldSize());
-
-            assert initialHeapSize.belowOrEqual(maxHeapSize);
-            assert maxSurvivorSize().belowThan(maxYoungSize);
-            assert maxYoungSize.add(maxOldSize()).equal(maxHeapSize);
-            assert maxHeapSize.belowOrEqual(ReferenceAccess.singleton().getMaxAddressSpaceSize());
-            assert initialEdenSize.add(initialSurvivorSize.multiply(2)).equal(initialYoungSize());
-            assert initialYoungSize().add(initialOldSize()).equal(initialHeapSize);
+        @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+        public boolean isInitialized() {
+            /*
+             * This only checks for non-null and doesn't access any values in the struct, so
+             * inlining into interruptible code is allowed.
+             */
+            return sizes.isNonNull();
         }
 
-        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+        public UnsignedWord getInitialEdenSize() {
+            assert isInitialized();
+            return sizes.getInitialEdenSize();
+        }
+
+        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+        public UnsignedWord getEdenSize() {
+            assert isInitialized();
+            return sizes.getEdenSize();
+        }
+
+        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+        public void setEdenSize(UnsignedWord value) {
+            assert isInitialized();
+            assert VMOperation.isGCInProgress();
+
+            sizes.setEdenSize(value);
+        }
+
+        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+        public UnsignedWord getMaxEdenSize() {
+            assert isInitialized();
+            return sizes.getMaxEdenSize();
+        }
+
+        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+        public UnsignedWord getInitialSurvivorSize() {
+            assert isInitialized();
+            return sizes.getInitialSurvivorSize();
+        }
+
+        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+        public UnsignedWord getSurvivorSize() {
+            assert isInitialized();
+            return sizes.getSurvivorSize();
+        }
+
+        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+        public void setSurvivorSize(UnsignedWord value) {
+            assert isInitialized();
+            assert VMOperation.isGCInProgress();
+
+            sizes.setSurvivorSize(value);
+        }
+
+        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
         @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25+21/src/hotspot/share/gc/parallel/psYoungGen.cpp#L104-L116")
-        UnsignedWord maxSurvivorSize() {
-            if (HeapParameters.getMaxSurvivorSpaces() == 0) {
-                return Word.zero();
+        UnsignedWord getMaxSurvivorSize() {
+            assert isInitialized();
+            return sizes.getMaxSurvivorSize();
+        }
+
+        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+        UnsignedWord getInitialYoungSize() {
+            assert isInitialized();
+            return sizes.getInitialYoungSize();
+        }
+
+        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+        public UnsignedWord getYoungSize() {
+            assert isInitialized();
+            return sizes.getYoungSize();
+        }
+
+        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+        public UnsignedWord getMaxYoungSize() {
+            assert isInitialized();
+            return sizes.getMaxYoungSize();
+        }
+
+        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+        UnsignedWord getInitialOldSize() {
+            assert isInitialized();
+            return sizes.getInitialOldSize();
+        }
+
+        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+        public UnsignedWord getOldSize() {
+            assert isInitialized();
+            return sizes.getOldSize();
+        }
+
+        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+        public void setOldSize(UnsignedWord value) {
+            assert isInitialized();
+            assert VMOperation.isGCInProgress();
+
+            sizes.setOldSize(value);
+        }
+
+        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+        UnsignedWord getMaxOldSize() {
+            assert isInitialized();
+            return sizes.getMaxOldSize();
+        }
+
+        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+        public UnsignedWord getPromoSize() {
+            assert isInitialized();
+            return sizes.getPromoSize();
+        }
+
+        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+        public void setPromoSize(UnsignedWord value) {
+            assert isInitialized();
+            assert VMOperation.isGCInProgress();
+
+            sizes.setPromoSize(value);
+        }
+
+        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+        public UnsignedWord getMinHeapSize() {
+            assert isInitialized();
+            return sizes.getMinHeapSize();
+        }
+
+        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+        public UnsignedWord getMaxHeapSize() {
+            assert isInitialized();
+            return sizes.getMaxHeapSize();
+        }
+
+        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+        public UnsignedWord getCurrentHeapCapacity() {
+            assert isInitialized();
+            assert VMOperation.isGCInProgress() : "use only during GC";
+
+            return sizes.getHeapSize();
+        }
+
+        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+        private void update(RawSizeParameters newValuesOnStack) {
+            RawSizeParameters prevValues = sizes;
+            if (prevValues.isNonNull() && matches(prevValues, newValuesOnStack)) {
+                /* Nothing to do - cached params are still accurate. */
+                return;
             }
-            UnsignedWord size = maxYoungSize.unsignedDivide(MIN_SURVIVOR_RATIO);
-            return minSpaceSize(alignDown(size));
+
+            /* Try allocating a struct on the C heap. */
+            UnsignedWord structSize = SizeOf.unsigned(RawSizeParameters.class);
+            RawSizeParameters newValuesOnHeap = NullableNativeMemory.malloc(structSize, NmtCategory.GC);
+            VMError.guarantee(newValuesOnHeap.isNonNull(), "Out-of-memory while updating GC policy sizes.");
+
+            /* Copy the values from the stack to the C heap. */
+            UnmanagedMemoryUtil.copyForward((Pointer) newValuesOnStack, (Pointer) newValuesOnHeap, structSize);
+            newValuesOnHeap.setNext(prevValues);
+
+            /*
+             * Publish the new struct via a volatile store. Once the data is published, other
+             * threads need to see a fully initialized struct right away. This is guaranteed by the
+             * implicit STORE_STORE barrier before the volatile write.
+             */
+            sizes = newValuesOnHeap;
+
+            assert isAligned(getMaxSurvivorSize()) && isAligned(getInitialYoungSize()) && isAligned(getInitialOldSize()) && isAligned(getMaxOldSize());
+            assert getMaxSurvivorSize().belowThan(getMaxYoungSize());
+            assert getMaxYoungSize().add(getMaxOldSize()).equal(getMaxHeapSize());
+            assert getInitialEdenSize().add(getInitialSurvivorSize().multiply(2)).equal(getInitialYoungSize());
+            assert getInitialYoungSize().add(getInitialOldSize()).equal(sizes.getInitialHeapSize());
         }
 
-        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-        UnsignedWord initialYoungSize() {
-            return initialEdenSize.add(initialSurvivorSize.multiply(2));
+        /**
+         * Frees no longer needed {@link RawSizeParameters}, so that only the most recent one
+         * remains.
+         */
+        public void freeUnusedSizeParameters() {
+            assert isInitialized();
+            assert VMOperation.isGCInProgress() : "would need to be uninterruptible otherwise";
+
+            RawSizeParameters cur = sizes;
+            freeSizeParameters(cur.getNext());
+            cur.setNext(Word.nullPointer());
         }
 
-        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-        UnsignedWord initialOldSize() {
-            return initialHeapSize.subtract(initialYoungSize());
+        @Uninterruptible(reason = "Tear-down in progress.")
+        public void tearDown() {
+            assert VMThreads.isTearingDown();
+
+            freeSizeParameters(sizes);
+            sizes = Word.nullPointer();
         }
 
-        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-        UnsignedWord maxOldSize() {
-            return maxHeapSize.subtract(maxYoungSize);
+        @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+        private static void freeSizeParameters(RawSizeParameters first) {
+            assert VMOperation.isGCInProgress() || VMThreads.isTearingDown();
+
+            RawSizeParameters cur = first;
+            while (cur.isNonNull()) {
+                RawSizeParameters next = cur.getNext();
+                NullableNativeMemory.free(cur);
+                cur = next;
+            }
         }
 
-        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-        boolean equal(SizeParameters other) {
-            return other == this || other.matches(maxHeapSize, maxYoungSize, initialHeapSize, initialEdenSize, initialSurvivorSize, minHeapSize);
-        }
+        @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+        private static boolean matches(RawSizeParameters a, RawSizeParameters b) {
+            return a.getInitialEdenSize() == b.getInitialEdenSize() &&
+                            a.getEdenSize() == b.getEdenSize() &&
+                            a.getMaxEdenSize() == b.getMaxEdenSize() &&
 
-        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-        boolean matches(UnsignedWord maxHeap, UnsignedWord maxYoung, UnsignedWord initialHeap, UnsignedWord initialEden, UnsignedWord initialSurvivor, UnsignedWord minHeap) {
-            return maxHeapSize.equal(maxHeap) && maxYoungSize.equal(maxYoung) && initialHeapSize.equal(initialHeap) &&
-                            initialEdenSize.equal(initialEden) && initialSurvivorSize.equal(initialSurvivor) && minHeapSize.equal(minHeap);
+                            a.getInitialSurvivorSize() == b.getInitialSurvivorSize() &&
+                            a.getSurvivorSize() == b.getSurvivorSize() &&
+                            a.getMaxSurvivorSize() == b.getMaxSurvivorSize() &&
+
+                            a.getInitialYoungSize() == b.getInitialYoungSize() &&
+                            a.getYoungSize() == b.getYoungSize() &&
+                            a.getMaxYoungSize() == b.getMaxYoungSize() &&
+
+                            a.getInitialOldSize() == b.getInitialOldSize() &&
+                            a.getOldSize() == b.getOldSize() &&
+                            a.getMaxOldSize() == b.getMaxOldSize() &&
+
+                            a.getPromoSize() == b.getPromoSize() &&
+
+                            a.getMinHeapSize() == b.getMinHeapSize() &&
+                            a.getInitialHeapSize() == b.getInitialHeapSize() &&
+                            a.getHeapSize() == b.getHeapSize() &&
+                            a.getMaxHeapSize() == b.getMaxHeapSize();
+        }
+    }
+
+    /**
+     * Struct that stores all GC-related sizes. See {@link SizeParameters} for more details on its
+     * lifecycle.
+     */
+    @RawStructure
+    private interface RawSizeParameters extends PointerBase {
+        @RawField
+        UnsignedWord getInitialEdenSize();
+
+        @RawField
+        void setInitialEdenSize(UnsignedWord value);
+
+        @RawField
+        UnsignedWord getEdenSize();
+
+        @RawField
+        void setEdenSize(UnsignedWord value);
+
+        @RawField
+        UnsignedWord getMaxEdenSize();
+
+        @RawField
+        void setMaxEdenSize(UnsignedWord value);
+
+        @RawField
+        UnsignedWord getInitialSurvivorSize();
+
+        @RawField
+        void setInitialSurvivorSize(UnsignedWord value);
+
+        @RawField
+        UnsignedWord getSurvivorSize();
+
+        @RawField
+        void setSurvivorSize(UnsignedWord value);
+
+        @RawField
+        UnsignedWord getMaxSurvivorSize();
+
+        @RawField
+        void setMaxSurvivorSize(UnsignedWord value);
+
+        @RawField
+        UnsignedWord getInitialYoungSize();
+
+        @RawField
+        void setInitialYoungSize(UnsignedWord value);
+
+        @RawField
+        UnsignedWord getYoungSize();
+
+        @RawField
+        void setYoungSize(UnsignedWord value);
+
+        @RawField
+        UnsignedWord getMaxYoungSize();
+
+        @RawField
+        void setMaxYoungSize(UnsignedWord value);
+
+        @RawField
+        UnsignedWord getInitialOldSize();
+
+        @RawField
+        void setInitialOldSize(UnsignedWord value);
+
+        @RawField
+        UnsignedWord getOldSize();
+
+        @RawField
+        void setOldSize(UnsignedWord value);
+
+        @RawField
+        UnsignedWord getMaxOldSize();
+
+        @RawField
+        void setMaxOldSize(UnsignedWord value);
+
+        @RawField
+        UnsignedWord getPromoSize();
+
+        @RawField
+        void setPromoSize(UnsignedWord value);
+
+        @RawField
+        UnsignedWord getMinHeapSize();
+
+        @RawField
+        void setMinHeapSize(UnsignedWord value);
+
+        @RawField
+        UnsignedWord getInitialHeapSize();
+
+        @RawField
+        void setInitialHeapSize(UnsignedWord value);
+
+        @RawField
+        UnsignedWord getHeapSize();
+
+        @RawField
+        void setHeapSize(UnsignedWord value);
+
+        @RawField
+        UnsignedWord getMaxHeapSize();
+
+        @RawField
+        void setMaxHeapSize(UnsignedWord value);
+
+        @RawField
+        RawSizeParameters getNext();
+
+        @RawField
+        void setNext(RawSizeParameters value);
+    }
+
+    /**
+     * The methods in this class may only be used on {@link RawSizeParameters} that are allocated on
+     * the stack and therefore not yet visible to other threads. Please keep the methods in this
+     * class to a minimum.
+     */
+    private static final class RawSizeParametersAccess {
+        static void initialize(RawSizeParameters valuesOnStack,
+                        UnsignedWord initialEdenSize, UnsignedWord edenSize, UnsignedWord maxEdenSize,
+                        UnsignedWord initialSurvivorSize, UnsignedWord survivorSize, UnsignedWord maxSurvivorSize,
+                        UnsignedWord initialOldSize, UnsignedWord oldSize, UnsignedWord maxOldSize,
+                        UnsignedWord promoSize,
+                        UnsignedWord initialYoungSize, UnsignedWord youngSize, UnsignedWord maxYoungSize,
+                        UnsignedWord minHeapSize, UnsignedWord initialHeapSize, UnsignedWord heapSize, UnsignedWord maxHeapSize) {
+            assert isAligned(maxHeapSize) && isAligned(maxYoungSize) && isAligned(initialHeapSize) && isAligned(initialEdenSize) && isAligned(initialSurvivorSize);
+
+            assert initialEdenSize.belowOrEqual(initialYoungSize);
+            assert edenSize.belowOrEqual(youngSize);
+            assert maxEdenSize.belowOrEqual(maxYoungSize);
+
+            assert initialSurvivorSize.belowOrEqual(initialYoungSize);
+            assert survivorSize.belowOrEqual(youngSize);
+            assert maxSurvivorSize.belowOrEqual(maxYoungSize);
+
+            assert initialOldSize.belowOrEqual(initialHeapSize);
+            assert oldSize.belowOrEqual(heapSize);
+            assert maxOldSize.belowOrEqual(maxHeapSize);
+
+            assert initialYoungSize.belowOrEqual(initialHeapSize);
+            assert youngSize.belowOrEqual(heapSize);
+            assert maxYoungSize.belowOrEqual(maxHeapSize);
+
+            assert minHeapSize.belowOrEqual(initialHeapSize);
+            assert initialHeapSize.belowOrEqual(maxHeapSize);
+            assert heapSize.belowOrEqual(maxHeapSize);
+            assert maxHeapSize.belowOrEqual(ReferenceAccess.singleton().getMaxAddressSpaceSize());
+
+            valuesOnStack.setInitialEdenSize(initialEdenSize);
+            valuesOnStack.setEdenSize(edenSize);
+            valuesOnStack.setMaxEdenSize(maxEdenSize);
+
+            valuesOnStack.setInitialSurvivorSize(initialSurvivorSize);
+            valuesOnStack.setSurvivorSize(survivorSize);
+            valuesOnStack.setMaxSurvivorSize(maxSurvivorSize);
+
+            valuesOnStack.setInitialYoungSize(initialYoungSize);
+            valuesOnStack.setYoungSize(youngSize);
+            valuesOnStack.setMaxYoungSize(maxYoungSize);
+
+            valuesOnStack.setInitialOldSize(initialOldSize);
+            valuesOnStack.setOldSize(oldSize);
+            valuesOnStack.setMaxOldSize(maxOldSize);
+
+            valuesOnStack.setPromoSize(promoSize);
+
+            valuesOnStack.setMinHeapSize(minHeapSize);
+            valuesOnStack.setInitialHeapSize(initialHeapSize);
+            valuesOnStack.setHeapSize(heapSize);
+            valuesOnStack.setMaxHeapSize(maxHeapSize);
+
+            valuesOnStack.setNext(Word.nullPointer());
         }
     }
 }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AdaptiveCollectionPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AdaptiveCollectionPolicy.java
@@ -30,6 +30,7 @@ import org.graalvm.word.UnsignedWord;
 
 import com.oracle.svm.core.Isolates;
 import com.oracle.svm.core.heap.GCCause;
+import com.oracle.svm.core.thread.VMOperation;
 import com.oracle.svm.core.util.BasedOnJDKFile;
 import com.oracle.svm.core.util.TimeUtils;
 import com.oracle.svm.core.util.Timer;
@@ -261,45 +262,45 @@ class AdaptiveCollectionPolicy extends AbstractCollectionPolicy {
     }
 
     protected void computeEdenSpaceSize(@SuppressWarnings("unused") boolean completeCollection, @SuppressWarnings("unused") GCCause cause) {
-        UnsignedWord curEdenSize = sizes.getEdenSize();
-        UnsignedWord curPromoSize = sizes.getPromoSize();
+        UnsignedWord curEden = sizes.getEdenSize();
+        UnsignedWord curPromo = sizes.getPromoSize();
 
         boolean expansionReducesCost = true; // general assumption
         if (shouldUseEstimator(youngGenChangeForMinorThroughput, minorGcCost())) {
-            expansionReducesCost = expansionSignificantlyReducesTotalCost(minorCostEstimator, curEdenSize, majorGcCost(), curPromoSize);
+            expansionReducesCost = expansionSignificantlyReducesTotalCost(minorCostEstimator, curEden, majorGcCost(), curPromo);
             /*
              * Note that if the estimator thinks expanding does not lead to significant improvement,
              * shrink so to not get stuck in a supposed optimum and to keep collecting data points.
              */
         }
 
-        UnsignedWord desiredEdenSize = curEdenSize;
+        UnsignedWord desiredEdenSize = curEden;
         if (expansionReducesCost && adjustedMutatorCost() < THROUGHPUT_GOAL && gcCost() > 0) {
             // from adjust_eden_for_throughput():
-            UnsignedWord edenHeapDelta = edenIncrementWithSupplementAlignedUp(curEdenSize);
+            UnsignedWord edenHeapDelta = edenIncrementWithSupplementAlignedUp(curEden);
             double scaleByRatio = minorGcCost() / gcCost();
             assert scaleByRatio >= 0 && scaleByRatio <= 1;
             UnsignedWord scaledEdenHeapDelta = UnsignedUtils.fromDouble(scaleByRatio * UnsignedUtils.toDouble(edenHeapDelta));
 
             desiredEdenSize = alignUp(desiredEdenSize.add(scaledEdenHeapDelta));
-            desiredEdenSize = UnsignedUtils.max(desiredEdenSize, curEdenSize);
+            desiredEdenSize = UnsignedUtils.max(desiredEdenSize, curEden);
             youngGenChangeForMinorThroughput++;
         }
         if (!expansionReducesCost || (USE_ADAPTIVE_SIZE_POLICY_FOOTPRINT_GOAL && youngGenPolicyIsReady && adjustedMutatorCost() >= THROUGHPUT_GOAL)) {
-            UnsignedWord desiredSum = curEdenSize.add(curPromoSize);
-            desiredEdenSize = adjustEdenForFootprint(curEdenSize, desiredSum);
+            UnsignedWord desiredSum = curEden.add(curPromo);
+            desiredEdenSize = adjustEdenForFootprint(curEden, desiredSum);
         }
         assert isAligned(desiredEdenSize);
         desiredEdenSize = minSpaceSize(desiredEdenSize);
 
-        UnsignedWord edenLimit = getMaximumEdenSize();
+        UnsignedWord edenLimit = computeEdenLimit();
         if (desiredEdenSize.aboveThan(edenLimit)) {
             /*
              * If the policy says to get a larger eden but is hitting the limit, don't decrease
              * eden. This can lead to a general drifting down of the eden size. Let the tenuring
              * calculation push more into the old gen.
              */
-            desiredEdenSize = UnsignedUtils.max(edenLimit, curEdenSize);
+            desiredEdenSize = UnsignedUtils.max(edenLimit, curEden);
         }
         sizes.setEdenSize(desiredEdenSize);
     }
@@ -472,40 +473,40 @@ class AdaptiveCollectionPolicy extends AbstractCollectionPolicy {
     }
 
     private void computeOldGenSpaceSize(UnsignedWord oldLive) { // compute_old_gen_free_space
-        UnsignedWord curEdenSize = sizes.getEdenSize();
-        UnsignedWord curMaxOldSize = sizes.getMaxOldSize();
-        UnsignedWord curPromoSize = sizes.getPromoSize();
+        UnsignedWord curEden = sizes.getEdenSize();
+        UnsignedWord curPromo = sizes.getPromoSize();
+        UnsignedWord curMaxOld = sizes.getMaxOldSize();
 
         avgOldLive.sample(oldLive);
 
         // NOTE: if maxOldSize shrunk and difference is negative, unsigned conversion results in 0
-        UnsignedWord promoLimit = UnsignedUtils.fromDouble(UnsignedUtils.toDouble(curMaxOldSize) - avgOldLive.getAverage());
-        promoLimit = alignDown(UnsignedUtils.max(curPromoSize, promoLimit));
+        UnsignedWord promoLimit = UnsignedUtils.fromDouble(UnsignedUtils.toDouble(curMaxOld) - avgOldLive.getAverage());
+        promoLimit = alignDown(UnsignedUtils.max(curPromo, promoLimit));
 
         boolean expansionReducesCost = true; // general assumption
         if (shouldUseEstimator(oldGenChangeForMajorThroughput, majorGcCost())) {
-            expansionReducesCost = expansionSignificantlyReducesTotalCost(majorCostEstimator, curPromoSize, minorGcCost(), curEdenSize);
+            expansionReducesCost = expansionSignificantlyReducesTotalCost(majorCostEstimator, curPromo, minorGcCost(), curEden);
             /*
              * Note that if the estimator thinks expanding does not lead to significant improvement,
              * shrink so to not get stuck in a supposed optimum and to keep collecting data points.
              */
         }
 
-        UnsignedWord desiredPromoSize = curPromoSize;
+        UnsignedWord desiredPromoSize = curPromo;
         if (expansionReducesCost && adjustedMutatorCost() < THROUGHPUT_GOAL && gcCost() > 0) {
             // from adjust_promo_for_throughput():
-            UnsignedWord promoHeapDelta = promoIncrementWithSupplementAlignedUp(curPromoSize);
+            UnsignedWord promoHeapDelta = promoIncrementWithSupplementAlignedUp(curPromo);
             double scaleByRatio = majorGcCost() / gcCost();
             assert scaleByRatio >= 0 && scaleByRatio <= 1;
             UnsignedWord scaledPromoHeapDelta = UnsignedUtils.fromDouble(scaleByRatio * UnsignedUtils.toDouble(promoHeapDelta));
 
-            desiredPromoSize = alignUp(curPromoSize.add(scaledPromoHeapDelta));
-            desiredPromoSize = UnsignedUtils.max(desiredPromoSize, curPromoSize);
+            desiredPromoSize = alignUp(curPromo.add(scaledPromoHeapDelta));
+            desiredPromoSize = UnsignedUtils.max(desiredPromoSize, curPromo);
             oldGenChangeForMajorThroughput++;
         }
         if (!expansionReducesCost || (USE_ADAPTIVE_SIZE_POLICY_FOOTPRINT_GOAL && youngGenPolicyIsReady && adjustedMutatorCost() >= THROUGHPUT_GOAL)) {
-            UnsignedWord desiredSum = curEdenSize.add(curPromoSize);
-            desiredPromoSize = adjustPromoForFootprint(curPromoSize, desiredSum);
+            UnsignedWord desiredSum = curEden.add(curPromo);
+            desiredPromoSize = adjustPromoForFootprint(curPromo, desiredSum);
         }
         assert isAligned(desiredPromoSize);
         desiredPromoSize = minSpaceSize(desiredPromoSize);
@@ -516,7 +517,7 @@ class AdaptiveCollectionPolicy extends AbstractCollectionPolicy {
         // from PSOldGen::resize
         UnsignedWord desiredFreeSpace = calculatedOldFreeSizeInBytes();
         UnsignedWord desiredOldSize = alignUp(oldLive.add(desiredFreeSpace));
-        sizes.setOldSize(UnsignedUtils.clamp(desiredOldSize, minSpaceSize(), curMaxOldSize));
+        sizes.setOldSize(UnsignedUtils.clamp(desiredOldSize, minSpaceSize(), curMaxOld));
     }
 
     UnsignedWord calculatedOldFreeSizeInBytes() {
@@ -564,6 +565,11 @@ class AdaptiveCollectionPolicy extends AbstractCollectionPolicy {
 
     protected boolean shouldUpdateStats(GCCause cause) { // should_update_{eden,promo}_stats
         return cause == GenScavengeGCCause.OnAllocation || USE_ADAPTIVE_SIZE_POLICY_WITH_SYSTEM_GC;
+    }
+
+    protected UnsignedWord computeEdenLimit() {
+        assert VMOperation.isGCInProgress() : "result wouldn't be consistent otherwise";
+        return alignDown(sizes.getMaxYoungSize().subtract(sizes.getSurvivorSize().multiply(2)));
     }
 
     private void updateCollectionEndAverages(AdaptiveWeightedAverage costAverage, AdaptivePaddedAverage pauseAverage, ReciprocalLeastSquareFit costEstimator,

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AdaptiveCollectionPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AdaptiveCollectionPolicy.java
@@ -28,7 +28,6 @@ import static com.oracle.svm.core.genscavenge.CollectionPolicy.shouldCollectYoun
 
 import org.graalvm.word.UnsignedWord;
 
-import com.oracle.svm.core.Isolates;
 import com.oracle.svm.core.heap.GCCause;
 import com.oracle.svm.core.thread.VMOperation;
 import com.oracle.svm.core.util.BasedOnJDKFile;

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AdaptiveCollectionPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AdaptiveCollectionPolicy.java
@@ -28,7 +28,7 @@ import static com.oracle.svm.core.genscavenge.CollectionPolicy.shouldCollectYoun
 
 import org.graalvm.word.UnsignedWord;
 
-import com.oracle.svm.core.Uninterruptible;
+import com.oracle.svm.core.Isolates;
 import com.oracle.svm.core.heap.GCCause;
 import com.oracle.svm.core.util.BasedOnJDKFile;
 import com.oracle.svm.core.util.TimeUtils;
@@ -107,7 +107,8 @@ class AdaptiveCollectionPolicy extends AbstractCollectionPolicy {
     private static final int ADAPTIVE_SIZE_POLICY_INITIALIZING_STEPS = ADAPTIVE_SIZE_POLICY_READY_THRESHOLD;
     /**
      * The minimum estimated decrease in {@link #gcCost()} in percent to decide in favor of
-     * expanding a space by 1% of the combined size of {@link #edenSize} and {@link #promoSize}.
+     * expanding a space by 1% of the combined size of {@link SizeParameters#getEdenSize} and
+     * {@link SizeParameters#getPromoSize}.
      */
     private static final double ADAPTIVE_SIZE_ESTIMATOR_MIN_TOTAL_SIZE_COST_TRADEOFF = 0.5;
     /** The effective number of most recent data points used by estimator (exponential decay). */
@@ -208,7 +209,7 @@ class AdaptiveCollectionPolicy extends AbstractCollectionPolicy {
          */
         UnsignedWord averagePromoted = UnsignedUtils.fromDouble(avgPromoted.getPaddedAverage());
         UnsignedWord promotionEstimate = UnsignedUtils.min(averagePromoted, youngUsed);
-        UnsignedWord oldFree = oldSize.subtract(oldUsed);
+        UnsignedWord oldFree = sizes.getOldSize().subtract(oldUsed);
         return promotionEstimate.aboveThan(oldFree);
     }
 
@@ -250,7 +251,7 @@ class AdaptiveCollectionPolicy extends AbstractCollectionPolicy {
             targetSize = survivorLimit;
             decrTenuringThreshold = true;
         }
-        survivorSize = targetSize;
+        sizes.setSurvivorSize(targetSize);
 
         if (decrTenuringThreshold) {
             tenuringThreshold = Math.max(tenuringThreshold - 1, 1);
@@ -260,30 +261,33 @@ class AdaptiveCollectionPolicy extends AbstractCollectionPolicy {
     }
 
     protected void computeEdenSpaceSize(@SuppressWarnings("unused") boolean completeCollection, @SuppressWarnings("unused") GCCause cause) {
+        UnsignedWord curEdenSize = sizes.getEdenSize();
+        UnsignedWord curPromoSize = sizes.getPromoSize();
+
         boolean expansionReducesCost = true; // general assumption
         if (shouldUseEstimator(youngGenChangeForMinorThroughput, minorGcCost())) {
-            expansionReducesCost = expansionSignificantlyReducesTotalCost(minorCostEstimator, edenSize, majorGcCost(), promoSize);
+            expansionReducesCost = expansionSignificantlyReducesTotalCost(minorCostEstimator, curEdenSize, majorGcCost(), curPromoSize);
             /*
              * Note that if the estimator thinks expanding does not lead to significant improvement,
              * shrink so to not get stuck in a supposed optimum and to keep collecting data points.
              */
         }
 
-        UnsignedWord desiredEdenSize = edenSize;
+        UnsignedWord desiredEdenSize = curEdenSize;
         if (expansionReducesCost && adjustedMutatorCost() < THROUGHPUT_GOAL && gcCost() > 0) {
             // from adjust_eden_for_throughput():
-            UnsignedWord edenHeapDelta = edenIncrementWithSupplementAlignedUp(edenSize);
+            UnsignedWord edenHeapDelta = edenIncrementWithSupplementAlignedUp(curEdenSize);
             double scaleByRatio = minorGcCost() / gcCost();
             assert scaleByRatio >= 0 && scaleByRatio <= 1;
             UnsignedWord scaledEdenHeapDelta = UnsignedUtils.fromDouble(scaleByRatio * UnsignedUtils.toDouble(edenHeapDelta));
 
             desiredEdenSize = alignUp(desiredEdenSize.add(scaledEdenHeapDelta));
-            desiredEdenSize = UnsignedUtils.max(desiredEdenSize, edenSize);
+            desiredEdenSize = UnsignedUtils.max(desiredEdenSize, curEdenSize);
             youngGenChangeForMinorThroughput++;
         }
         if (!expansionReducesCost || (USE_ADAPTIVE_SIZE_POLICY_FOOTPRINT_GOAL && youngGenPolicyIsReady && adjustedMutatorCost() >= THROUGHPUT_GOAL)) {
-            UnsignedWord desiredSum = edenSize.add(promoSize);
-            desiredEdenSize = adjustEdenForFootprint(edenSize, desiredSum);
+            UnsignedWord desiredSum = curEdenSize.add(curPromoSize);
+            desiredEdenSize = adjustEdenForFootprint(curEdenSize, desiredSum);
         }
         assert isAligned(desiredEdenSize);
         desiredEdenSize = minSpaceSize(desiredEdenSize);
@@ -295,9 +299,9 @@ class AdaptiveCollectionPolicy extends AbstractCollectionPolicy {
              * eden. This can lead to a general drifting down of the eden size. Let the tenuring
              * calculation push more into the old gen.
              */
-            desiredEdenSize = UnsignedUtils.max(edenLimit, edenSize);
+            desiredEdenSize = UnsignedUtils.max(edenLimit, curEdenSize);
         }
-        edenSize = desiredEdenSize;
+        sizes.setEdenSize(desiredEdenSize);
     }
 
     private static boolean shouldUseEstimator(long genChangeForThroughput, double cost) {
@@ -420,13 +424,13 @@ class AdaptiveCollectionPolicy extends AbstractCollectionPolicy {
 
         if (completeCollection) {
             updateCollectionEndAverages(avgMajorGcCost, avgMajorPause, majorCostEstimator, avgMajorIntervalSeconds,
-                            cause, latestMajorMutatorIntervalNanos, timer.totalNanos(), promoSize);
+                            cause, latestMajorMutatorIntervalNanos, timer.lastIntervalNanos(), sizes.getPromoSize());
             majorCount++;
             minorCountSinceMajorCollection = 0;
 
         } else {
             updateCollectionEndAverages(avgMinorGcCost, avgMinorPause, minorCostEstimator, null,
-                            cause, latestMinorMutatorIntervalNanos, timer.totalNanos(), edenSize);
+                            cause, latestMinorMutatorIntervalNanos, timer.lastIntervalNanos(), sizes.getEdenSize());
             minorCount++;
             minorCountSinceMajorCollection++;
 
@@ -440,7 +444,7 @@ class AdaptiveCollectionPolicy extends AbstractCollectionPolicy {
 
         GCAccounting accounting = GCImpl.getAccounting();
         UnsignedWord oldLive = accounting.getOldGenerationAfterChunkBytes();
-        oldSizeExceededInPreviousCollection = oldLive.aboveThan(oldSize);
+        oldSizeExceededInPreviousCollection = oldLive.aboveThan(sizes.getOldSize());
 
         if (!completeCollection) {
             /*
@@ -456,7 +460,7 @@ class AdaptiveCollectionPolicy extends AbstractCollectionPolicy {
             UnsignedWord tenuredChunkBytes = accounting.getLastIncrementalCollectionPromotedChunkBytes();
             updateAverages(survivorOverflow, survivedChunkBytes, tenuredChunkBytes);
 
-            computeSurvivorSpaceSizeAndThreshold(survivorOverflow, sizes.maxSurvivorSize());
+            computeSurvivorSpaceSizeAndThreshold(survivorOverflow, sizes.getMaxSurvivorSize());
         }
         if (shouldUpdateStats(cause)) {
             computeEdenSpaceSize(completeCollection, cause);
@@ -468,51 +472,55 @@ class AdaptiveCollectionPolicy extends AbstractCollectionPolicy {
     }
 
     private void computeOldGenSpaceSize(UnsignedWord oldLive) { // compute_old_gen_free_space
+        UnsignedWord curEdenSize = sizes.getEdenSize();
+        UnsignedWord curMaxOldSize = sizes.getMaxOldSize();
+        UnsignedWord curPromoSize = sizes.getPromoSize();
+
         avgOldLive.sample(oldLive);
 
         // NOTE: if maxOldSize shrunk and difference is negative, unsigned conversion results in 0
-        UnsignedWord promoLimit = UnsignedUtils.fromDouble(UnsignedUtils.toDouble(sizes.maxOldSize()) - avgOldLive.getAverage());
-        promoLimit = alignDown(UnsignedUtils.max(promoSize, promoLimit));
+        UnsignedWord promoLimit = UnsignedUtils.fromDouble(UnsignedUtils.toDouble(curMaxOldSize) - avgOldLive.getAverage());
+        promoLimit = alignDown(UnsignedUtils.max(curPromoSize, promoLimit));
 
         boolean expansionReducesCost = true; // general assumption
         if (shouldUseEstimator(oldGenChangeForMajorThroughput, majorGcCost())) {
-            expansionReducesCost = expansionSignificantlyReducesTotalCost(majorCostEstimator, promoSize, minorGcCost(), edenSize);
+            expansionReducesCost = expansionSignificantlyReducesTotalCost(majorCostEstimator, curPromoSize, minorGcCost(), curEdenSize);
             /*
              * Note that if the estimator thinks expanding does not lead to significant improvement,
              * shrink so to not get stuck in a supposed optimum and to keep collecting data points.
              */
         }
 
-        UnsignedWord desiredPromoSize = promoSize;
+        UnsignedWord desiredPromoSize = curPromoSize;
         if (expansionReducesCost && adjustedMutatorCost() < THROUGHPUT_GOAL && gcCost() > 0) {
             // from adjust_promo_for_throughput():
-            UnsignedWord promoHeapDelta = promoIncrementWithSupplementAlignedUp(promoSize);
+            UnsignedWord promoHeapDelta = promoIncrementWithSupplementAlignedUp(curPromoSize);
             double scaleByRatio = majorGcCost() / gcCost();
             assert scaleByRatio >= 0 && scaleByRatio <= 1;
             UnsignedWord scaledPromoHeapDelta = UnsignedUtils.fromDouble(scaleByRatio * UnsignedUtils.toDouble(promoHeapDelta));
 
-            desiredPromoSize = alignUp(promoSize.add(scaledPromoHeapDelta));
-            desiredPromoSize = UnsignedUtils.max(desiredPromoSize, promoSize);
+            desiredPromoSize = alignUp(curPromoSize.add(scaledPromoHeapDelta));
+            desiredPromoSize = UnsignedUtils.max(desiredPromoSize, curPromoSize);
             oldGenChangeForMajorThroughput++;
         }
         if (!expansionReducesCost || (USE_ADAPTIVE_SIZE_POLICY_FOOTPRINT_GOAL && youngGenPolicyIsReady && adjustedMutatorCost() >= THROUGHPUT_GOAL)) {
-            UnsignedWord desiredSum = edenSize.add(promoSize);
-            desiredPromoSize = adjustPromoForFootprint(promoSize, desiredSum);
+            UnsignedWord desiredSum = curEdenSize.add(curPromoSize);
+            desiredPromoSize = adjustPromoForFootprint(curPromoSize, desiredSum);
         }
         assert isAligned(desiredPromoSize);
         desiredPromoSize = minSpaceSize(desiredPromoSize);
 
         desiredPromoSize = UnsignedUtils.min(desiredPromoSize, promoLimit);
-        promoSize = desiredPromoSize;
+        sizes.setPromoSize(desiredPromoSize);
 
         // from PSOldGen::resize
         UnsignedWord desiredFreeSpace = calculatedOldFreeSizeInBytes();
         UnsignedWord desiredOldSize = alignUp(oldLive.add(desiredFreeSpace));
-        oldSize = UnsignedUtils.clamp(desiredOldSize, minSpaceSize(), sizes.maxOldSize());
+        sizes.setOldSize(UnsignedUtils.clamp(desiredOldSize, minSpaceSize(), curMaxOldSize));
     }
 
     UnsignedWord calculatedOldFreeSizeInBytes() {
-        return UnsignedUtils.fromDouble(UnsignedUtils.toDouble(promoSize) + avgPromoted.getPaddedAverage());
+        return UnsignedUtils.fromDouble(UnsignedUtils.toDouble(sizes.getPromoSize()) + avgPromoted.getPaddedAverage());
     }
 
     private static UnsignedWord adjustPromoForFootprint(UnsignedWord curPromo, UnsignedWord desiredSum) {
@@ -575,11 +583,5 @@ class AdaptiveCollectionPolicy extends AbstractCollectionPolicy {
             }
             costEstimator.sample(UnsignedUtils.toDouble(sizeBytes), cost);
         }
-    }
-
-    @Override
-    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    protected long gcCount() {
-        return minorCount + majorCount;
     }
 }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CollectionPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CollectionPolicy.java
@@ -226,4 +226,8 @@ public interface CollectionPolicy {
     default void onMaximumHeapSizeExceeded() {
         throw OutOfMemoryUtil.heapSizeExceeded();
     }
+
+    @Uninterruptible(reason = "Tear-down in progress.")
+    default void tearDown() {
+    }
 }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/DynamicCollectionPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/DynamicCollectionPolicy.java
@@ -50,20 +50,21 @@ class DynamicCollectionPolicy extends AdaptiveCollectionPolicy {
 
     @Override
     public boolean isOutOfMemory(UnsignedWord usedBytes) {
-        if (ImageSingletons.contains(DynamicHeapSizeManager.class)) {
-            return ImageSingletons.lookup(DynamicHeapSizeManager.class).outOfMemory(usedBytes);
+        boolean outOfMemory = super.isOutOfMemory(usedBytes);
+        if (ImageSingletons.contains(DynamicHeapSizeManager.class) && outOfMemory) {
+            outOfMemory = ImageSingletons.lookup(DynamicHeapSizeManager.class).outOfMemory(usedBytes);
+            if (!outOfMemory) {
+                /* No longer out-of-memory - update the heap size parameters to reflect that. */
+                GCImpl.getPolicy().updateSizeParameters();
+            }
         }
-
-        return super.isOutOfMemory(usedBytes);
+        return outOfMemory;
     }
 
     @Override
     public void onMaximumHeapSizeExceeded() {
         if (isOutOfMemory(HeapImpl.getAccounting().getUsedBytes())) {
             super.onMaximumHeapSizeExceeded();
-        } else {
-            /* No longer out-of-memory - update the heap size parameters to reflect that. */
-            GCImpl.getPolicy().updateSizeParameters();
         }
     }
 }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/DynamicCollectionPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/DynamicCollectionPolicy.java
@@ -27,7 +27,6 @@ package com.oracle.svm.core.genscavenge;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.word.UnsignedWord;
 
-import com.oracle.svm.core.SubstrateGCOptions;
 import com.oracle.svm.core.heap.DynamicHeapSizeManager;
 
 /**
@@ -46,8 +45,7 @@ class DynamicCollectionPolicy extends AdaptiveCollectionPolicy {
         if (ImageSingletons.contains(DynamicHeapSizeManager.class)) {
             return ImageSingletons.lookup(DynamicHeapSizeManager.class).maxHeapSize().rawValue();
         }
-
-        return SubstrateGCOptions.MaxHeapSize.getValue();
+        return super.getMaximumHeapSizeOptionValue();
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
@@ -412,7 +412,7 @@ public final class GCImpl implements GC {
     }
 
     private static void resizeAllTlabs() {
-        if (SubstrateGCOptions.TlabOptions.ResizeTLAB.getValue()) {
+        if (SubstrateGCOptions.ResizeTLAB.getValue()) {
             for (IsolateThread thread = VMThreads.firstThread(); thread.isNonNull(); thread = VMThreads.nextThread(thread)) {
                 TlabSupport.resize(thread);
             }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
@@ -142,6 +142,11 @@ public final class GCImpl implements GC {
         RuntimeSupport.getRuntimeSupport().addShutdownHook(isFirstIsolate -> printGCSummary());
     }
 
+    @Uninterruptible(reason = "Tear-down in progress.")
+    public void tearDown() {
+        policy.tearDown();
+    }
+
     @Override
     public String getName() {
         if (SubstrateOptions.useEpsilonGC()) {

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapImpl.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapImpl.java
@@ -77,6 +77,7 @@ import com.oracle.svm.core.locks.VMMutex;
 import com.oracle.svm.core.log.Log;
 import com.oracle.svm.core.nodes.CFunctionEpilogueNode;
 import com.oracle.svm.core.nodes.CFunctionPrologueNode;
+import com.oracle.svm.core.option.NotifyGCRuntimeOptionKey;
 import com.oracle.svm.core.option.RuntimeOptionKey;
 import com.oracle.svm.core.os.ImageHeapProvider;
 import com.oracle.svm.core.snippets.KnownIntrinsics;
@@ -706,10 +707,18 @@ public final class HeapImpl extends Heap {
     }
 
     @Override
-    public void optionValueChanged(RuntimeOptionKey<?> key) {
-        if (!SubstrateUtil.HOSTED) {
-            GCImpl.getPolicy().updateSizeParameters();
+    public void optionValueChanged(NotifyGCRuntimeOptionKey<?> key) {
+        if (SubstrateUtil.HOSTED || isIrrelevantForGCPolicy(key)) {
+            return;
         }
+
+        GCImpl.getPolicy().updateSizeParameters();
+    }
+
+    private static boolean isIrrelevantForGCPolicy(RuntimeOptionKey<?> key) {
+        return key == SubstrateGCOptions.DisableExplicitGC ||
+                        key == SubstrateGCOptions.PrintGC ||
+                        key == SubstrateGCOptions.VerboseGC;
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapImpl.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapImpl.java
@@ -218,7 +218,12 @@ public final class HeapImpl extends Heap {
     public boolean tearDown() {
         youngGeneration.tearDown();
         oldGeneration.tearDown();
-        getChunkProvider().tearDown();
+        chunkProvider.tearDown();
+        gcImpl.tearDown();
+
+        if (Metaspace.isSupported()) {
+            MetaspaceImpl.singleton().tearDown();
+        }
         return true;
     }
 
@@ -1093,7 +1098,7 @@ final class Target_java_lang_Runtime {
 
     @Substitute
     private long maxMemory() {
-        GCImpl.getPolicy().updateSizeParameters();
+        GCImpl.getPolicy().ensureSizeParametersInitialized();
         return GCImpl.getPolicy().getMaximumHeapSize().rawValue();
     }
 

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapImpl.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapImpl.java
@@ -720,6 +720,7 @@ public final class HeapImpl extends Heap {
         GCImpl.getPolicy().updateSizeParameters();
     }
 
+    /** For the GC policy, mainly heap-size-related GC options are relevant. */
     private static boolean isIrrelevantForGCPolicy(RuntimeOptionKey<?> key) {
         return key == SubstrateGCOptions.DisableExplicitGC ||
                         key == SubstrateGCOptions.PrintGC ||

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapImpl.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapImpl.java
@@ -221,9 +221,6 @@ public final class HeapImpl extends Heap {
         chunkProvider.tearDown();
         gcImpl.tearDown();
 
-        if (Metaspace.isSupported()) {
-            MetaspaceImpl.singleton().tearDown();
-        }
         return true;
     }
 

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapParameters.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapParameters.java
@@ -110,6 +110,7 @@ public final class HeapParameters {
         return Word.unsigned(SerialGCOptions.MaxHeapFree.getValue());
     }
 
+    @Fold
     public static int getHeapChunkHeaderPadding() {
         return SerialAndEpsilonGCOptions.HeapChunkHeaderPadding.getValue();
     }
@@ -146,15 +147,12 @@ public final class HeapParameters {
         return Word.unsigned(SerialAndEpsilonGCOptions.LargeArrayThreshold.getValue());
     }
 
-    /*
-     * Zapping
-     */
-
-    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    @Fold
     public static boolean getZapProducedHeapChunks() {
         return SerialAndEpsilonGCOptions.ZapChunks.getValue() || SerialAndEpsilonGCOptions.ZapProducedHeapChunks.getValue();
     }
 
+    @Fold
     public static boolean getZapConsumedHeapChunks() {
         return SerialAndEpsilonGCOptions.ZapChunks.getValue() || SerialAndEpsilonGCOptions.ZapConsumedHeapChunks.getValue();
     }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/LibGraalCollectionPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/LibGraalCollectionPolicy.java
@@ -142,19 +142,19 @@ class LibGraalCollectionPolicy extends AdaptiveCollectionPolicy {
     protected void computeEdenSpaceSize(boolean completeCollection, GCCause cause) {
         if (cause == GCCause.HintedGC) {
             if (completeCollection && lastGCCause == GCCause.HintedGC) {
-                UnsignedWord curEdenSize = sizes.getEdenSize();
-                UnsignedWord newEdenSize = UnsignedUtils.max(sizes.getInitialEdenSize(), alignUp(curEdenSize.unsignedDivide(2)));
-                if (curEdenSize.aboveThan(newEdenSize)) {
-                    sizes.setEdenSize(newEdenSize);
+                UnsignedWord curEden = sizes.getEdenSize();
+                UnsignedWord newEden = UnsignedUtils.max(sizes.getInitialEdenSize(), alignUp(curEden.unsignedDivide(2)));
+                if (curEden.aboveThan(newEden)) {
+                    sizes.setEdenSize(newEden);
                 }
             }
         } else {
             UnsignedWord sizeAfter = GCImpl.getChunkBytes();
             if (sizeBefore.notEqual(0) && sizeBefore.belowThan(sizeAfter.multiply(2))) {
-                UnsignedWord curEdenSize = sizes.getEdenSize();
-                UnsignedWord newEdenSize = UnsignedUtils.min(getMaximumEdenSize(), alignUp(curEdenSize.multiply(2)));
-                if (curEdenSize.belowThan(newEdenSize)) {
-                    sizes.setEdenSize(newEdenSize);
+                UnsignedWord curEden = sizes.getEdenSize();
+                UnsignedWord newEden = UnsignedUtils.min(computeEdenLimit(), alignUp(curEden.multiply(2)));
+                if (curEden.belowThan(newEden)) {
+                    sizes.setEdenSize(newEden);
                 }
             } else {
                 super.computeEdenSpaceSize(completeCollection, cause);

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ProportionateSpacesPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ProportionateSpacesPolicy.java
@@ -26,12 +26,12 @@ package com.oracle.svm.core.genscavenge;
 
 import static com.oracle.svm.core.genscavenge.CollectionPolicy.shouldCollectYoungGenSeparately;
 
-import jdk.graal.compiler.word.Word;
 import org.graalvm.word.UnsignedWord;
 
-import com.oracle.svm.core.Uninterruptible;
 import com.oracle.svm.core.heap.GCCause;
 import com.oracle.svm.core.util.UnsignedUtils;
+
+import jdk.graal.compiler.word.Word;
 
 /** A port of HotSpot's SerialGC size policy. */
 final class ProportionateSpacesPolicy extends AbstractCollectionPolicy {
@@ -50,7 +50,6 @@ final class ProportionateSpacesPolicy extends AbstractCollectionPolicy {
     static final int MAX_TENURING_THRESHOLD = 15;
     static final int TARGET_SURVIVOR_RATIO = 50;
 
-    private int totalCollections;
     private boolean oldSizeExceededInPreviousCollection;
     private int shrinkFactor;
 
@@ -91,19 +90,17 @@ final class ProportionateSpacesPolicy extends AbstractCollectionPolicy {
     @Override
     public void onCollectionEnd(boolean completeCollection, GCCause cause) {
         UnsignedWord oldLive = GCImpl.getAccounting().getOldGenerationAfterChunkBytes();
-        oldSizeExceededInPreviousCollection = oldLive.aboveThan(oldSize);
+        oldSizeExceededInPreviousCollection = oldLive.aboveThan(sizes.getOldSize());
 
         boolean resizeOldOnlyForPromotions = !completeCollection;
         computeNewOldGenSize(resizeOldOnlyForPromotions);
         computeNewYoungGenSize();
         adjustDesiredTenuringThreshold();
-
-        totalCollections++;
     }
 
     private void adjustDesiredTenuringThreshold() { // DefNewGeneration::adjust_desired_tenuring_threshold
         // Set the desired survivor size to half the real survivor space
-        UnsignedWord desiredSurvivorSize = UnsignedUtils.fromDouble(UnsignedUtils.toDouble(survivorSize) * TARGET_SURVIVOR_RATIO / 100);
+        UnsignedWord desiredSurvivorSize = UnsignedUtils.fromDouble(UnsignedUtils.toDouble(sizes.getSurvivorSize()) * TARGET_SURVIVOR_RATIO / 100);
 
         // AgeTable::compute_tenuring_threshold
         YoungGeneration youngGen = HeapImpl.getHeapImpl().getYoungGeneration();
@@ -122,10 +119,10 @@ final class ProportionateSpacesPolicy extends AbstractCollectionPolicy {
     }
 
     private void computeNewOldGenSize(boolean resizeOnlyForPromotions) { // TenuredGeneration::compute_new_size_inner
-        UnsignedWord capacityAtPrologue = oldSize;
+        UnsignedWord capacityAtPrologue = sizes.getOldSize();
         UnsignedWord usedAfterGc = GCImpl.getAccounting().getOldGenerationAfterChunkBytes();
-        if (oldSize.belowThan(usedAfterGc)) {
-            oldSize = usedAfterGc;
+        if (sizes.getOldSize().belowThan(usedAfterGc)) {
+            sizes.setOldSize(usedAfterGc);
         }
         if (resizeOnlyForPromotions) {
             return;
@@ -138,24 +135,24 @@ final class ProportionateSpacesPolicy extends AbstractCollectionPolicy {
         double maximumUsedPercentage = 1 - minimumFreePercentage;
 
         UnsignedWord minimumDesiredCapacity = UnsignedUtils.fromDouble(UnsignedUtils.toDouble(usedAfterGc) / maximumUsedPercentage);
-        minimumDesiredCapacity = UnsignedUtils.max(minimumDesiredCapacity, sizes.initialOldSize());
+        minimumDesiredCapacity = UnsignedUtils.max(minimumDesiredCapacity, sizes.getInitialOldSize());
 
-        if (oldSize.belowThan(minimumDesiredCapacity)) {
-            oldSize = alignUp(minimumDesiredCapacity);
+        if (sizes.getOldSize().belowThan(minimumDesiredCapacity)) {
+            sizes.setOldSize(alignUp(minimumDesiredCapacity));
             return;
         }
 
-        UnsignedWord maxShrinkBytes = oldSize.subtract(minimumDesiredCapacity);
+        UnsignedWord maxShrinkBytes = sizes.getOldSize().subtract(minimumDesiredCapacity);
         UnsignedWord shrinkBytes = Word.zero();
         if (MAX_HEAP_FREE_RATIO < 100) {
             double maximumFreePercentage = MAX_HEAP_FREE_RATIO / 100.0;
             double minimumUsedPercentage = 1 - maximumFreePercentage;
             UnsignedWord maximumDesiredCapacity = UnsignedUtils.fromDouble(UnsignedUtils.toDouble(usedAfterGc) / minimumUsedPercentage);
-            maximumDesiredCapacity = UnsignedUtils.max(maximumDesiredCapacity, sizes.initialOldSize());
+            maximumDesiredCapacity = UnsignedUtils.max(maximumDesiredCapacity, sizes.getInitialOldSize());
             assert minimumDesiredCapacity.belowOrEqual(maximumDesiredCapacity);
 
-            if (oldSize.aboveThan(maximumDesiredCapacity)) {
-                shrinkBytes = oldSize.subtract(maximumDesiredCapacity);
+            if (sizes.getOldSize().aboveThan(maximumDesiredCapacity)) {
+                shrinkBytes = sizes.getOldSize().subtract(maximumDesiredCapacity);
                 if (SHRINK_HEAP_IN_STEPS) {
                     /*
                      * We don't want to shrink all the way back to initSize if people call
@@ -176,39 +173,36 @@ final class ProportionateSpacesPolicy extends AbstractCollectionPolicy {
             }
         }
 
-        if (oldSize.aboveThan(capacityAtPrologue)) {
+        if (sizes.getOldSize().aboveThan(capacityAtPrologue)) {
             /*
              * We might have expanded for promotions, in which case we might want to take back that
              * expansion if there's room after GC. That keeps us from stretching the heap with
              * promotions when there's plenty of room.
              */
-            UnsignedWord expansionForPromotion = oldSize.subtract(capacityAtPrologue);
+            UnsignedWord expansionForPromotion = sizes.getOldSize().subtract(capacityAtPrologue);
             expansionForPromotion = UnsignedUtils.min(expansionForPromotion, maxShrinkBytes);
             shrinkBytes = UnsignedUtils.max(shrinkBytes, expansionForPromotion);
         }
 
         if (shrinkBytes.aboveThan(MIN_HEAP_FREE_RATIO)) {
-            oldSize = oldSize.subtract(shrinkBytes);
+            sizes.setOldSize(sizes.getOldSize().subtract(shrinkBytes));
         }
     }
 
     private void computeNewYoungGenSize() { // DefNewGeneration::compute_new_size
-        UnsignedWord desiredNewSize = oldSize.unsignedDivide(NEW_RATIO);
-        desiredNewSize = UnsignedUtils.clamp(desiredNewSize, sizes.initialYoungSize(), sizes.maxYoungSize);
+        UnsignedWord desiredNewSize = sizes.getOldSize().unsignedDivide(NEW_RATIO);
+        desiredNewSize = UnsignedUtils.clamp(desiredNewSize, sizes.getInitialYoungSize(), sizes.getMaxYoungSize());
 
         // DefNewGeneration::compute_space_boundaries, DefNewGeneration::compute_survivor_size
-        survivorSize = minSpaceSize(alignDown(desiredNewSize.unsignedDivide(SURVIVOR_RATIO)));
-        UnsignedWord desiredEdenSize = Word.zero();
-        if (desiredNewSize.aboveThan(survivorSize.multiply(2))) {
-            desiredEdenSize = desiredNewSize.subtract(survivorSize.multiply(2));
-        }
-        edenSize = minSpaceSize(alignDown(desiredEdenSize));
-        assert edenSize.aboveThan(0) && survivorSize.belowOrEqual(edenSize);
-    }
+        UnsignedWord newSurvivorSize = minSpaceSize(alignDown(desiredNewSize.unsignedDivide(SURVIVOR_RATIO)));
+        sizes.setSurvivorSize(newSurvivorSize);
 
-    @Override
-    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    protected long gcCount() {
-        return totalCollections;
+        UnsignedWord desiredEdenSize = Word.zero();
+        if (desiredNewSize.aboveThan(newSurvivorSize.multiply(2))) {
+            desiredEdenSize = desiredNewSize.subtract(newSurvivorSize.multiply(2));
+        }
+        UnsignedWord newEdenSize = minSpaceSize(alignDown(desiredEdenSize));
+        sizes.setEdenSize(newEdenSize);
+        assert newEdenSize.aboveThan(0) && newSurvivorSize.belowOrEqual(newEdenSize);
     }
 }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/RawSizeParameters.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/RawSizeParameters.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2025, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.genscavenge;
+
+import org.graalvm.nativeimage.c.struct.RawField;
+import org.graalvm.nativeimage.c.struct.RawStructure;
+import org.graalvm.word.PointerBase;
+import org.graalvm.word.UnsignedWord;
+
+/**
+ * Struct that stores all GC-related sizes. See {@link SizeParameters} for more details on its
+ * lifecycle. When adding fields to this struct, please also change
+ * {@link RawSizeParametersOnStackAccess#initialize} and {@link SizeParameters#matches} accordingly.
+ */
+@RawStructure
+interface RawSizeParameters extends PointerBase {
+    @RawField
+    UnsignedWord getInitialEdenSize();
+
+    @RawField
+    void setInitialEdenSize(UnsignedWord value);
+
+    @RawField
+    UnsignedWord getEdenSize();
+
+    @RawField
+    void setEdenSize(UnsignedWord value);
+
+    @RawField
+    UnsignedWord getMaxEdenSize();
+
+    @RawField
+    void setMaxEdenSize(UnsignedWord value);
+
+    @RawField
+    UnsignedWord getInitialSurvivorSize();
+
+    @RawField
+    void setInitialSurvivorSize(UnsignedWord value);
+
+    @RawField
+    UnsignedWord getSurvivorSize();
+
+    @RawField
+    void setSurvivorSize(UnsignedWord value);
+
+    @RawField
+    UnsignedWord getMaxSurvivorSize();
+
+    @RawField
+    void setMaxSurvivorSize(UnsignedWord value);
+
+    @RawField
+    UnsignedWord getInitialYoungSize();
+
+    @RawField
+    void setInitialYoungSize(UnsignedWord value);
+
+    @RawField
+    UnsignedWord getYoungSize();
+
+    @RawField
+    void setYoungSize(UnsignedWord value);
+
+    @RawField
+    UnsignedWord getMaxYoungSize();
+
+    @RawField
+    void setMaxYoungSize(UnsignedWord value);
+
+    @RawField
+    UnsignedWord getInitialOldSize();
+
+    @RawField
+    void setInitialOldSize(UnsignedWord value);
+
+    @RawField
+    UnsignedWord getOldSize();
+
+    @RawField
+    void setOldSize(UnsignedWord value);
+
+    @RawField
+    UnsignedWord getMaxOldSize();
+
+    @RawField
+    void setMaxOldSize(UnsignedWord value);
+
+    @RawField
+    UnsignedWord getPromoSize();
+
+    @RawField
+    void setPromoSize(UnsignedWord value);
+
+    @RawField
+    UnsignedWord getMinHeapSize();
+
+    @RawField
+    void setMinHeapSize(UnsignedWord value);
+
+    @RawField
+    UnsignedWord getInitialHeapSize();
+
+    @RawField
+    void setInitialHeapSize(UnsignedWord value);
+
+    @RawField
+    UnsignedWord getHeapSize();
+
+    @RawField
+    void setHeapSize(UnsignedWord value);
+
+    @RawField
+    UnsignedWord getMaxHeapSize();
+
+    @RawField
+    void setMaxHeapSize(UnsignedWord value);
+
+    /**
+     * Either points to null or to an obsolete {@link RawSizeParameters} struct that wasn't freed
+     * yet.
+     */
+    @RawField
+    RawSizeParameters getNext();
+
+    @RawField
+    void setNext(RawSizeParameters value);
+}

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/RawSizeParametersOnStackAccess.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/RawSizeParametersOnStackAccess.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2025, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.genscavenge;
+
+import static com.oracle.svm.core.genscavenge.AbstractCollectionPolicy.isAligned;
+
+import org.graalvm.word.UnsignedWord;
+
+import com.oracle.svm.core.heap.ReferenceAccess;
+
+import jdk.graal.compiler.word.Word;
+
+/**
+ * The methods in this class may only be used on {@link RawSizeParameters} that are allocated on the
+ * stack and therefore not yet visible to other threads. Please keep the methods in this class to a
+ * minimum.
+ */
+final class RawSizeParametersOnStackAccess {
+    static void initialize(RawSizeParameters valuesOnStack,
+                    UnsignedWord initialEdenSize, UnsignedWord edenSize, UnsignedWord maxEdenSize,
+                    UnsignedWord initialSurvivorSize, UnsignedWord survivorSize, UnsignedWord maxSurvivorSize,
+                    UnsignedWord initialOldSize, UnsignedWord oldSize, UnsignedWord maxOldSize,
+                    UnsignedWord promoSize,
+                    UnsignedWord initialYoungSize, UnsignedWord youngSize, UnsignedWord maxYoungSize,
+                    UnsignedWord minHeapSize, UnsignedWord initialHeapSize, UnsignedWord heapSize, UnsignedWord maxHeapSize) {
+        assert isAligned(maxHeapSize) && isAligned(maxYoungSize) && isAligned(initialHeapSize) && isAligned(initialEdenSize) && isAligned(initialSurvivorSize);
+
+        assert initialEdenSize.belowOrEqual(initialYoungSize);
+        assert edenSize.belowOrEqual(youngSize);
+        assert maxEdenSize.belowOrEqual(maxYoungSize);
+
+        assert initialSurvivorSize.belowOrEqual(initialYoungSize);
+        assert survivorSize.belowOrEqual(youngSize);
+        assert maxSurvivorSize.belowOrEqual(maxYoungSize);
+
+        assert initialOldSize.belowOrEqual(initialHeapSize);
+        assert oldSize.belowOrEqual(heapSize);
+        assert maxOldSize.belowOrEqual(maxHeapSize);
+
+        assert initialYoungSize.belowOrEqual(initialHeapSize);
+        assert youngSize.belowOrEqual(heapSize);
+        assert maxYoungSize.belowOrEqual(maxHeapSize);
+
+        assert minHeapSize.belowOrEqual(initialHeapSize);
+        assert initialHeapSize.belowOrEqual(maxHeapSize);
+        assert heapSize.belowOrEqual(maxHeapSize);
+        assert maxHeapSize.belowOrEqual(ReferenceAccess.singleton().getMaxAddressSpaceSize());
+
+        valuesOnStack.setInitialEdenSize(initialEdenSize);
+        valuesOnStack.setEdenSize(edenSize);
+        valuesOnStack.setMaxEdenSize(maxEdenSize);
+
+        valuesOnStack.setInitialSurvivorSize(initialSurvivorSize);
+        valuesOnStack.setSurvivorSize(survivorSize);
+        valuesOnStack.setMaxSurvivorSize(maxSurvivorSize);
+
+        valuesOnStack.setInitialYoungSize(initialYoungSize);
+        valuesOnStack.setYoungSize(youngSize);
+        valuesOnStack.setMaxYoungSize(maxYoungSize);
+
+        valuesOnStack.setInitialOldSize(initialOldSize);
+        valuesOnStack.setOldSize(oldSize);
+        valuesOnStack.setMaxOldSize(maxOldSize);
+
+        valuesOnStack.setPromoSize(promoSize);
+
+        valuesOnStack.setMinHeapSize(minHeapSize);
+        valuesOnStack.setInitialHeapSize(initialHeapSize);
+        valuesOnStack.setHeapSize(heapSize);
+        valuesOnStack.setMaxHeapSize(maxHeapSize);
+
+        valuesOnStack.setNext(Word.nullPointer());
+    }
+}

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/SizeParameters.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/SizeParameters.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.genscavenge;
+
+import static com.oracle.svm.core.Uninterruptible.CALLED_FROM_UNINTERRUPTIBLE_CODE;
+import static com.oracle.svm.core.genscavenge.AbstractCollectionPolicy.isAligned;
+
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+import org.graalvm.nativeimage.c.struct.SizeOf;
+import org.graalvm.word.Pointer;
+import org.graalvm.word.UnsignedWord;
+
+import com.oracle.svm.core.Uninterruptible;
+import com.oracle.svm.core.UnmanagedMemoryUtil;
+import com.oracle.svm.core.memory.NullableNativeMemory;
+import com.oracle.svm.core.nmt.NmtCategory;
+import com.oracle.svm.core.thread.VMOperation;
+import com.oracle.svm.core.thread.VMThreads;
+import com.oracle.svm.core.util.VMError;
+
+import jdk.graal.compiler.word.Word;
+
+/**
+ * Once a {@link RawSizeParameters} struct is visible to other threads (see {@link #update}), it may
+ * only be accessed by {@link Uninterruptible} code or when the VM is at a safepoint. This is
+ * necessary to prevent use-after-free errors because no longer needed {@link RawSizeParameters}
+ * structs may be freed during a GC.
+ * <p>
+ * When the VM is at a safepoint, the GC may directly update some of the values in the latest
+ * {@link RawSizeParameters} (see setters below).
+ */
+final class SizeParameters {
+    private static final String ACCESS_RAW_SIZE_PARAMETERS = "Prevent that RawSizeParameters are freed.";
+
+    private volatile RawSizeParameters sizes;
+
+    @Platforms(Platform.HOSTED_ONLY.class)
+    SizeParameters() {
+    }
+
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+    public boolean isInitialized() {
+        /*
+         * This only checks for non-null and doesn't access any values in the struct, so inlining
+         * into interruptible code is allowed.
+         */
+        return sizes.isNonNull();
+    }
+
+    @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+    public UnsignedWord getInitialEdenSize() {
+        assert isInitialized();
+        return sizes.getInitialEdenSize();
+    }
+
+    @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+    public UnsignedWord getEdenSize() {
+        assert isInitialized();
+        return sizes.getEdenSize();
+    }
+
+    @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+    public void setEdenSize(UnsignedWord value) {
+        assert isInitialized();
+        assert VMOperation.isGCInProgress();
+
+        sizes.setEdenSize(value);
+    }
+
+    @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+    public UnsignedWord getMaxEdenSize() {
+        assert isInitialized();
+        return sizes.getMaxEdenSize();
+    }
+
+    @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+    public UnsignedWord getInitialSurvivorSize() {
+        assert isInitialized();
+        return sizes.getInitialSurvivorSize();
+    }
+
+    @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+    public UnsignedWord getSurvivorSize() {
+        assert isInitialized();
+        return sizes.getSurvivorSize();
+    }
+
+    @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+    public void setSurvivorSize(UnsignedWord value) {
+        assert isInitialized();
+        assert VMOperation.isGCInProgress();
+
+        sizes.setSurvivorSize(value);
+    }
+
+    @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+    UnsignedWord getMaxSurvivorSize() {
+        assert isInitialized();
+        return sizes.getMaxSurvivorSize();
+    }
+
+    @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+    UnsignedWord getInitialYoungSize() {
+        assert isInitialized();
+        return sizes.getInitialYoungSize();
+    }
+
+    @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+    public UnsignedWord getYoungSize() {
+        assert isInitialized();
+        return sizes.getYoungSize();
+    }
+
+    @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+    public UnsignedWord getMaxYoungSize() {
+        assert isInitialized();
+        return sizes.getMaxYoungSize();
+    }
+
+    @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+    UnsignedWord getInitialOldSize() {
+        assert isInitialized();
+        return sizes.getInitialOldSize();
+    }
+
+    @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+    public UnsignedWord getOldSize() {
+        assert isInitialized();
+        return sizes.getOldSize();
+    }
+
+    @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+    public void setOldSize(UnsignedWord value) {
+        assert isInitialized();
+        assert VMOperation.isGCInProgress();
+
+        sizes.setOldSize(value);
+    }
+
+    @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+    UnsignedWord getMaxOldSize() {
+        assert isInitialized();
+        return sizes.getMaxOldSize();
+    }
+
+    @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+    public UnsignedWord getPromoSize() {
+        assert isInitialized();
+        return sizes.getPromoSize();
+    }
+
+    @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+    public void setPromoSize(UnsignedWord value) {
+        assert isInitialized();
+        assert VMOperation.isGCInProgress();
+
+        sizes.setPromoSize(value);
+    }
+
+    @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+    public UnsignedWord getMinHeapSize() {
+        assert isInitialized();
+        return sizes.getMinHeapSize();
+    }
+
+    @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+    public UnsignedWord getMaxHeapSize() {
+        assert isInitialized();
+        return sizes.getMaxHeapSize();
+    }
+
+    @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+    public UnsignedWord getHeapSize() {
+        assert isInitialized();
+        assert VMOperation.isGCInProgress() : "use only during GC";
+
+        return sizes.getHeapSize();
+    }
+
+    /** The caller needs to ensure that . */
+    @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+    void update(RawSizeParameters newValuesOnStack) {
+        RawSizeParameters prevValues = sizes;
+        if (prevValues.isNonNull() && matches(prevValues, newValuesOnStack)) {
+            /* Nothing to do - cached params are still accurate. */
+            return;
+        }
+
+        /* Try allocating a struct on the C heap. */
+        UnsignedWord structSize = SizeOf.unsigned(RawSizeParameters.class);
+        RawSizeParameters newValuesOnHeap = NullableNativeMemory.malloc(structSize, NmtCategory.GC);
+        VMError.guarantee(newValuesOnHeap.isNonNull(), "Out-of-memory while updating GC policy sizes.");
+
+        /* Copy the values from the stack to the C heap. */
+        UnmanagedMemoryUtil.copyForward((Pointer) newValuesOnStack, (Pointer) newValuesOnHeap, structSize);
+        newValuesOnHeap.setNext(prevValues);
+
+        /*
+         * Publish the new struct via a volatile store. Once the data is published, other threads
+         * need to see a fully initialized struct right away. This is guaranteed by the implicit
+         * STORE_STORE barrier before the volatile write.
+         */
+        sizes = newValuesOnHeap;
+
+        assert isAligned(getMaxSurvivorSize()) && isAligned(getInitialYoungSize()) && isAligned(getInitialOldSize()) && isAligned(getMaxOldSize());
+        assert getMaxSurvivorSize().belowThan(getMaxYoungSize());
+        assert getMaxYoungSize().add(getMaxOldSize()).equal(getMaxHeapSize());
+        assert getInitialEdenSize().add(getInitialSurvivorSize().multiply(2)).equal(getInitialYoungSize());
+        assert getInitialYoungSize().add(getInitialOldSize()).equal(sizes.getInitialHeapSize());
+    }
+
+    /**
+     * Frees no longer needed {@link RawSizeParameters}, so that only the most recent one remains.
+     */
+    public void freeUnusedSizeParameters() {
+        assert isInitialized();
+        assert VMOperation.isGCInProgress() : "would need to be uninterruptible otherwise";
+
+        RawSizeParameters cur = sizes;
+        freeSizeParameters(cur.getNext());
+        cur.setNext(Word.nullPointer());
+    }
+
+    @Uninterruptible(reason = "Tear-down in progress.")
+    public void tearDown() {
+        assert VMThreads.isTearingDown();
+
+        freeSizeParameters(sizes);
+        sizes = Word.nullPointer();
+    }
+
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+    private static void freeSizeParameters(RawSizeParameters first) {
+        assert VMOperation.isGCInProgress() || VMThreads.isTearingDown();
+
+        RawSizeParameters cur = first;
+        while (cur.isNonNull()) {
+            RawSizeParameters next = cur.getNext();
+            NullableNativeMemory.free(cur);
+            cur = next;
+        }
+    }
+
+    @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+    private static boolean matches(RawSizeParameters a, RawSizeParameters b) {
+        return a.getInitialEdenSize() == b.getInitialEdenSize() &&
+                        a.getEdenSize() == b.getEdenSize() &&
+                        a.getMaxEdenSize() == b.getMaxEdenSize() &&
+
+                        a.getInitialSurvivorSize() == b.getInitialSurvivorSize() &&
+                        a.getSurvivorSize() == b.getSurvivorSize() &&
+                        a.getMaxSurvivorSize() == b.getMaxSurvivorSize() &&
+
+                        a.getInitialYoungSize() == b.getInitialYoungSize() &&
+                        a.getYoungSize() == b.getYoungSize() &&
+                        a.getMaxYoungSize() == b.getMaxYoungSize() &&
+
+                        a.getInitialOldSize() == b.getInitialOldSize() &&
+                        a.getOldSize() == b.getOldSize() &&
+                        a.getMaxOldSize() == b.getMaxOldSize() &&
+
+                        a.getPromoSize() == b.getPromoSize() &&
+
+                        a.getMinHeapSize() == b.getMinHeapSize() &&
+                        a.getInitialHeapSize() == b.getInitialHeapSize() &&
+                        a.getHeapSize() == b.getHeapSize() &&
+                        a.getMaxHeapSize() == b.getMaxHeapSize();
+    }
+}

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/SizeParameters.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/SizeParameters.java
@@ -187,6 +187,12 @@ final class SizeParameters {
     }
 
     @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
+    public UnsignedWord getInitialHeapSize() {
+        assert isInitialized();
+        return sizes.getInitialHeapSize();
+    }
+
+    @Uninterruptible(reason = ACCESS_RAW_SIZE_PARAMETERS)
     public UnsignedWord getMaxHeapSize() {
         assert isInitialized();
         return sizes.getMaxHeapSize();

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ThreadLocalAllocation.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ThreadLocalAllocation.java
@@ -77,11 +77,38 @@ import jdk.graal.compiler.replacements.AllocationSnippets.FillContent;
 import jdk.graal.compiler.word.Word;
 
 /**
- * Bump-pointer allocation from thread-local top and end Pointers. Many of these methods are called
- * from allocation snippets, so they can not do anything fancy. It happens that prefetch
- * instructions access memory outside the TLAB. At the moment, this is not an issue as we only
- * support architectures where the prefetch instructions never cause a segfault, even if they try to
- * access memory that is not accessible.
+ * Multiple threads may execute the methods in this class concurrently. All code that is
+ * transitively reachable from those method can get executed as a side effect of an allocation slow
+ * path. To prevent hard to debug transient issues, we execute as little code as possible in these
+ * methods.
+ *
+ * If the executed code is too complex, then it can happen that we unexpectedly change some shared
+ * global state as a side effect of an allocation. This may result in issues that look similar to
+ * races but that can even happen in single-threaded environments, e.g.:
+ *
+ * <pre>
+ * {@code
+ * private static Object singleton;
+ *
+ * private static synchronized Object createSingleton() {
+ *     if (singleton == null) {
+ *         Object o = new Object();
+ *         // If the allocation above enters the allocation slow path code, and executes a
+ *         // complex slow path hook, then it is possible that createSingleton() gets
+ *         // recursively execute by the current thread. So, the assertion below may fail
+ *         // because the singleton got already initialized by the same thread in the meanwhile.
+ *         assert singleton == null;
+ *         singleton = o;
+ *     }
+ *     return result;
+ * }
+ * }
+ * </pre>
+ *
+ * The allocation fast-path emits prefetch instructions. Those instructions may try to access memory
+ * that is outside the TLAB and therefore not necessarily accessible. At the moment, this is not an
+ * issue as we only support architectures where prefetch instructions never cause segfaults, even if
+ * they access memory that is not accessible.
  */
 public final class ThreadLocalAllocation {
     @RawStructure
@@ -182,46 +209,14 @@ public final class ThreadLocalAllocation {
         return allocatedAlignedBytes.getVolatile(thread);
     }
 
-    /**
-     * NOTE: Multiple threads may execute this method concurrently. All code that is transitively
-     * reachable from this method may get executed as a side effect of an allocation slow path. To
-     * prevent hard to debug transient issues, we execute as little code as possible in this method.
-     *
-     * If the executed code is too complex, then it can happen that we unexpectedly change some
-     * shared global state as a side effect of an allocation. This may result in issues that look
-     * similar to races but that can even happen in single-threaded environments, e.g.:
-     *
-     * <pre>
-     * {@code
-     * private static Object singleton;
-     *
-     * private static synchronized Object createSingleton() {
-     *     if (singleton == null) {
-     *         Object o = new Object();
-     *         // If the allocation above enters the allocation slow path code, and executes a
-     *         // complex slow path hook, then it is possible that createSingleton() gets
-     *         // recursively execute by the current thread. So, the assertion below may fail
-     *         // because the singleton got already initialized by the same thread in the meanwhile.
-     *         assert singleton == null;
-     *         singleton = o;
-     *     }
-     *     return result;
-     * }
-     * }
-     * </pre>
-     */
-    private static void runSlowPathHooks() {
-        GCImpl.getPolicy().updateSizeParameters();
-    }
-
     public static Object slowPathNewInstance(Word objectHeader) {
         DynamicHub hub = ObjectHeaderImpl.getObjectHeaderImpl().dynamicHubFromObjectHeader(objectHeader);
 
         UnsignedWord size = LayoutEncoding.getPureInstanceAllocationSize(hub.getLayoutEncoding());
         Object result = allocateInstanceInCurrentTlab(hub, size);
         if (result == null) {
+            GCImpl.getPolicy().ensureSizeParametersInitialized();
             result = slowPathNewInstanceWithoutAllocating(hub, size);
-            runSlowPathHooks();
             sampleSlowPathAllocation(result, size, Integer.MIN_VALUE);
         }
         return result;
@@ -268,10 +263,7 @@ public final class ThreadLocalAllocation {
         }
 
         Object result = slowPathNewArrayLikeObjectWithoutAllocating(hub, length, size, podReferenceMap);
-
-        runSlowPathHooks();
         sampleSlowPathAllocation(result, size, length);
-
         return result;
     }
 

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ThreadLocalAllocation.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ThreadLocalAllocation.java
@@ -77,14 +77,15 @@ import jdk.graal.compiler.replacements.AllocationSnippets.FillContent;
 import jdk.graal.compiler.word.Word;
 
 /**
- * Multiple threads may execute the methods in this class concurrently. All code that is
- * transitively reachable from those method can get executed as a side effect of an allocation slow
- * path. To prevent hard to debug transient issues, we execute as little code as possible in these
- * methods.
- *
- * If the executed code is too complex, then it can happen that we unexpectedly change some shared
- * global state as a side effect of an allocation. This may result in issues that look similar to
- * races but that can even happen in single-threaded environments, e.g.:
+ * Implements the thread-local allocation logic for serial and epsilon GC.
+ * <p>
+ * Multiple threads may execute the methods in this class concurrently. All code transitively
+ * reachable from these methods can be executed as a side effect of any Java heap allocation. To
+ * prevent hard to debug transient issues, we execute as little code as possible in these methods.
+ * <p>
+ * Executing complex logic in the allocation slow path can modify shared global state, causing
+ * issues that look similar to race conditions but that can even happen in single-threaded
+ * environments. For example:
  *
  * <pre>
  * {@code
@@ -93,14 +94,14 @@ import jdk.graal.compiler.word.Word;
  * private static synchronized Object createSingleton() {
  *     if (singleton == null) {
  *         Object o = new Object();
- *         // If the allocation above enters the allocation slow path code, and executes a
- *         // complex slow path hook, then it is possible that createSingleton() gets
- *         // recursively execute by the current thread. So, the assertion below may fail
- *         // because the singleton got already initialized by the same thread in the meanwhile.
+ *         // If the allocation above enters the slow path, and if that slow
+ *         // path executes code that calls createSingleton() as well, then
+ *         // the assertion below will fail because the singleton already
+ *         // got initialized by the same thread in the meanwhile.
  *         assert singleton == null;
  *         singleton = o;
  *     }
- *     return result;
+ *     return singleton;
  * }
  * }
  * </pre>

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/TlabSupport.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/TlabSupport.java
@@ -397,7 +397,7 @@ public class TlabSupport {
      */
     @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25+11/src/hotspot/share/gc/shared/threadLocalAllocBuffer.cpp#L154-L172")
     public static void resize(IsolateThread thread) {
-        assert SubstrateGCOptions.TlabOptions.ResizeTLAB.getValue();
+        assert SubstrateGCOptions.ResizeTLAB.getValue();
         assert VMOperation.isGCInProgress();
 
         UnsignedWord allocatedAvg = Word.unsigned((long) AdaptiveWeightedAverageStruct.getAverage(allocatedBytesAvg.getAddress(thread)));

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/graal/BarrierSnippets.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/graal/BarrierSnippets.java
@@ -183,7 +183,6 @@ public class BarrierSnippets extends SubstrateTemplates implements Snippets {
         }
 
         Word addr = Word.fromAddress(address);
-
         if (shouldOutline && !eliminated) {
             callPostWriteBarrierStub(POST_WRITE_BARRIER, fixedObject, addr);
             return;
@@ -286,14 +285,23 @@ public class BarrierSnippets extends SubstrateTemplates implements Snippets {
     }
 
     private static boolean shouldOutline(WriteBarrierNode barrier) {
-        if (SerialGCOptions.OutlineWriteBarriers.getValue() != null) {
-            return SerialGCOptions.OutlineWriteBarriers.getValue();
+        SerialGCOptions.OutlineWriteBarriers outlining = SerialGCOptions.WriteBarrierOutlining.getValue();
+        if (outlining == SerialGCOptions.OutlineWriteBarriers.Always) {
+            return true;
+        } else if (outlining == SerialGCOptions.OutlineWriteBarriers.Never) {
+            return false;
         }
-        if (GraalOptions.ReduceCodeSize.getValue(barrier.getOptions())) {
+
+        OptionValues graphOptions = barrier.graph().getOptions();
+        if (GraalOptions.ReduceCodeSize.getValue(graphOptions) && outlining == SerialGCOptions.OutlineWriteBarriers.Auto) {
             return true;
         }
-        // Newly allocated objects are likely young, so we can outline the execution after
-        // checking hasRememberedSet
+
+        /*
+         * Newly allocated objects are likely in the young generation, so we can outline the write
+         * barrier with minimal performance impact.
+         */
+        assert outlining == SerialGCOptions.OutlineWriteBarriers.Auto || outlining == SerialGCOptions.OutlineWriteBarriers.YoungOnly;
         return barrier instanceof SerialWriteBarrierNode serialBarrier && serialBarrier.getBaseStatus().likelyYoung();
     }
 

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/graal/GenScavengeAllocationSupport.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/graal/GenScavengeAllocationSupport.java
@@ -29,7 +29,6 @@ import static jdk.graal.compiler.core.common.spi.ForeignCallDescriptor.CallSideE
 
 import org.graalvm.word.UnsignedWord;
 
-import com.oracle.svm.core.SubstrateGCOptions;
 import com.oracle.svm.core.Uninterruptible;
 import com.oracle.svm.core.genscavenge.HeapImpl;
 import com.oracle.svm.core.genscavenge.HeapParameters;
@@ -97,11 +96,6 @@ public class GenScavengeAllocationSupport implements GCAllocationSupport {
     @Override
     public SubstrateForeignCallDescriptor getNewDynamicHub() {
         return NEW_DYNAMICHUB;
-    }
-
-    @Override
-    public boolean useTLAB() {
-        return SubstrateGCOptions.TlabOptions.UseTLAB.getValue();
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/IsolateArgumentParser.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/IsolateArgumentParser.java
@@ -330,6 +330,11 @@ public class IsolateArgumentParser {
         return parsedOptionValues[index];
     }
 
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+    public void setLongOptionValue(int optionIndex, long newValue) {
+        parsedOptionValues[optionIndex] = newValue;
+    }
+
     protected CCharPointer getCCharPointerOptionValue(int index) {
         return Word.pointer(parsedOptionValues[index]);
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateGCOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateGCOptions.java
@@ -55,7 +55,12 @@ public class SubstrateGCOptions {
         protected void onValueUpdate(EconomicMap<OptionKey<?>, Object> values, Long oldValue, Long newValue) {
             if (!SubstrateUtil.HOSTED) {
                 HeapSizeVerifier.verifyMinHeapSizeAgainstMaxAddressSpaceSize(Word.unsigned(newValue));
+
+                /* Update the isolate argument parser value. */
+                int optionIndex = IsolateArgumentParser.getOptionIndex(MinHeapSize);
+                IsolateArgumentParser.singleton().setLongOptionValue(optionIndex, newValue);
             }
+
             super.onValueUpdate(values, oldValue, newValue);
         }
     };
@@ -66,7 +71,12 @@ public class SubstrateGCOptions {
         protected void onValueUpdate(EconomicMap<OptionKey<?>, Object> values, Long oldValue, Long newValue) {
             if (!SubstrateUtil.HOSTED) {
                 HeapSizeVerifier.verifyMaxHeapSizeAgainstMaxAddressSpaceSize(Word.unsigned(newValue));
+
+                /* Update the isolate argument parser value. */
+                int optionIndex = IsolateArgumentParser.getOptionIndex(MaxHeapSize);
+                IsolateArgumentParser.singleton().setLongOptionValue(optionIndex, newValue);
             }
+
             super.onValueUpdate(values, oldValue, newValue);
         }
     };
@@ -77,7 +87,12 @@ public class SubstrateGCOptions {
         protected void onValueUpdate(EconomicMap<OptionKey<?>, Object> values, Long oldValue, Long newValue) {
             if (!SubstrateUtil.HOSTED) {
                 HeapSizeVerifier.verifyMaxNewSizeAgainstMaxAddressSpaceSize(Word.unsigned(newValue));
+
+                /* Update the isolate argument parser value. */
+                int optionIndex = IsolateArgumentParser.getOptionIndex(MaxNewSize);
+                IsolateArgumentParser.singleton().setLongOptionValue(optionIndex, newValue);
             }
+
             super.onValueUpdate(values, oldValue, newValue);
         }
     };

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateGCOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateGCOptions.java
@@ -121,6 +121,12 @@ public class SubstrateGCOptions {
     @Option(help = "Determines if references from runtime-compiled code to Java heap objects should be treated as strong or weak.", type = OptionType.Debug)//
     public static final HostedOptionKey<Boolean> TreatRuntimeCodeInfoReferencesAsWeak = new HostedOptionKey<>(true);
 
+    @Option(help = "Use a thread-local allocation buffer.", type = OptionType.Expert)//
+    public static final HostedOptionKey<Boolean> UseTLAB = new HostedOptionKey<>(null);
+
+    @Option(help = "Dynamically resize TLAB size for threads.", type = OptionType.Expert)//
+    public static final RuntimeOptionKey<Boolean> ResizeTLAB = new RuntimeOptionKey<>(true, IsolateCreationOnly);
+
     @DuplicatedInNativeCode
     public static class TlabOptions {
         @Option(help = "Use thread-local object allocation.", type = OptionType.Expert)//

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateGCOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateGCOptions.java
@@ -24,6 +24,7 @@
  */
 package com.oracle.svm.core;
 
+import static com.oracle.svm.core.option.HostedOptionKey.HostedOptionKeyFlag.DoNotPassToNativeGC;
 import static com.oracle.svm.core.option.RuntimeOptionKey.RuntimeOptionKeyFlag.Immutable;
 import static com.oracle.svm.core.option.RuntimeOptionKey.RuntimeOptionKeyFlag.IsolateCreationOnly;
 import static com.oracle.svm.core.option.RuntimeOptionKey.RuntimeOptionKeyFlag.RegisterForIsolateArgumentParser;
@@ -35,6 +36,7 @@ import com.oracle.svm.core.option.HostedOptionKey;
 import com.oracle.svm.core.option.NotifyGCRuntimeOptionKey;
 import com.oracle.svm.core.option.RuntimeOptionKey;
 import com.oracle.svm.core.util.DuplicatedInNativeCode;
+import com.oracle.svm.core.util.UserError;
 
 import jdk.graal.compiler.options.Option;
 import jdk.graal.compiler.options.OptionKey;
@@ -121,11 +123,20 @@ public class SubstrateGCOptions {
     @Option(help = "Determines if references from runtime-compiled code to Java heap objects should be treated as strong or weak.", type = OptionType.Debug)//
     public static final HostedOptionKey<Boolean> TreatRuntimeCodeInfoReferencesAsWeak = new HostedOptionKey<>(true);
 
-    @Option(help = "Use a thread-local allocation buffer.", type = OptionType.Expert)//
-    public static final HostedOptionKey<Boolean> UseTLAB = new HostedOptionKey<>(null);
+    @Option(help = "Use thread-local object allocation.", type = OptionType.Expert)//
+    public static final HostedOptionKey<Boolean> UseTLAB = new HostedOptionKey<>(true);
+
+    @Option(help = "Determines when to use thread-local object allocation.")//
+    public static final HostedOptionKey<TLABPolicy> TLABUsagePolicy = new HostedOptionKey<>(TLABPolicy.Auto, SubstrateGCOptions::verifyTLABUsagePolicy, DoNotPassToNativeGC);
 
     @Option(help = "Dynamically resize TLAB size for threads.", type = OptionType.Expert)//
     public static final RuntimeOptionKey<Boolean> ResizeTLAB = new RuntimeOptionKey<>(true, IsolateCreationOnly);
+
+    private static void verifyTLABUsagePolicy(@SuppressWarnings("unused") HostedOptionKey<?> key) {
+        if (!UseTLAB.getValue() && TLABUsagePolicy.getValue() == TLABPolicy.Always) {
+            throw UserError.invalidOptionValue(TLABUsagePolicy, TLABPolicy.Always.name(), "This option value can only be used if option '" + UseTLAB.getName() + "' is enabled");
+        }
+    }
 
     @DuplicatedInNativeCode
     public static class TlabOptions {
@@ -143,4 +154,8 @@ public class SubstrateGCOptions {
 
     }
 
+    public enum TLABPolicy {
+        Auto,
+        Always;
+    }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateGCOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateGCOptions.java
@@ -140,12 +140,6 @@ public class SubstrateGCOptions {
 
     @DuplicatedInNativeCode
     public static class TlabOptions {
-        @Option(help = "Use thread-local object allocation.", type = OptionType.Expert)//
-        public static final HostedOptionKey<Boolean> UseTLAB = new HostedOptionKey<>(true);
-
-        @Option(help = "Dynamically resize TLAB size for threads.", type = OptionType.Expert)//
-        public static final RuntimeOptionKey<Boolean> ResizeTLAB = new RuntimeOptionKey<>(true, IsolateCreationOnly);
-
         @Option(help = "Minimum allowed TLAB size (in bytes).", type = OptionType.Expert)//
         public static final RuntimeOptionKey<Long> MinTLABSize = new RuntimeOptionKey<>(2L * K, RegisterForIsolateArgumentParser);
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -92,6 +92,8 @@ import jdk.graal.compiler.phases.common.DeadCodeEliminationPhase;
 import jdk.internal.misc.Unsafe;
 import jdk.vm.ci.amd64.AMD64;
 
+import jdk.graal.compiler.asm.amd64.AMD64Assembler;
+
 public class SubstrateOptions {
 
     @Option(help = "Deprecated, option no longer has any effect.", deprecated = true, deprecationMessage = "It no longer has any effect, and no replacement is available")//
@@ -397,7 +399,7 @@ public class SubstrateOptions {
          */
         GraalOptions.LoopHeaderAlignment.update(values, 0);
         GraalOptions.IsolatedLoopHeaderAlignment.update(values, 0);
-                
+
         // We cannot check for architecture at the moment because ImageSingletons has not been
         // initialized yet
         disable(AMD64Assembler.Options.UseBranchesWithin32ByteBoundary, values);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -366,7 +366,7 @@ public class SubstrateOptions {
             GraalOptions.OptimizeLongJumps.update(values, !newLevel.isOneOf(OptimizationLevel.O0, OptimizationLevel.BUILD_TIME));
 
             if (newLevel == OptimizationLevel.SIZE) {
-                configureOs(values);
+                configureOptimizeForCodeSize(values, true, true);
             }
 
             if (optimizeValueUpdateHandler != null) {
@@ -376,30 +376,38 @@ public class SubstrateOptions {
         }
     };
 
-    public static void configureOs(EconomicMap<OptionKey<?>, Object> values) {
+    public static void configureOptimizeForCodeSize(EconomicMap<OptionKey<?>, Object> values, boolean disableLoopOptimizations, boolean disablePEA) {
         enable(GraalOptions.ReduceCodeSize, values);
         enable(ReduceImplicitExceptionStackTraceInformation, values);
         enable(GraalOptions.OptimizeLongJumps, values);
 
-        /*
-         * Remove all loop optimizations that can increase code size, i.e., duplicate a loop body
-         * somehow.
-         */
-        disable(GraalOptions.LoopPeeling, values);
-        disable(GraalOptions.LoopUnswitch, values);
-        disable(GraalOptions.FullUnroll, values);
-        disable(GraalOptions.PartialUnroll, values);
+        if (disableLoopOptimizations) {
+            /*
+             * Remove all loop optimizations that can increase code size, i.e., duplicate a loop
+             * body somehow.
+             */
+            disable(GraalOptions.LoopPeeling, values);
+            disable(GraalOptions.LoopUnswitch, values);
+            disable(GraalOptions.FullUnroll, values);
+            disable(GraalOptions.PartialUnroll, values);
+        }
 
         /*
          * Do not align loop headers to further reduce code size.
          */
         GraalOptions.LoopHeaderAlignment.update(values, 0);
         GraalOptions.IsolatedLoopHeaderAlignment.update(values, 0);
+                
+        // We cannot check for architecture at the moment because ImageSingletons has not been
+        // initialized yet
+        disable(AMD64Assembler.Options.UseBranchesWithin32ByteBoundary, values);
 
-        /*
-         * Do not run PEA - it can fan out allocations too much.
-         */
-        disable(GraalOptions.PartialEscapeAnalysis, values);
+        if (disablePEA) {
+            /*
+             * Do not run PEA - it can fan out allocations too much.
+             */
+            disable(GraalOptions.PartialEscapeAnalysis, values);
+        }
 
         /*
          * Do not fan out division.
@@ -417,10 +425,18 @@ public class SubstrateOptions {
         disable(DeadCodeEliminationPhase.Options.ReduceDCE, values);
     }
 
+    /**
+     * Sets {@code key} to false in {@code values}. This silently overrides any existing value for
+     * {@code key} in {@code values}.
+     */
     public static void disable(OptionKey<Boolean> key, EconomicMap<OptionKey<?>, Object> values) {
         key.update(values, false);
     }
 
+    /**
+     * Sets {@code key} to true in {@code values}. This silently overrides any existing value for
+     * {@code key} in {@code values}.
+     */
     public static void enable(OptionKey<Boolean> key, EconomicMap<OptionKey<?>, Object> values) {
         key.update(values, true);
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/gc/shared/NativeGCOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/gc/shared/NativeGCOptions.java
@@ -275,19 +275,8 @@ public class NativeGCOptions {
     }
 
     public static class NativeGCHostedOptionKey<T> extends HostedOptionKey<T> {
-        private final boolean passToCpp;
-
-        public NativeGCHostedOptionKey(T defaultValue, Consumer<HostedOptionKey<T>> validation) {
-            this(defaultValue, true, validation);
-        }
-
-        public NativeGCHostedOptionKey(T defaultValue, boolean passToCpp, Consumer<HostedOptionKey<T>> validation) {
-            super(defaultValue, validation);
-            this.passToCpp = passToCpp;
-        }
-
-        public boolean shouldPassToCpp() {
-            return passToCpp;
+        public NativeGCHostedOptionKey(T defaultValue, Consumer<HostedOptionKey<T>> validation, HostedOptionKeyFlag... flags) {
+            super(defaultValue, validation, flags);
         }
 
         @Override
@@ -328,7 +317,7 @@ public class NativeGCOptions {
                     if (HostedOptionKey.class.isAssignableFrom(type)) {
                         HostedOptionKey<?> key = (HostedOptionKey<?>) field.get(null);
                         Object value = key.getValueOrDefault(map);
-                        if (shouldPassToCpp(key) && value != null) {
+                        if (key.shouldPassToNativeGC() && value != null) {
                             buffer.putString(key.getName());
                             buffer.putPrimitive(value);
                         }
@@ -339,13 +328,6 @@ public class NativeGCOptions {
             }
             buffer.putEnd();
             return buffer.toArray();
-        }
-
-        private static boolean shouldPassToCpp(HostedOptionKey<?> key) {
-            if (key instanceof NativeGCHostedOptionKey<?>) {
-                return ((NativeGCHostedOptionKey<?>) key).shouldPassToCpp();
-            }
-            return true;
         }
     }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/gc/shared/NativeGCOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/gc/shared/NativeGCOptions.java
@@ -386,13 +386,13 @@ public class NativeGCOptions {
 
         public void putPrimitive(Object value) {
             long rawLong = switch (value) {
-                case Boolean _ -> ((boolean) value) ? 1L : 0L;
-                case Byte _ -> ((byte) value) & 0xFFL;
-                case Character _ -> ((char) value) & 0xFFFFL;
-                case Short _ -> ((short) value) & 0xFFFFL;
-                case Integer _ -> ((int) value) & 0xFFFFFFFFL;
-                case Long _ -> (long) value;
-                case Double _ -> Double.doubleToLongBits((double) value);
+                case Boolean _x -> ((boolean) value) ? 1L : 0L;
+                case Byte _x -> ((byte) value) & 0xFFL;
+                case Character _x -> ((char) value) & 0xFFFFL;
+                case Short _x -> ((short) value) & 0xFFFFL;
+                case Integer _x -> ((int) value) & 0xFFFFFFFFL;
+                case Long _x -> (long) value;
+                case Double _x -> Double.doubleToLongBits((double) value);
                 default -> throw VMError.shouldNotReachHere("Unexpected type: " + value.getClass());
             };
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/gc/shared/NativeGCOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/gc/shared/NativeGCOptions.java
@@ -1,0 +1,448 @@
+/*
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.gc.shared;
+
+import static com.oracle.svm.core.option.RuntimeOptionKey.RuntimeOptionKeyFlag.IsolateCreationOnly;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.graalvm.collections.UnmodifiableEconomicMap;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+
+import com.oracle.svm.core.SubstrateOptions;
+import com.oracle.svm.core.option.HostedOptionKey;
+import com.oracle.svm.core.option.HostedOptionValues;
+import com.oracle.svm.core.option.RuntimeOptionKey;
+import com.oracle.svm.core.option.RuntimeOptionValues;
+import com.oracle.svm.core.option.SubstrateOptionKey;
+import com.oracle.svm.core.util.UserError;
+import com.oracle.svm.core.util.VMError;
+
+import jdk.graal.compiler.options.Option;
+import jdk.graal.compiler.options.OptionKey;
+import jdk.graal.compiler.options.OptionType;
+import jdk.graal.compiler.options.OptionValues;
+import jdk.vm.ci.code.CodeUtil;
+
+/**
+ * Defines options that are specific to GCs such as G1. Hosted options are properly validated at
+ * build-time. Runtime options, for which a default value is specified at build-time using
+ * {@code -R:...}, undergo only basic build-time validation. Comprehensive validation of these
+ * runtime options is performed by the C++ code during GC initialization.
+ * <p>
+ * Please note that the default values below don't necessarily match the default values that are
+ * specified in files such as {@code gc_globals.hpp}. Some of these values are computed during
+ * startup as they depend on the used GC and operating system.
+ * <p>
+ * All options that are relevant for the C++ code are serialized into byte arrays (see
+ * {@link HostedArgumentsSupplier} and {@link RuntimeArgumentsSupplier}). During VM startup, SVM
+ * passes those byte arrays to the C++ code.
+ * <p>
+ * <b>Important:</b> After VM startup, only the C++ code knows which value each runtime option has.
+ * Option values are not synced back to SVM, so Java code must not access any of the runtime options
+ * below, as doing so may return outdated or incorrect values.
+ */
+public class NativeGCOptions {
+    public static final int K = 1024;
+    public static final int M = 1024 * K;
+
+    /* gc_globals.hpp */
+
+    @Option(help = "Number of parallel threads that the GC will use.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Integer> ParallelGCThreads = new NativeGCRuntimeOptionKey<>(0, IsolateCreationOnly);
+
+    @Option(help = "Dynamically choose the number of threads up to a maximum of ParallelGCThreads that the GC will use for garbage collection work.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Boolean> UseDynamicNumberOfGCThreads = new NativeGCRuntimeOptionKey<>(true, IsolateCreationOnly);
+
+    @Option(help = "Size of heap (bytes) per GC thread used in calculating the number of GC threads.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Long> HeapSizePerGCThread = new NativeGCRuntimeOptionKey<>(42L * M, IsolateCreationOnly);
+
+    @Option(help = "Number of concurrent threads that the GC will use.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Integer> ConcGCThreads = new NativeGCRuntimeOptionKey<>(0, IsolateCreationOnly);
+
+    @Option(help = "Determines if System.gc() invokes a concurrent collection.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Boolean> ExplicitGCInvokesConcurrent = new NativeGCRuntimeOptionKey<>(false, IsolateCreationOnly);
+
+    @Option(help = "Wasted fraction of parallel allocation buffer.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Integer> ParallelGCBufferWastePct = new NativeGCRuntimeOptionKey<>(10, IsolateCreationOnly);
+
+    @Option(help = "Target wasted space in last buffer as percent of overall allocation.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Integer> TargetPLABWastePct = new NativeGCRuntimeOptionKey<>(10, IsolateCreationOnly);
+
+    @Option(help = "Percentage (0-100) used to weight the current sample when computing exponentially decaying average for ResizePLAB.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Integer> PLABWeight = new NativeGCRuntimeOptionKey<>(75, IsolateCreationOnly);
+
+    @Option(help = "Dynamically resize (survivor space) promotion LAB's.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Boolean> ResizePLAB = new NativeGCRuntimeOptionKey<>(true, IsolateCreationOnly);
+
+    @Option(help = "Scan a subset of object array and push remainder, if array is bigger than this.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Integer> ParGCArrayScanChunk = new NativeGCRuntimeOptionKey<>(50, IsolateCreationOnly);
+
+    @Option(help = "Force all freshly committed pages to be pre-touched.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Boolean> AlwaysPreTouch = new NativeGCRuntimeOptionKey<>(false, IsolateCreationOnly);
+
+    @Option(help = "Per-thread chunk size for parallel memory pre-touch.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Long> PreTouchParallelChunkSize = new NativeGCRuntimeOptionKey<>(4L * M, IsolateCreationOnly);
+
+    @Option(help = "Maximum size of marking stack in bytes.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Long> MarkStackSizeMax = new NativeGCRuntimeOptionKey<>(512L * M, IsolateCreationOnly);
+
+    @Option(help = "Size of marking stack in bytes.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Long> MarkStackSize = new NativeGCRuntimeOptionKey<>(4L * M, IsolateCreationOnly);
+
+    @Option(help = "Enable parallel reference processing whenever possible.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Boolean> ParallelRefProcEnabled = new NativeGCRuntimeOptionKey<>(false, IsolateCreationOnly);
+
+    @Option(help = "Enable balancing of reference processing queues.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Boolean> ParallelRefProcBalancingEnabled = new NativeGCRuntimeOptionKey<>(true, IsolateCreationOnly);
+
+    @Option(help = "The percent occupancy (IHOP) of the current old generation capacity above which a concurrent mark cycle will be initiated. Its value may change over time if adaptive IHOP is enabled, otherwise " +
+                    "the value remains constant. In the latter case a value of 0 will result as frequent as possible concurrent marking cycles. A value of 100 disables concurrent marking. Fragmentation waste in the old generation " +
+                    "is not considered free space in this calculation.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Integer> InitiatingHeapOccupancyPercent = new NativeGCRuntimeOptionKey<>(45, IsolateCreationOnly);
+
+    protected static final RuntimeOptionKey<Long> MaxRAM = SubstrateOptions.ConcealedOptions.MaxRAM;
+
+    @Option(help = "Maximum ergonomically set heap size (in bytes); zero means use MaxRAM * MaxRAMPercentage / 100.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Long> ErgoHeapSizeLimit = new NativeGCRuntimeOptionKey<>(0L, IsolateCreationOnly);
+
+    @Option(help = "Maximum percentage of real memory used for maximum heap size.", type = OptionType.Expert)//
+    public static final RuntimeOptionKey<Double> MaxRAMPercentage = new NativeGCRuntimeOptionKey<>(25.0, IsolateCreationOnly);
+
+    @Option(help = "Minimum percentage of real memory used for maximum heap size on systems with small physical memory size.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Double> MinRAMPercentage = new NativeGCRuntimeOptionKey<>(50.0, IsolateCreationOnly);
+
+    @Option(help = "Percentage of real memory used for initial heap size.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Double> InitialRAMPercentage = new NativeGCRuntimeOptionKey<>(0.2, IsolateCreationOnly);
+
+    protected static final RuntimeOptionKey<Integer> ActiveProcessorCount = SubstrateOptions.ActiveProcessorCount;
+
+    @Option(help = "Adaptive size policy maximum GC pause time goal in millisecond, or the maximum GC time per MMU time slice.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Long> MaxGCPauseMillis = new NativeGCRuntimeOptionKey<>(200L, IsolateCreationOnly);
+
+    @Option(help = "Time slice for MMU specification.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Long> GCPauseIntervalMillis = new NativeGCRuntimeOptionKey<>(201L, IsolateCreationOnly);
+
+    @Option(help = "Adaptive size policy application time to GC time ratio.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Integer> GCTimeRatio = new NativeGCRuntimeOptionKey<>(12, IsolateCreationOnly);
+
+    @Option(help = "How far ahead to prefetch destination area (<= 0 means off).", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Long> PrefetchCopyIntervalInBytes = new NativeGCRuntimeOptionKey<>(-1L, IsolateCreationOnly);
+
+    @Option(help = "How far ahead to prefetch scan area (<= 0 means off).", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Long> PrefetchScanIntervalInBytes = new NativeGCRuntimeOptionKey<>(-1L, IsolateCreationOnly);
+
+    @Option(help = "Verify memory system before GC.", type = OptionType.Debug)//
+    protected static final RuntimeOptionKey<Boolean> VerifyBeforeGC = new NativeGCRuntimeOptionKey<>(false, IsolateCreationOnly);
+
+    @Option(help = "Verify memory system after GC.", type = OptionType.Debug)//
+    protected static final RuntimeOptionKey<Boolean> VerifyAfterGC = new NativeGCRuntimeOptionKey<>(false, IsolateCreationOnly);
+
+    @Option(help = "Verify memory system during GC (between phases).", type = OptionType.Debug)//
+    protected static final RuntimeOptionKey<Boolean> VerifyDuringGC = new NativeGCRuntimeOptionKey<>(false, IsolateCreationOnly);
+
+    @Option(help = "Initial heap size (in bytes); zero means use ergonomics.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Long> InitialHeapSize = new NativeGCRuntimeOptionKey<>(0L, IsolateCreationOnly);
+
+    @Option(help = "Initial new generation size (in bytes).", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Long> NewSize = new NativeGCRuntimeOptionKey<>(1L * M, IsolateCreationOnly);
+
+    @Option(help = "Ratio of eden/survivor space size.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Long> SurvivorRatio = new NativeGCRuntimeOptionKey<>(8L, IsolateCreationOnly);
+
+    @Option(help = "Ratio of old/new generation sizes.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Long> NewRatio = new NativeGCRuntimeOptionKey<>(2L, IsolateCreationOnly);
+
+    @Option(help = "Number of times an allocation that queues behind a GC will retry before printing a warning.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Long> QueuedAllocationWarningCount = new NativeGCRuntimeOptionKey<>(0L, IsolateCreationOnly);
+
+    @Option(help = "GC invoke count where +VerifyHeap kicks in.", type = OptionType.Debug)//
+    protected static final RuntimeOptionKey<Long> VerifyGCStartAt = new NativeGCRuntimeOptionKey<>(0L, IsolateCreationOnly);
+
+    @Option(help = "Maximum value for tenuring threshold.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Integer> MaxTenuringThreshold = new NativeGCRuntimeOptionKey<>(15, IsolateCreationOnly);
+
+    @Option(help = "Desired percentage of survivor space used after scavenge.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Integer> TargetSurvivorRatio = new NativeGCRuntimeOptionKey<>(50, IsolateCreationOnly);
+
+    @Option(help = "Number of entries we will try to leave on the stack during gc.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Integer> GCDrainStackTargetSize = new NativeGCRuntimeOptionKey<>(64, IsolateCreationOnly);
+
+    @Option(help = "Card table entry size (in bytes).", type = OptionType.Expert)//
+    public static final HostedOptionKey<Integer> GCCardSizeInBytes = new NativeGCHostedOptionKey<>(512, NativeGCOptions::validatePowerOfTwo);
+
+    /* tlab_globals.hpp */
+    @Option(help = "Zero out the newly created TLAB.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Boolean> ZeroTLAB = new NativeGCRuntimeOptionKey<>(false, IsolateCreationOnly);
+
+    @Option(help = "Size of young gen promotion LAB's (in HeapWords).", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Long> YoungPLABSize = new NativeGCRuntimeOptionKey<>(4096L, IsolateCreationOnly);
+
+    @Option(help = "Size of old gen promotion LAB's (in HeapWords).", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Long> OldPLABSize = new NativeGCRuntimeOptionKey<>(1024L, IsolateCreationOnly);
+
+    @Option(help = "Allocation averaging weight.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Long> TLABAllocationWeight = new NativeGCRuntimeOptionKey<>(35L, IsolateCreationOnly);
+
+    @Option(help = "Percentage of Eden that can be wasted (half-full TLABs at GC).", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Long> TLABWasteTargetPercent = new NativeGCRuntimeOptionKey<>(1L, IsolateCreationOnly);
+
+    @Option(help = "Maximum TLAB waste at a refill (internal fragmentation).", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Long> TLABRefillWasteFraction = new NativeGCRuntimeOptionKey<>(64L, IsolateCreationOnly);
+
+    @Option(help = "Increment allowed waste at slow allocation.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Long> TLABWasteIncrement = new NativeGCRuntimeOptionKey<>(4L, IsolateCreationOnly);
+
+    /* globals.hpp */
+
+    @Option(help = "The minimum percentage of heap free after GC to avoid expansion.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Long> MinHeapFreeRatio = new NativeGCRuntimeOptionKey<>(40L, IsolateCreationOnly);
+
+    @Option(help = "Number of milliseconds per MB of free space in the heap.", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Long> SoftRefLRUPolicyMSPerMB = new NativeGCRuntimeOptionKey<>(1000L, IsolateCreationOnly);
+
+    @Option(help = "The minimum change in heap space due to GC (in bytes).", type = OptionType.Expert)//
+    protected static final RuntimeOptionKey<Long> MinHeapDeltaBytes = new NativeGCRuntimeOptionKey<>(168L * K, IsolateCreationOnly);
+
+    /* This runtime option depends on a hosted option (see special handling in svmToGC.cpp). */
+    protected static final RuntimeOptionKey<Boolean> UsePerfData = SubstrateOptions.ConcealedOptions.UsePerfData;
+
+    /* globals_linux.hpp */
+    protected static final HostedOptionKey<Boolean> UseContainerSupport = SubstrateOptions.UseContainerSupport;
+
+    @Platforms(Platform.HOSTED_ONLY.class)
+    public static ArrayList<Field> getOptionFields(Class<?>[] optionClasses) {
+        ArrayList<Field> result = new ArrayList<>();
+        for (Class<?> clazz : optionClasses) {
+            for (Field field : clazz.getDeclaredFields()) {
+                if (Modifier.isStatic(field.getModifiers()) && OptionKey.class.isAssignableFrom(field.getType())) {
+                    field.setAccessible(true);
+                    result.add(field);
+                }
+            }
+        }
+        return result;
+    }
+
+    private static void validatePowerOfTwo(HostedOptionKey<Integer> optionKey) {
+        int value = optionKey.getValue();
+        if (!CodeUtil.isPowerOf2(value)) {
+            throw UserError.invalidOptionValue(optionKey, value, "The value must be a power of two");
+        }
+    }
+
+    private static void validatePlatformAndGC(SubstrateOptionKey<?> optionKey) {
+        if (!optionKey.hasBeenSet()) {
+            return;
+        }
+
+        if (!Platform.includedIn(Platform.LINUX_AMD64.class) && !Platform.includedIn(Platform.LINUX_AARCH64.class)) {
+            throw UserError.abort("The option '%s' can only be used on linux/amd64 or linux/aarch64.", optionKey.getName());
+        } else if (!SubstrateOptions.useG1GC()) {
+            throw UserError.abort("The option '%s' can only be used with the G1 ('--gc=G1') garbage collector.", optionKey.getName());
+        }
+    }
+
+    public static class NativeGCHostedOptionKey<T> extends HostedOptionKey<T> {
+        private final boolean passToCpp;
+
+        public NativeGCHostedOptionKey(T defaultValue, Consumer<HostedOptionKey<T>> validation) {
+            this(defaultValue, true, validation);
+        }
+
+        public NativeGCHostedOptionKey(T defaultValue, boolean passToCpp, Consumer<HostedOptionKey<T>> validation) {
+            super(defaultValue, validation);
+            this.passToCpp = passToCpp;
+        }
+
+        public boolean shouldPassToCpp() {
+            return passToCpp;
+        }
+
+        @Override
+        public void validate() {
+            validatePlatformAndGC(this);
+            super.validate();
+        }
+    }
+
+    public static class NativeGCRuntimeOptionKey<T> extends RuntimeOptionKey<T> {
+        public NativeGCRuntimeOptionKey(T defaultValue, RuntimeOptionKeyFlag... flags) {
+            super(defaultValue, flags);
+        }
+
+        @Override
+        public void validate() {
+            validatePlatformAndGC(this);
+            super.validate();
+        }
+    }
+
+    /** Serializes GC-relevant hosted options and their build-time values into a byte array. */
+    @Platforms(Platform.HOSTED_ONLY.class)
+    public static final class HostedArgumentsSupplier implements Supplier<byte[]> {
+        private final ArrayList<Field> optionFields;
+
+        public HostedArgumentsSupplier(ArrayList<Field> optionFields) {
+            this.optionFields = optionFields;
+        }
+
+        @Override
+        public byte[] get() {
+            NativeGCArgumentsBuffer buffer = new NativeGCArgumentsBuffer();
+            UnmodifiableEconomicMap<OptionKey<?>, Object> map = HostedOptionValues.singleton().getMap();
+            for (Field field : optionFields) {
+                try {
+                    Class<?> type = field.getType();
+                    if (HostedOptionKey.class.isAssignableFrom(type)) {
+                        HostedOptionKey<?> key = (HostedOptionKey<?>) field.get(null);
+                        Object value = key.getValueOrDefault(map);
+                        if (shouldPassToCpp(key) && value != null) {
+                            buffer.putString(key.getName());
+                            buffer.putPrimitive(value);
+                        }
+                    }
+                } catch (IllegalArgumentException | IllegalAccessException e) {
+                    throw VMError.shouldNotReachHere(e);
+                }
+            }
+            buffer.putEnd();
+            return buffer.toArray();
+        }
+
+        private static boolean shouldPassToCpp(HostedOptionKey<?> key) {
+            if (key instanceof NativeGCHostedOptionKey<?>) {
+                return ((NativeGCHostedOptionKey<?>) key).shouldPassToCpp();
+            }
+            return true;
+        }
+    }
+
+    /** Serializes GC-relevant runtime options and their build-time values into a byte array. */
+    @Platforms(Platform.HOSTED_ONLY.class)
+    public static final class RuntimeArgumentsSupplier implements Supplier<byte[]> {
+        private final ArrayList<Field> optionFields;
+
+        public RuntimeArgumentsSupplier(ArrayList<Field> optionFields) {
+            this.optionFields = optionFields;
+        }
+
+        @Override
+        public byte[] get() {
+            NativeGCArgumentsBuffer buffer = new NativeGCArgumentsBuffer();
+            OptionValues optionValues = RuntimeOptionValues.singleton();
+            for (Field field : optionFields) {
+                try {
+                    Class<?> type = field.getType();
+                    if (RuntimeOptionKey.class.isAssignableFrom(type)) {
+                        RuntimeOptionKey<?> key = (RuntimeOptionKey<?>) field.get(null);
+                        if (key.hasBeenSet(optionValues)) {
+                            buffer.putString(key.getName());
+                            buffer.putPrimitive(key.getValue(optionValues));
+                        }
+                    }
+                } catch (IllegalArgumentException | IllegalAccessException e) {
+                    throw VMError.shouldNotReachHere(e);
+                }
+            }
+            buffer.putEnd();
+            return buffer.toArray();
+        }
+    }
+
+    /**
+     * Writes Strings as ISO_8859_1 with zero termination. Primitive values are encoded as 64-bit
+     * values (regardless of their actual size and type).
+     */
+    @Platforms(Platform.HOSTED_ONLY.class)
+    private static class NativeGCArgumentsBuffer {
+        private ByteBuffer buffer;
+
+        NativeGCArgumentsBuffer() {
+            buffer = allocateBuffer(128);
+        }
+
+        public void putString(String value) {
+            assert value != null && !value.isEmpty() : value;
+            byte[] latin1String = value.getBytes(StandardCharsets.ISO_8859_1);
+            ensureCapacity(latin1String.length + 1);
+
+            buffer.put(latin1String);
+            buffer.put((byte) 0);
+        }
+
+        public void putPrimitive(Object value) {
+            long rawLong = switch (value) {
+                case Boolean _ -> ((boolean) value) ? 1L : 0L;
+                case Byte _ -> ((byte) value) & 0xFFL;
+                case Character _ -> ((char) value) & 0xFFFFL;
+                case Short _ -> ((short) value) & 0xFFFFL;
+                case Integer _ -> ((int) value) & 0xFFFFFFFFL;
+                case Long _ -> (long) value;
+                case Double _ -> Double.doubleToLongBits((double) value);
+                default -> throw VMError.shouldNotReachHere("Unexpected type: " + value.getClass());
+            };
+
+            ensureCapacity(Long.BYTES);
+            buffer.putLong(rawLong);
+        }
+
+        public void putEnd() {
+            ensureCapacity(1);
+            buffer.put((byte) 0);
+        }
+
+        public void ensureCapacity(int requested) {
+            int needed = buffer.position() + requested;
+            if (buffer.capacity() < needed) {
+                int newCapacity = buffer.capacity();
+                do {
+                    newCapacity *= 2;
+                } while (newCapacity < needed);
+
+                ByteBuffer newBuffer = allocateBuffer(newCapacity);
+                newBuffer.put(buffer.array(), 0, buffer.position());
+                buffer = newBuffer;
+            }
+        }
+
+        public byte[] toArray() {
+            return Arrays.copyOf(buffer.array(), buffer.position());
+        }
+
+        private static ByteBuffer allocateBuffer(int size) {
+            return ByteBuffer.allocate(size).order(ByteOrder.nativeOrder());
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/gc/shared/graal/NativeGCAllocationSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/gc/shared/graal/NativeGCAllocationSupport.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.gc.shared.graal;
+
+import static com.oracle.svm.core.Uninterruptible.CALLED_FROM_UNINTERRUPTIBLE_CODE;
+import static jdk.graal.compiler.core.common.spi.ForeignCallDescriptor.CallSideEffect.NO_SIDE_EFFECT;
+import static jdk.graal.compiler.nodes.extended.BranchProbabilityNode.VERY_SLOW_PATH_PROBABILITY;
+import static jdk.graal.compiler.nodes.extended.BranchProbabilityNode.probability;
+
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.word.UnsignedWord;
+
+import com.oracle.svm.core.Uninterruptible;
+import com.oracle.svm.core.graal.meta.SubstrateForeignCallsProvider;
+import com.oracle.svm.core.graal.snippets.GCAllocationSupport;
+import com.oracle.svm.core.heap.Heap;
+import com.oracle.svm.core.heap.NoAllocationVerifier;
+import com.oracle.svm.core.heap.OutOfMemoryUtil;
+import com.oracle.svm.core.heap.Pod;
+import com.oracle.svm.core.hub.DynamicHub;
+import com.oracle.svm.core.snippets.SnippetRuntime;
+import com.oracle.svm.core.snippets.SnippetRuntime.SubstrateForeignCallDescriptor;
+import com.oracle.svm.core.snippets.SubstrateForeignCallTarget;
+import com.oracle.svm.core.stack.StackOverflowCheck;
+import com.oracle.svm.core.thread.ContinuationSupport;
+import com.oracle.svm.core.threadlocal.FastThreadLocalFactory;
+import com.oracle.svm.core.threadlocal.FastThreadLocalObject;
+
+import jdk.graal.compiler.api.replacements.Fold;
+import jdk.graal.compiler.core.common.spi.ForeignCallDescriptor;
+import jdk.graal.compiler.word.Word;
+
+/**
+ * This class contains the {@link SubstrateForeignCallTarget}s for the allocation slow path. These
+ * methods are {@link Uninterruptible} to ensure that newly allocated objects are either placed in
+ * the young generation or that the covered cards are marked as dirty (this dirtying is done by the
+ * GC at a later point in time, see ReduceInitialCardMarks and DeferInitialCardMark in HotSpot).
+ * This allows the compiler to safely eliminate GC write barriers for initializing writes to the
+ * last allocated object, which reduces code size.
+ */
+public abstract class NativeGCAllocationSupport implements GCAllocationSupport {
+    private static final SubstrateForeignCallDescriptor SLOW_NEW_INSTANCE = SnippetRuntime.findForeignCall(NativeGCAllocationSupport.class, "slowPathNewInstance", NO_SIDE_EFFECT);
+    private static final SubstrateForeignCallDescriptor SLOW_NEW_ARRAY = SnippetRuntime.findForeignCall(NativeGCAllocationSupport.class, "slowPathNewArray", NO_SIDE_EFFECT);
+    private static final SubstrateForeignCallDescriptor SLOW_NEW_STORED_CONTINUATION = SnippetRuntime.findForeignCall(NativeGCAllocationSupport.class, "slowPathNewStoredContinuation", NO_SIDE_EFFECT);
+    private static final SubstrateForeignCallDescriptor SLOW_NEW_POD_INSTANCE = SnippetRuntime.findForeignCall(NativeGCAllocationSupport.class, "slowPathNewPodInstance", NO_SIDE_EFFECT);
+    private static final SubstrateForeignCallDescriptor[] UNCONDITIONAL_FOREIGN_CALLS = new SubstrateForeignCallDescriptor[]{SLOW_NEW_INSTANCE, SLOW_NEW_ARRAY};
+
+    /* The following thread locals may only be accessed in uninterruptible code. */
+    public static final FastThreadLocalObject<Object> podReferenceMapTL = FastThreadLocalFactory.createObject(Object.class, "podReferenceMap");
+
+    @Fold
+    public static NativeGCAllocationSupport singleton() {
+        return ImageSingletons.lookup(NativeGCAllocationSupport.class);
+    }
+
+    public static void registerForeignCalls(SubstrateForeignCallsProvider foreignCalls) {
+        foreignCalls.register(UNCONDITIONAL_FOREIGN_CALLS);
+        if (ContinuationSupport.isSupported()) {
+            foreignCalls.register(SLOW_NEW_STORED_CONTINUATION);
+        }
+        if (Pod.RuntimeSupport.isPresent()) {
+            foreignCalls.register(SLOW_NEW_POD_INSTANCE);
+        }
+    }
+
+    @Override
+    public ForeignCallDescriptor getNewInstanceStub() {
+        return SLOW_NEW_INSTANCE;
+    }
+
+    @Override
+    public ForeignCallDescriptor getNewArrayStub() {
+        return SLOW_NEW_ARRAY;
+    }
+
+    @Override
+    public ForeignCallDescriptor getNewStoredContinuationStub() {
+        return SLOW_NEW_STORED_CONTINUATION;
+    }
+
+    @Override
+    public ForeignCallDescriptor getNewPodInstanceStub() {
+        return SLOW_NEW_POD_INSTANCE;
+    }
+
+    @Override
+    public boolean shouldAllocateInTLAB(UnsignedWord size, boolean isArray) {
+        /* Always try to allocate in the TLAB (humongous objects will not fit into the TLAB). */
+        return true;
+    }
+
+    @SubstrateForeignCallTarget(stubCallingConvention = false)
+    @Uninterruptible(reason = "The newly allocated object must be young or all its covered cards must be dirty.")
+    private static Object slowPathNewInstance(Word objectHeader) {
+        StackOverflowCheck.singleton().makeYellowZoneAvailable();
+        try {
+            DynamicHub hub = Heap.getHeap().getObjectHeader().dynamicHubFromObjectHeader(objectHeader);
+            guaranteeAllocationAllowed("allocateInstance", hub);
+
+            Object result = NativeGCAllocationSupport.singleton().allocateInstance0(hub);
+            return checkForOOME(result);
+        } finally {
+            StackOverflowCheck.singleton().protectYellowZone();
+        }
+    }
+
+    @SubstrateForeignCallTarget(stubCallingConvention = false)
+    @Uninterruptible(reason = "The newly allocated object must be young or all its covered cards must be dirty.")
+    private static Object slowPathNewArray(Word objectHeader, int length) {
+        StackOverflowCheck.singleton().makeYellowZoneAvailable();
+        try {
+            DynamicHub hub = Heap.getHeap().getObjectHeader().dynamicHubFromObjectHeader(objectHeader);
+            guaranteeAllocationAllowed("allocateArray", hub);
+            checkArrayLength(length);
+
+            Object result = NativeGCAllocationSupport.singleton().allocateArray0(length, hub);
+            return checkForOOME(result);
+        } finally {
+            StackOverflowCheck.singleton().protectYellowZone();
+        }
+    }
+
+    @SubstrateForeignCallTarget(stubCallingConvention = false)
+    @Uninterruptible(reason = "The newly allocated object must be young or all its covered cards must be dirty.")
+    private static Object slowPathNewStoredContinuation(Word objectHeader, int length) {
+        StackOverflowCheck.singleton().makeYellowZoneAvailable();
+        try {
+            DynamicHub hub = Heap.getHeap().getObjectHeader().dynamicHubFromObjectHeader(objectHeader);
+            guaranteeAllocationAllowed("allocateStoredContinuation", hub);
+            checkArrayLength(length);
+
+            Object result = NativeGCAllocationSupport.singleton().allocateStoredContinuation0(length, hub);
+            return checkForOOME(result);
+        } finally {
+            StackOverflowCheck.singleton().protectYellowZone();
+        }
+    }
+
+    @SubstrateForeignCallTarget(stubCallingConvention = false)
+    @Uninterruptible(reason = "The newly allocated object must be young or all its covered cards must be dirty.")
+    private static Object slowPathNewPodInstance(Word objectHeader, int length, byte[] referenceMap) {
+        StackOverflowCheck.singleton().makeYellowZoneAvailable();
+        try {
+            DynamicHub hub = Heap.getHeap().getObjectHeader().dynamicHubFromObjectHeader(objectHeader);
+            guaranteeAllocationAllowed("allocatePod", hub);
+            checkArrayLength(length);
+
+            /* The reference map object can live in the Java heap. */
+            podReferenceMapTL.set(referenceMap);
+            Object result = NativeGCAllocationSupport.singleton().allocatePod0(length, hub);
+            podReferenceMapTL.set(null);
+            return checkForOOME(result);
+        } finally {
+            StackOverflowCheck.singleton().protectYellowZone();
+        }
+    }
+
+    @Uninterruptible(reason = "The newly allocated object must be young or all its covered cards must be dirty.", callerMustBe = true, calleeMustBe = false)
+    protected abstract Object allocateInstance0(DynamicHub hub);
+
+    @Uninterruptible(reason = "The newly allocated object must be young or all its covered cards must be dirty.", callerMustBe = true, calleeMustBe = false)
+    protected abstract Object allocateArray0(int length, DynamicHub hub);
+
+    @Uninterruptible(reason = "The newly allocated object must be young or all its covered cards must be dirty.", callerMustBe = true, calleeMustBe = false)
+    protected abstract Object allocateStoredContinuation0(int length, DynamicHub hub);
+
+    @Uninterruptible(reason = "The newly allocated object must be young or all its covered cards must be dirty.", callerMustBe = true, calleeMustBe = false)
+    protected abstract Object allocatePod0(int length, DynamicHub hub);
+
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+    private static void checkArrayLength(int length) {
+        if (probability(VERY_SLOW_PATH_PROBABILITY, length < 0)) {
+            throwNegativeArraySizeExceptionInterruptibly();
+        }
+    }
+
+    @Uninterruptible(reason = "No need to be uninterruptible because no object was allocated.", calleeMustBe = false)
+    private static void throwNegativeArraySizeExceptionInterruptibly() {
+        throwNegativeArraySizeException();
+    }
+
+    private static void throwNegativeArraySizeException() {
+        throw new NegativeArraySizeException();
+    }
+
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+    private static void guaranteeAllocationAllowed(String callSite, DynamicHub hub) {
+        if (probability(VERY_SLOW_PATH_PROBABILITY, Heap.getHeap().isAllocationDisallowed())) {
+            throwAllocationNotAllowedInterruptibly(callSite, hub);
+        }
+    }
+
+    @Uninterruptible(reason = "No need to be uninterruptible because it kills the process.", calleeMustBe = false)
+    private static void throwAllocationNotAllowedInterruptibly(String callSite, DynamicHub hub) {
+        throw NoAllocationVerifier.exit(callSite, DynamicHub.toClass(hub).getName());
+    }
+
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+    private static Object checkForOOME(Object result) {
+        if (probability(VERY_SLOW_PATH_PROBABILITY, result == null)) {
+            throwHeapSizeExceededInterruptibly();
+        }
+        return result;
+    }
+
+    @Uninterruptible(reason = "No need to be uninterruptible because no object was allocated.", calleeMustBe = false)
+    private static void throwHeapSizeExceededInterruptibly() {
+        throw OutOfMemoryUtil.heapSizeExceeded();
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/graal/snippets/GCAllocationSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/graal/snippets/GCAllocationSupport.java
@@ -43,8 +43,6 @@ public interface GCAllocationSupport {
 
     ForeignCallDescriptor getNewDynamicHub();
 
-    boolean useTLAB();
-
     boolean shouldAllocateInTLAB(UnsignedWord size, boolean isArray);
 
     Word getTLABInfo();

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/graal/snippets/SubstrateAllocationSnippets.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/graal/snippets/SubstrateAllocationSnippets.java
@@ -42,6 +42,7 @@ import org.graalvm.word.UnsignedWord;
 
 import com.oracle.svm.configure.ConfigurationFile;
 import com.oracle.svm.core.MissingRegistrationUtils;
+import com.oracle.svm.core.SubstrateGCOptions;
 import com.oracle.svm.core.SubstrateOptions;
 import com.oracle.svm.core.allocationprofile.AllocationCounter;
 import com.oracle.svm.core.allocationprofile.AllocationSite;
@@ -138,31 +139,31 @@ public class SubstrateAllocationSnippets extends AllocationSnippets {
     @Snippet
     protected Object allocateInstance(@NonNullParameter DynamicHub hub,
                     @ConstantParameter long size,
-                    @ConstantParameter boolean forceSlowPath,
+                    @ConstantParameter boolean useTLAB,
                     @ConstantParameter FillContent fillContents,
                     @ConstantParameter boolean emitMemoryBarrier,
                     @ConstantParameter AllocationProfilingData profilingData,
                     @ConstantParameter boolean withException) {
-        Object result = allocateInstanceImpl(encodeAsTLABObjectHeader(hub), Word.unsigned(size), forceSlowPath, fillContents, emitMemoryBarrier, true, profilingData, withException);
+        Object result = allocateInstanceImpl(encodeAsTLABObjectHeader(hub), Word.unsigned(size), useTLAB, fillContents, emitMemoryBarrier, true, profilingData, withException);
         return piCastToSnippetReplaceeStamp(result);
     }
 
     @Snippet
     protected Object allocateInstanceConstantHeader(long objectHeader,
                     @ConstantParameter long size,
-                    @ConstantParameter boolean forceSlowPath,
+                    @ConstantParameter boolean useTLAB,
                     @ConstantParameter FillContent fillContents,
                     @ConstantParameter boolean emitMemoryBarrier,
                     @ConstantParameter AllocationProfilingData profilingData,
                     @ConstantParameter boolean withException) {
-        Object result = allocateInstanceImpl(Word.unsigned(objectHeader), Word.unsigned(size), forceSlowPath, fillContents, emitMemoryBarrier, true, profilingData, withException);
+        Object result = allocateInstanceImpl(Word.unsigned(objectHeader), Word.unsigned(size), useTLAB, fillContents, emitMemoryBarrier, true, profilingData, withException);
         return piCastToSnippetReplaceeStamp(result);
     }
 
     @Snippet
     public Object allocateArray(@NonNullParameter DynamicHub hub,
                     int length,
-                    @ConstantParameter boolean forceSlowPath,
+                    @ConstantParameter boolean useTLAB,
                     @ConstantParameter int arrayBaseOffset,
                     @ConstantParameter int log2ElementSize,
                     @ConstantParameter FillContent fillContents,
@@ -172,7 +173,7 @@ public class SubstrateAllocationSnippets extends AllocationSnippets {
                     @ConstantParameter boolean supportsOptimizedFilling,
                     @ConstantParameter AllocationProfilingData profilingData,
                     @ConstantParameter boolean withException) {
-        Object result = allocateArrayImpl(encodeAsTLABObjectHeader(hub), length, forceSlowPath, arrayBaseOffset, log2ElementSize, fillContents,
+        Object result = allocateArrayImpl(encodeAsTLABObjectHeader(hub), length, useTLAB, arrayBaseOffset, log2ElementSize, fillContents,
                         afterArrayLengthOffset(), emitMemoryBarrier, maybeUnroll, supportsBulkZeroing, supportsOptimizedFilling, profilingData, withException);
         return piArrayCastToSnippetReplaceeStamp(result, length);
     }
@@ -180,7 +181,7 @@ public class SubstrateAllocationSnippets extends AllocationSnippets {
     @Snippet
     public Object allocateArrayConstantHeader(long objectHeader,
                     int length,
-                    @ConstantParameter boolean forceSlowPath,
+                    @ConstantParameter boolean useTLAB,
                     @ConstantParameter int arrayBaseOffset,
                     @ConstantParameter int log2ElementSize,
                     @ConstantParameter FillContent fillContents,
@@ -190,7 +191,7 @@ public class SubstrateAllocationSnippets extends AllocationSnippets {
                     @ConstantParameter boolean supportsOptimizedFilling,
                     @ConstantParameter AllocationProfilingData profilingData,
                     @ConstantParameter boolean withException) {
-        Object result = allocateArrayImpl(Word.unsigned(objectHeader), length, forceSlowPath, arrayBaseOffset, log2ElementSize, fillContents,
+        Object result = allocateArrayImpl(Word.unsigned(objectHeader), length, useTLAB, arrayBaseOffset, log2ElementSize, fillContents,
                         afterArrayLengthOffset(), emitMemoryBarrier, maybeUnroll, supportsBulkZeroing, supportsOptimizedFilling, profilingData, withException);
         return piArrayCastToSnippetReplaceeStamp(result, length);
     }
@@ -198,7 +199,7 @@ public class SubstrateAllocationSnippets extends AllocationSnippets {
     @Snippet
     public Object allocateStoredContinuation(@NonNullParameter DynamicHub hub,
                     int length,
-                    @ConstantParameter boolean forceSlowPath,
+                    @ConstantParameter boolean useTLAB,
                     @ConstantParameter int arrayBaseOffset,
                     @ConstantParameter int log2ElementSize,
                     @ConstantParameter long ipOffset,
@@ -215,7 +216,7 @@ public class SubstrateAllocationSnippets extends AllocationSnippets {
         Word newTop = top.add(allocationSize);
 
         Object result;
-        if (!forceSlowPath && useTLAB() && probability(FAST_PATH_PROBABILITY, shouldAllocateInTLAB(allocationSize, true)) && probability(FAST_PATH_PROBABILITY, newTop.belowOrEqual(end))) {
+        if (useTLAB && probability(FAST_PATH_PROBABILITY, shouldAllocateInTLAB(allocationSize, true)) && probability(FAST_PATH_PROBABILITY, newTop.belowOrEqual(end))) {
             writeTlabTop(thread, newTop);
             emitPrefetchAllocate(newTop, true);
             result = formatStoredContinuation(encodeAsTLABObjectHeader(hub), allocationSize, length, top, emitMemoryBarrier, ipOffset, profilingData.snippetCounters);
@@ -230,7 +231,7 @@ public class SubstrateAllocationSnippets extends AllocationSnippets {
     @Snippet
     public Object allocatePod(@NonNullParameter DynamicHub hub,
                     int arrayLength,
-                    @ConstantParameter boolean forceSlowPath,
+                    @ConstantParameter boolean useTLAB,
                     byte[] referenceMap,
                     @ConstantParameter boolean emitMemoryBarrier,
                     @ConstantParameter boolean maybeUnroll,
@@ -249,7 +250,7 @@ public class SubstrateAllocationSnippets extends AllocationSnippets {
         Word newTop = top.add(allocationSize);
 
         Object result;
-        if (!forceSlowPath && useTLAB() && probability(FAST_PATH_PROBABILITY, shouldAllocateInTLAB(allocationSize, true)) && probability(FAST_PATH_PROBABILITY, newTop.belowOrEqual(end))) {
+        if (useTLAB && probability(FAST_PATH_PROBABILITY, shouldAllocateInTLAB(allocationSize, true)) && probability(FAST_PATH_PROBABILITY, newTop.belowOrEqual(end))) {
             writeTlabTop(thread, newTop);
             emitPrefetchAllocate(newTop, true);
             result = formatPod(encodeAsTLABObjectHeader(hub), hub, allocationSize, arrayLength, referenceMap, top, AllocationSnippets.FillContent.WITH_ZEROES,
@@ -280,28 +281,28 @@ public class SubstrateAllocationSnippets extends AllocationSnippets {
 
     @Snippet
     public Object allocateInstanceDynamic(@NonNullParameter DynamicHub hub,
-                    @ConstantParameter boolean forceSlowPath,
+                    @ConstantParameter boolean useTLAB,
                     @ConstantParameter FillContent fillContents,
                     @ConstantParameter boolean emitMemoryBarrier,
                     @ConstantParameter boolean supportsBulkZeroing,
                     @ConstantParameter boolean supportsOptimizedFilling,
                     @ConstantParameter AllocationProfilingData profilingData,
                     @ConstantParameter boolean withException) {
-        return allocateInstanceDynamicImpl(hub, forceSlowPath, fillContents, emitMemoryBarrier, supportsBulkZeroing, supportsOptimizedFilling, profilingData, withException);
+        return allocateInstanceDynamicImpl(hub, useTLAB, fillContents, emitMemoryBarrier, supportsBulkZeroing, supportsOptimizedFilling, profilingData, withException);
     }
 
-    protected Object allocateInstanceDynamicImpl(DynamicHub hub, boolean forceSlowPath, FillContent fillContents, boolean emitMemoryBarrier, @SuppressWarnings("unused") boolean supportsBulkZeroing,
+    protected Object allocateInstanceDynamicImpl(DynamicHub hub, boolean useTLAB, FillContent fillContents, boolean emitMemoryBarrier, @SuppressWarnings("unused") boolean supportsBulkZeroing,
                     @SuppressWarnings("unused") boolean supportsOptimizedFilling, AllocationProfilingData profilingData, boolean withException) {
         // The hub was already verified by a ValidateNewInstanceClassNode.
         UnsignedWord size = LayoutEncoding.getPureInstanceAllocationSize(hub.getLayoutEncoding());
-        Object result = allocateInstanceImpl(encodeAsTLABObjectHeader(hub), size, forceSlowPath, fillContents, emitMemoryBarrier, false, profilingData, withException);
+        Object result = allocateInstanceImpl(encodeAsTLABObjectHeader(hub), size, useTLAB, fillContents, emitMemoryBarrier, false, profilingData, withException);
         return piCastToSnippetReplaceeStamp(result);
     }
 
     @Snippet
     public Object allocateArrayDynamic(DynamicHub elementType,
                     int length,
-                    @ConstantParameter boolean forceSlowPath,
+                    @ConstantParameter boolean useTLAB,
                     @ConstantParameter FillContent fillContents,
                     @ConstantParameter boolean emitMemoryBarrier,
                     @ConstantParameter boolean supportsBulkZeroing,
@@ -314,7 +315,7 @@ public class SubstrateAllocationSnippets extends AllocationSnippets {
         int arrayBaseOffset = getArrayBaseOffset(layoutEncoding);
         int log2ElementSize = LayoutEncoding.getArrayIndexShift(layoutEncoding);
 
-        Object result = allocateArrayImpl(encodeAsTLABObjectHeader(checkedArrayHub), length, forceSlowPath, arrayBaseOffset, log2ElementSize, fillContents,
+        Object result = allocateArrayImpl(encodeAsTLABObjectHeader(checkedArrayHub), length, useTLAB, arrayBaseOffset, log2ElementSize, fillContents,
                         arrayBaseOffset, emitMemoryBarrier, false, supportsBulkZeroing, supportsOptimizedFilling, profilingData, withException);
 
         return piArrayCastToSnippetReplaceeStamp(result, length);
@@ -587,11 +588,6 @@ public class SubstrateAllocationSnippets extends AllocationSnippets {
     }
 
     @Override
-    public boolean useTLAB() {
-        return gcAllocationSupport().useTLAB();
-    }
-
-    @Override
     protected boolean shouldAllocateInTLAB(UnsignedWord size, boolean isArray) {
         return gcAllocationSupport().shouldAllocateInTLAB(size, isArray);
     }
@@ -804,8 +800,17 @@ public class SubstrateAllocationSnippets extends AllocationSnippets {
             return allocationSite.createCounter(counterName);
         }
 
-        private static boolean shouldForceSlowPath(StructuredGraph graph) {
-            return GraalOptions.ReduceCodeSize.getValue(graph.getOptions());
+        public static boolean shouldUseTLAB(StructuredGraph graph) {
+            Boolean useTLAB = SubstrateGCOptions.UseTLAB.getValue();
+            if (useTLAB != null) {
+                return useTLAB;
+            }
+
+            /*
+             * Use a TLAB by default, except when we optimize for code size or when we do an image
+             * build for a non-native platform.
+             */
+            return !GraalOptions.ReduceCodeSize.getValue(graph.getOptions());
         }
 
         private final class NewInstanceLowering implements NodeLoweringProvider<FixedNode> {
@@ -849,7 +854,7 @@ public class SubstrateAllocationSnippets extends AllocationSnippets {
                 }
 
                 args.add("size", size);
-                args.add("forceSlowPath", shouldForceSlowPath(graph));
+                args.add("useTLAB", shouldUseTLAB(graph));
                 args.add("fillContents", FillContent.fromBoolean(fillContents));
                 args.add("emitMemoryBarrier", emitMemoryBarrier);
                 args.add("profilingData", getProfilingData(node, type));
@@ -881,7 +886,7 @@ public class SubstrateAllocationSnippets extends AllocationSnippets {
                 Arguments args = new Arguments(allocateArray, graph.getGuardsStage(), tool.getLoweringStage());
                 args.add("hub", hubConstant);
                 args.add("length", length.isAlive() ? length : graph.addOrUniqueWithInputs(length));
-                args.add("forceSlowPath", shouldForceSlowPath(graph));
+                args.add("useTLAB", shouldUseTLAB(graph));
                 args.add("arrayBaseOffset", arrayBaseOffset);
                 args.add("log2ElementSize", log2ElementSize);
                 args.add("fillContents", FillContent.fromBoolean(fillContents));
@@ -916,7 +921,7 @@ public class SubstrateAllocationSnippets extends AllocationSnippets {
                 Arguments args = new Arguments(allocateStoredContinuation, graph.getGuardsStage(), tool.getLoweringStage());
                 args.add("hub", hubConstant);
                 args.add("length", length.isAlive() ? length : graph.addOrUniqueWithInputs(length));
-                args.add("forceSlowPath", shouldForceSlowPath(graph));
+                args.add("useTLAB", shouldUseTLAB(graph));
                 args.add("arrayBaseOffset", arrayBaseOffset);
                 args.add("log2ElementSize", log2ElementSize);
                 args.add("ipOffset", ContinuationSupport.singleton().getIPOffset());
@@ -973,7 +978,7 @@ public class SubstrateAllocationSnippets extends AllocationSnippets {
                 }
 
                 args.add("length", length.isAlive() ? length : graph.addOrUniqueWithInputs(length));
-                args.add("forceSlowPath", shouldForceSlowPath(graph));
+                args.add("useTLAB", shouldUseTLAB(graph));
                 args.add("arrayBaseOffset", arrayBaseOffset);
                 args.add("log2ElementSize", log2ElementSize);
                 args.add("fillContents", FillContent.fromBoolean(fillContents));
@@ -1052,7 +1057,7 @@ public class SubstrateAllocationSnippets extends AllocationSnippets {
 
                 Arguments args = new Arguments(allocateInstanceDynamic, graph.getGuardsStage(), tool.getLoweringStage());
                 args.add("hub", node.getInstanceType());
-                args.add("forceSlowPath", shouldForceSlowPath(graph));
+                args.add("useTLAB", shouldUseTLAB(graph));
                 args.add("fillContents", FillContent.fromBoolean(node.fillContents()));
                 args.add("emitMemoryBarrier", node.emitMemoryBarrier());
                 args.add("supportsBulkZeroing", tool.getLowerer().supportsBulkZeroingOfEden());
@@ -1074,7 +1079,7 @@ public class SubstrateAllocationSnippets extends AllocationSnippets {
 
                 Arguments args = new Arguments(allocateInstanceDynamic, graph.getGuardsStage(), tool.getLoweringStage());
                 args.add("hub", node.getInstanceType());
-                args.add("forceSlowPath", shouldForceSlowPath(graph));
+                args.add("useTLAB", shouldUseTLAB(graph));
                 args.add("fillContents", FillContent.fromBoolean(true));
                 args.add("emitMemoryBarrier", true/* barriers */);
                 args.add("supportsBulkZeroing", tool.getLowerer().supportsBulkZeroingOfEden());
@@ -1097,7 +1102,7 @@ public class SubstrateAllocationSnippets extends AllocationSnippets {
                 Arguments args = new Arguments(allocateArrayDynamic, graph.getGuardsStage(), tool.getLoweringStage());
                 args.add("elementType", node.getElementType());
                 args.add("length", node.length());
-                args.add("forceSlowPath", shouldForceSlowPath(graph));
+                args.add("useTLAB", shouldUseTLAB(graph));
                 args.add("fillContents", FillContent.fromBoolean(node.fillContents()));
                 args.add("emitMemoryBarrier", node.emitMemoryBarrier());
                 args.add("supportsBulkZeroing", tool.getLowerer().supportsBulkZeroingOfEden());
@@ -1120,7 +1125,7 @@ public class SubstrateAllocationSnippets extends AllocationSnippets {
                 Arguments args = new Arguments(allocateArrayDynamic, graph.getGuardsStage(), tool.getLoweringStage());
                 args.add("elementType", node.getElementType());
                 args.add("length", node.length());
-                args.add("forceSlowPath", shouldForceSlowPath(graph));
+                args.add("useTLAB", shouldUseTLAB(graph));
                 args.add("fillContents", FillContent.fromBoolean(true));
                 args.add("emitMemoryBarrier", true/* barriers */);
                 args.add("supportsBulkZeroing", tool.getLowerer().supportsBulkZeroingOfEden());
@@ -1159,7 +1164,7 @@ public class SubstrateAllocationSnippets extends AllocationSnippets {
                 Arguments args = new Arguments(allocatePod, graph.getGuardsStage(), tool.getLoweringStage());
                 args.add("hub", node.getHub());
                 args.add("arrayLength", node.getArrayLength());
-                args.add("forceSlowPath", shouldForceSlowPath(graph));
+                args.add("useTLAB", shouldUseTLAB(graph));
                 args.add("referenceMap", node.getReferenceMap());
                 args.add("emitMemoryBarrier", node.emitMemoryBarrier());
                 args.add("maybeUnroll", node.getArrayLength().isConstant());

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/graal/snippets/SubstrateAllocationSnippets.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/graal/snippets/SubstrateAllocationSnippets.java
@@ -43,6 +43,7 @@ import org.graalvm.word.UnsignedWord;
 import com.oracle.svm.configure.ConfigurationFile;
 import com.oracle.svm.core.MissingRegistrationUtils;
 import com.oracle.svm.core.SubstrateGCOptions;
+import com.oracle.svm.core.SubstrateGCOptions.TLABPolicy;
 import com.oracle.svm.core.SubstrateOptions;
 import com.oracle.svm.core.allocationprofile.AllocationCounter;
 import com.oracle.svm.core.allocationprofile.AllocationSite;
@@ -802,14 +803,21 @@ public class SubstrateAllocationSnippets extends AllocationSnippets {
 
         public static boolean shouldUseTLAB(StructuredGraph graph) {
             Boolean useTLAB = SubstrateGCOptions.UseTLAB.getValue();
-            if (useTLAB != null) {
-                return useTLAB;
+            if (!useTLAB) {
+                /* Never use a TLAB. */
+                return false;
+            }
+
+            TLABPolicy policy = SubstrateGCOptions.TLABUsagePolicy.getValue();
+            if (policy == TLABPolicy.Always) {
+                return true;
             }
 
             /*
              * Use a TLAB by default, except when we optimize for code size or when we do an image
              * build for a non-native platform.
              */
+            assert policy == TLABPolicy.Auto;
             return !GraalOptions.ReduceCodeSize.getValue(graph.getOptions());
         }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/Heap.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/Heap.java
@@ -41,7 +41,7 @@ import com.oracle.svm.core.hub.DynamicHub;
 import com.oracle.svm.core.hub.PredefinedClassesSupport;
 import com.oracle.svm.core.identityhashcode.IdentityHashCodeSupport;
 import com.oracle.svm.core.log.Log;
-import com.oracle.svm.core.option.RuntimeOptionKey;
+import com.oracle.svm.core.option.NotifyGCRuntimeOptionKey;
 import com.oracle.svm.core.snippets.KnownIntrinsics;
 
 import jdk.graal.compiler.api.replacements.Fold;
@@ -222,7 +222,7 @@ public abstract class Heap {
     /**
      * Notify the GC that the value of a GC-relevant option changed.
      */
-    public abstract void optionValueChanged(RuntimeOptionKey<?> key);
+    public abstract void optionValueChanged(NotifyGCRuntimeOptionKey<?> key);
 
     /**
      * Returns the number of bytes that were allocated by the given thread. The caller of this

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/option/HostedOptionKey.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/option/HostedOptionKey.java
@@ -24,14 +24,17 @@
  */
 package com.oracle.svm.core.option;
 
+import java.util.function.Consumer;
+
+import org.graalvm.collections.EconomicMap;
+
 import com.oracle.svm.common.option.LocatableOption;
 import com.oracle.svm.common.option.MultiOptionValue;
-import org.graalvm.collections.EconomicMap;
+import com.oracle.svm.core.collections.EnumBitmask;
+
 import jdk.graal.compiler.api.replacements.Fold;
 import jdk.graal.compiler.options.Option;
 import jdk.graal.compiler.options.OptionKey;
-
-import java.util.function.Consumer;
 
 /**
  * Defines a hosted {@link Option} that is used during native image generation, in contrast to a
@@ -41,15 +44,21 @@ import java.util.function.Consumer;
  */
 public class HostedOptionKey<T> extends OptionKey<T> implements SubstrateOptionKey<T> {
     private final Consumer<HostedOptionKey<T>> validation;
+    private final int flags;
     private OptionOrigin lastOrigin;
 
-    public HostedOptionKey(T defaultValue) {
-        this(defaultValue, null);
+    public HostedOptionKey(T defaultValue, HostedOptionKeyFlag... flags) {
+        this(defaultValue, null, flags);
     }
 
-    public HostedOptionKey(T defaultValue, Consumer<HostedOptionKey<T>> validation) {
+    public HostedOptionKey(T defaultValue, Consumer<HostedOptionKey<T>> validation, HostedOptionKeyFlag... flags) {
         super(defaultValue);
         this.validation = validation;
+        this.flags = EnumBitmask.computeBitmask(flags);
+    }
+
+    public boolean shouldPassToNativeGC() {
+        return !EnumBitmask.hasBit(flags, HostedOptionKeyFlag.DoNotPassToNativeGC);
     }
 
     /**
@@ -110,5 +119,10 @@ public class HostedOptionKey<T> extends OptionKey<T> implements SubstrateOptionK
 
     public OptionOrigin getLastOrigin() {
         return lastOrigin;
+    }
+
+    public enum HostedOptionKeyFlag {
+        /** If this flag is set, then the option value is not passed to native GCs like G1. */
+        DoNotPassToNativeGC,
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/option/NotifyGCRuntimeOptionKey.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/option/NotifyGCRuntimeOptionKey.java
@@ -24,10 +24,10 @@
  */
 package com.oracle.svm.core.option;
 
+import java.util.function.Consumer;
+
 import com.oracle.svm.core.SubstrateUtil;
 import com.oracle.svm.core.heap.Heap;
-
-import java.util.function.Consumer;
 
 /**
  * Notifies the {@link Heap} implementation after the value of the option has changed.

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/RecurringCallbackSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/RecurringCallbackSupport.java
@@ -36,7 +36,6 @@ import org.graalvm.nativeimage.Threading.RecurringCallbackAccess;
 
 import com.oracle.svm.core.Uninterruptible;
 import com.oracle.svm.core.heap.RestrictHeapAccess;
-import com.oracle.svm.core.jdk.UninterruptibleUtils;
 import com.oracle.svm.core.jfr.sampler.JfrRecurringCallbackExecutionSampler;
 import com.oracle.svm.core.option.HostedOptionKey;
 import com.oracle.svm.core.threadlocal.FastThreadLocalFactory;
@@ -189,8 +188,14 @@ public class RecurringCallbackSupport {
         if (!isCallbackTimerSuspended()) {
             RecurringCallbackTimer timer = timerTL.get();
             if (timer != null) {
-                timer.updateStatistics();
-                timer.setCounter(1);
+                long nowNanos = System.nanoTime();
+                /*
+                 * A lot of time can have passed since callbacks were suspended. Update the
+                 * statistics and the counter so that the callback can trigger at the next safepoint
+                 * if necessary.
+                 */
+                timer.updateStatistics(nowNanos);
+                timer.updateCounter(nowNanos);
             }
         }
     }
@@ -253,6 +258,8 @@ public class RecurringCallbackSupport {
     }
 
     /**
+     * Instances of this class are always only used by a single thread.
+     *
      * The timer starts with an initial {@link #INITIAL_CHECKS number of safepoint check operations}
      * for the interval and then measures how frequently check operations occur to determine the
      * period of check operations for the requested time intervals. The timer uses an exponentially
@@ -270,7 +277,6 @@ public class RecurringCallbackSupport {
         private static final double EWMA_LAMBDA = 0.3;
         private static final double TARGET_INTERVAL_FLEXIBILITY = 0.95;
         private static final int INITIAL_CHECKS = 100;
-        private static final long MINIMUM_INTERVAL_NANOS = 1_000;
 
         private final long targetIntervalNanos;
         private final long flexibleTargetIntervalNanos;
@@ -278,19 +284,25 @@ public class RecurringCallbackSupport {
 
         private int requestedChecks;
         private double ewmaChecksPerNano;
-        private long lastCapture;
-        private long lastCallbackExecution;
+        private long lastCaptureNanos;
+        private long lastCallbackExecutionNanos;
 
-        private volatile boolean isExecuting = false;
+        /**
+         * This field does not need to be volatile because it is only used by a single thread and
+         * only modified in uninterruptible code to prevent recursive recurring callback invocation.
+         * As recurring callbacks can only be invoked at safepoint checks, there is never the risk
+         * that we see a stale value because of read elimination.
+         */
+        private boolean isExecuting = false;
 
         RecurringCallbackTimer(long targetIntervalNanos, RecurringCallback callback) {
-            this.targetIntervalNanos = Math.max(MINIMUM_INTERVAL_NANOS, targetIntervalNanos);
+            this.targetIntervalNanos = targetIntervalNanos;
             this.flexibleTargetIntervalNanos = (long) (targetIntervalNanos * TARGET_INTERVAL_FLEXIBILITY);
             this.callback = callback;
 
-            long now = System.nanoTime();
-            this.lastCapture = now;
-            this.lastCallbackExecution = now;
+            long nowNanos = System.nanoTime();
+            this.lastCaptureNanos = nowNanos;
+            this.lastCallbackExecutionNanos = nowNanos;
             this.requestedChecks = INITIAL_CHECKS;
         }
 
@@ -304,18 +316,14 @@ public class RecurringCallbackSupport {
 
         @Uninterruptible(reason = "Must not contain safepoint checks.")
         void evaluate() {
-            updateStatistics();
-            try {
-                maybeExecuteCallback();
-            } finally {
-                updateCounter();
-            }
+            long nowNanos = System.nanoTime();
+            updateStatistics(nowNanos);
+            maybeExecuteCallback(nowNanos);
         }
 
         @Uninterruptible(reason = "Must be uninterruptible to avoid races with the safepoint code.")
-        void updateStatistics() {
-            long now = System.nanoTime();
-            long elapsedNanos = now - lastCapture;
+        void updateStatistics(long nowNanos) {
+            long elapsedNanos = nowNanos - lastCaptureNanos;
 
             int skippedChecks = getSkippedChecks(CurrentIsolate.getCurrentThread());
             int executedChecks = requestedChecks - skippedChecks;
@@ -327,7 +335,7 @@ public class RecurringCallbackSupport {
                 } else {
                     ewmaChecksPerNano = EWMA_LAMBDA * checksPerNano + (1 - EWMA_LAMBDA) * ewmaChecksPerNano;
                 }
-                lastCapture = now;
+                lastCaptureNanos = nowNanos;
             }
         }
 
@@ -338,44 +346,51 @@ public class RecurringCallbackSupport {
         }
 
         @Uninterruptible(reason = "Must not contain safepoint checks.")
-        private void maybeExecuteCallback() {
-            if (isCallbackDisabled()) {
+        private void maybeExecuteCallback(long nowNanos) {
+            if (!shouldExecute(nowNanos)) {
+                updateCounter(nowNanos);
                 return;
             }
 
-            isExecuting = true;
+            /*
+             * Before executing the callback, reset the safepoint requested counter as we don't want
+             * to trigger another callback execution in the near future. Note that we already called
+             * updateStatistics() in the caller, so this doesn't skew the recurring callback
+             * statistics.
+             *
+             * Recurring callbacks typically execute VM-internal code that performs hardly any
+             * safepoint checks. The number of performed safepoint checks can be very different from
+             * the application code. Therefore, we explicitly don't update the recurring callback
+             * statistics anywhere in this method as this could skew the numbers.
+             */
+            setCounter(SafepointCheckCounter.MAX_VALUE);
             try {
+                invokeCallback();
                 /*
-                 * Allow the callback to trigger a bit early - otherwise, it can happen that we
-                 * enter the slowpath multiple times while closing in on the deadline.
+                 * The callback is allowed to throw an exception (e.g., to stop or interrupt
+                 * long-running code). All code that must run to reinitialize the recurring callback
+                 * state must therefore be in a finally-block.
                  */
-                if (System.nanoTime() >= lastCallbackExecution + flexibleTargetIntervalNanos) {
-                    /*
-                     * Before executing the callback, reset the safepoint requested counter as we
-                     * don't want to trigger another callback execution in the near future.
-                     */
-                    setCounter(SafepointCheckCounter.MAX_VALUE);
-                    try {
-                        invokeCallback();
-                        /*
-                         * The callback is allowed to throw an exception (e.g., to stop or interrupt
-                         * long-running code). All code that must run to reinitialize the recurring
-                         * callback state must therefore be in a finally-block.
-                         */
-                    } finally {
-                        lastCallbackExecution = System.nanoTime();
-                        updateStatistics();
-                    }
-                }
             } finally {
-                isExecuting = false;
+                long afterNanos = System.nanoTime();
+                lastCallbackExecutionNanos = afterNanos;
+                updateCounter(afterNanos);
             }
         }
 
         @Uninterruptible(reason = "Must not contain safepoint checks.")
-        private void updateCounter() {
-            long nextDeadline = lastCallbackExecution + targetIntervalNanos;
-            long remainingNanos = nextDeadline - System.nanoTime();
+        private boolean shouldExecute(long nowNanos) {
+            /*
+             * Allow the callback to trigger a bit early - otherwise, it can happen that we enter
+             * the slowpath many times while closing in on the deadline.
+             */
+            return !isCallbackDisabled() && nowNanos >= lastCallbackExecutionNanos + flexibleTargetIntervalNanos;
+        }
+
+        @Uninterruptible(reason = "Must not contain safepoint checks.")
+        private void updateCounter(long nowNanos) {
+            long nextDeadline = lastCallbackExecutionNanos + targetIntervalNanos;
+            long remainingNanos = nextDeadline - nowNanos;
             if (remainingNanos < 0 && isCallbackDisabled()) {
                 /*
                  * If we are already behind the deadline and recurring callbacks are disabled for
@@ -385,9 +400,9 @@ public class RecurringCallbackSupport {
                  */
                 setCounter(SafepointCheckCounter.MAX_VALUE);
             } else {
-                remainingNanos = UninterruptibleUtils.Math.max(remainingNanos, MINIMUM_INTERVAL_NANOS);
                 double checks = ewmaChecksPerNano * remainingNanos;
-                setCounter(checks > SafepointCheckCounter.MAX_VALUE ? SafepointCheckCounter.MAX_VALUE : ((checks < 1) ? 1 : (int) checks));
+                int value = checks > SafepointCheckCounter.MAX_VALUE ? SafepointCheckCounter.MAX_VALUE : ((checks < 1) ? 1 : (int) checks);
+                setCounter(value);
             }
         }
 
@@ -410,6 +425,11 @@ public class RecurringCallbackSupport {
         @Uninterruptible(reason = "Required by caller, but does not apply to callee.", calleeMustBe = false)
         @RestrictHeapAccess(reason = "Recurring callbacks must not allocate.", access = NO_ALLOCATION)
         private void invokeCallback() {
+            /*
+             * The callback that is invoked below may contain interruptible code. So, we explicitly
+             * need to prevent recursive recurring callback invocations.
+             */
+            isExecuting = true;
             try {
                 callback.run(CALLBACK_ACCESS);
             } catch (SafepointException e) {
@@ -421,6 +441,8 @@ public class RecurringCallbackSupport {
                  * We cannot even log the exception because that could lead to a StackOverflowError
                  * (especially when the recurring callback failed with a StackOverflowError).
                  */
+            } finally {
+                isExecuting = false;
             }
         }
 

--- a/web-image/src/com.oracle.svm.hosted.webimage/src/com/oracle/svm/hosted/webimage/NativeImageWasmGeneratorRunner.java
+++ b/web-image/src/com.oracle.svm.hosted.webimage/src/com/oracle/svm/hosted/webimage/NativeImageWasmGeneratorRunner.java
@@ -36,6 +36,7 @@ import org.graalvm.nativeimage.c.type.CShortPointer;
 
 import com.oracle.graal.pointsto.util.TimerCollection;
 import com.oracle.svm.core.JavaMainWrapper;
+import com.oracle.svm.core.SubstrateGCOptions;
 import com.oracle.svm.core.SubstrateOptions;
 import com.oracle.svm.core.option.ReplacingLocatableMultiOptionValue;
 import com.oracle.svm.core.util.ExitStatus;
@@ -136,6 +137,7 @@ public class NativeImageWasmGeneratorRunner extends NativeImageGeneratorRunner {
 
         // We do not need to compile a GC because the JavaScript environment provides one.
         optionProvider.getHostedValues().put(SubstrateOptions.SupportedGCs, ReplacingLocatableMultiOptionValue.DelimitedString.buildWithCommaDelimiter());
+        optionProvider.getHostedValues().put(SubstrateGCOptions.UseTLAB, false);
 
         // Forcibly turn off CAnnotation processor cache
         optionProvider.getHostedValues().put(CAnnotationProcessorCache.Options.UseCAPCache, false);

--- a/web-image/src/com.oracle.svm.hosted.webimage/src/com/oracle/svm/hosted/webimage/wasm/gc/WasmHeap.java
+++ b/web-image/src/com.oracle.svm.hosted.webimage/src/com/oracle/svm/hosted/webimage/wasm/gc/WasmHeap.java
@@ -49,7 +49,7 @@ import com.oracle.svm.core.heap.ObjectVisitor;
 import com.oracle.svm.core.heap.RestrictHeapAccess;
 import com.oracle.svm.core.heap.RuntimeCodeInfoGCSupport;
 import com.oracle.svm.core.log.Log;
-import com.oracle.svm.core.option.RuntimeOptionKey;
+import com.oracle.svm.core.option.NotifyGCRuntimeOptionKey;
 import com.oracle.svm.core.thread.VMOperation;
 import com.oracle.svm.core.thread.VMThreads.SafepointBehavior;
 import com.oracle.svm.core.util.VMError;
@@ -334,7 +334,7 @@ public class WasmHeap extends Heap {
     }
 
     @Override
-    public void optionValueChanged(RuntimeOptionKey<?> key) {
+    public void optionValueChanged(NotifyGCRuntimeOptionKey<?> key) {
         // Nothing to do
     }
 

--- a/web-image/src/com.oracle.svm.hosted.webimage/src/com/oracle/svm/hosted/webimage/wasm/gc/WasmLMAllocationSupport.java
+++ b/web-image/src/com.oracle.svm.hosted.webimage/src/com/oracle/svm/hosted/webimage/wasm/gc/WasmLMAllocationSupport.java
@@ -73,12 +73,6 @@ public class WasmLMAllocationSupport implements GCAllocationSupport {
         throw GraalError.unimplementedOverride(); // ExcludeFromJacocoGeneratedReport
     }
 
-    @Override
-    public boolean useTLAB() {
-        return false;
-    }
-
-    @Override
     public boolean shouldAllocateInTLAB(UnsignedWord size, boolean isArray) {
         throw GraalError.unimplementedOverride(); // ExcludeFromJacocoGeneratedReport
     }

--- a/web-image/src/com.oracle.svm.webimage/src/com/oracle/svm/webimage/heap/WebImageJSHeap.java
+++ b/web-image/src/com.oracle.svm.webimage/src/com/oracle/svm/webimage/heap/WebImageJSHeap.java
@@ -41,7 +41,7 @@ import com.oracle.svm.core.heap.ObjectHeader;
 import com.oracle.svm.core.heap.ObjectVisitor;
 import com.oracle.svm.core.heap.RuntimeCodeInfoGCSupport;
 import com.oracle.svm.core.log.Log;
-import com.oracle.svm.core.option.RuntimeOptionKey;
+import com.oracle.svm.core.option.NotifyGCRuntimeOptionKey;
 import com.oracle.svm.core.util.VMError;
 
 import jdk.graal.compiler.word.Word;
@@ -204,7 +204,7 @@ public class WebImageJSHeap extends Heap {
     }
 
     @Override
-    public void optionValueChanged(RuntimeOptionKey<?> key) {
+    public void optionValueChanged(NotifyGCRuntimeOptionKey<?> key) {
     }
 
     @Override

--- a/web-image/src/com.oracle.svm.webimage/src/com/oracle/svm/webimage/heap/WebImageNopAllocationSupport.java
+++ b/web-image/src/com.oracle.svm.webimage/src/com/oracle/svm/webimage/heap/WebImageNopAllocationSupport.java
@@ -69,11 +69,6 @@ public class WebImageNopAllocationSupport implements GCAllocationSupport {
     }
 
     @Override
-    public boolean useTLAB() {
-        throw GraalError.unimplementedOverride();
-    }
-
-    @Override
     public boolean shouldAllocateInTLAB(UnsignedWord size, boolean isArray) {
         throw GraalError.unimplementedOverride();
     }


### PR DESCRIPTION
# Summary

This PR backports the following commits:

(oracle/graal@34364c0)
(oracle/graal@5e5d98f)
(oracle/graal@a107990)
(oracle/graal@4873ef6)
(oracle/graal@333471d)
(oracle/graal@40b566f)
(oracle/graal@70f997d)
(oracle/graal@d1285aa)
(oracle/graal@811cf88)

Closes: [#33](https://github.com/graalvm/graalvm-community-jdk25u/issues/33)

# Merge conflicts

There were quite a few, as there are other commits in the upstream history that haven't been backported.

## cherry-pick 40b566f

### conflicts
imports, code refactoring:

```substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AbstractCollectionPolicy.java
substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AdaptiveCollectionPolicy.java
substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapImpl.java
```

## cherry-pick 4873ef6

retain `public SubstrateForeignCallDescriptor getNewDynamicHub()`
```substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/graal/GenScavengeAllocationSupport.java```

added gc options `UseTLAB` and `ResizeTLAB` from `HEAD` to general section; removed from class `TlabOptions`
```substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateGCOptions.java```


remove `public static void ConfigureOs`, add `public static void configureOptimizeForCodeSize`
removed code related to [cold method alignment](https://github.com/oracle/graal/commit/444a542e15385e6fbc9fdf7ae43cccedf5d7c77d), which is not part of this ticket
```substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java```

added files back:
```
        substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/gc/shared/NativeGCOptions.java
        substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/gc/shared/graal/NativeGCAllocationSupport.java
```

removed `useTLAB()`, kept `ForeignCallDescriptor getNewDynamicHub();` from `HEAD`.
```substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/graal/snippets/GCAllocationSupport.java
web-image/src/com.oracle.svm.hosted.webimage/src/com/oracle/svm/hosted/webimage/wasm/gc/WasmLMAllocationSupport.java
web-image/src/com.oracle.svm.webimage/src/com/oracle/svm/webimage/heap/WebImageNopAllocationSupport.java
```


## cherry-pick a107990

### substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateGCOptions.java
spacing.


### substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/option/HostedOptionKey.java
eschew renaming the field `Consumer<HostedOptionKey<T>> validation` to `buildTimeValidation`, which is done in https://github.com/oracle/graal/commit/8b54a794b9141b78deb40f2e06ae161747ff1800


## cherry-pick 5e5d98f

### substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/RecurringCallbackSupport.java
took change deleting section of `maybeExecuteCallback`

## fixups after cherry-picking all commits except `f8b9f7a`

### substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapImpl.java

metaspace code hasn't been merged from upstream:
```
// removed this code related to metaspace, which comes from this commit: https://github.com/oracle/graal/commit/b5caff6ea0c74fd379eb022551fd560f5ca90248
        if (Metaspace.isSupported()) {
            MetaspaceImpl.singleton().tearDown();
        }
```

### substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java

```
// added missing import
import jdk.graal.compiler.asm.amd64.AMD64Assembler;

altered case statements in switch statement variable bindings to work with java 21 code (bind to a legal name, i.e. `_x` instead of `_`)
```


## substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/graal/snippets/GCAllocationSupport.java

removed `boolean useTLAB();` from interface `GCAllocationSupport`

---

# Testing

Passes GHA `GraalVM Gate`.

## mx --primary-suite=vm unittest

[issue-33 commit](https://github.com/synecdoche/graalvm-community-jdk25u/commit/d83271aec8c655a895af17d2f990bb1175650f48)
```
Time: 387.007

OK (14287 tests)


10 longest running test classes after running 610 of 618 classes:
     41,786 ms    com.oracle.truffle.api.test.polyglot.PolyglotCachingTest
     37,114 ms    com.oracle.truffle.api.bytecode.test.basic_interpreter.BasicInterpreterTest
     35,651 ms    com.oracle.truffle.api.test.polyglot.PolyglotGCTest
     33,591 ms    org.graalvm.collections.test.LockFreePrefixTreeTest
     23,812 ms    com.oracle.truffle.api.staticobject.test.InheritanceTest
     23,707 ms    com.oracle.truffle.api.test.polyglot.ContextAPITest
     20,321 ms    com.oracle.truffle.api.bytecode.test.basic_interpreter.VariadicTest
     18,720 ms    com.oracle.truffle.api.strings.test.ops.TStringSwitchEncodingTest
     14,628 ms    com.oracle.truffle.api.strings.test.builder.TStringBuilderAppendSubStringTest
     12,966 ms    com.oracle.truffle.api.dsl.test.NeverDefaultTest
10 longest running tests:
     29,416 ms    testEngineStrongContextFree(com.oracle.truffle.api.test.polyglot.PolyglotCachingTest)
     14,970 ms    largeMultiThreadedPool(org.graalvm.collections.test.LockFreePrefixTreeTest)
      9,602 ms    testAll[TruffleStringFactory.SwitchEncodingNodeGen@1a6c1270, MutableTruffleStringFactory.SwitchEncodingNodeGen@18a136ac](com.oracle.truffle.api.strings.test.ops.TStringSwitchEncodingTest)
      9,255 ms    testGetCurrentContextEnteredRaceCondition(com.oracle.truffle.api.test.polyglot.ContextAPITest)
      9,112 ms    testAll[TruffleStringFactory.SwitchEncodingNodeGen.Uncached@77d67cf3, MutableTruffleStringFactory.SwitchEncodingNodeGen.Uncached@6dee4f1b](com.oracle.truffle.api.strings.test.ops.TStringSwitchEncodingTest)
      9,079 ms    testGetCurrentContextNotEnteredRaceCondition(com.oracle.truffle.api.test.polyglot.ContextAPITest)
      7,693 ms    testAll[TruffleStringBuilderFactory.AppendSubstringByteIndexNodeGen@1f760b47](com.oracle.truffle.api.strings.test.builder.TStringBuilderAppendSubStringTest)
      7,102 ms    testFromByteArray(com.oracle.truffle.api.strings.test.TStringConstructorTests)
      6,893 ms    deepHashMultiThreadedPool(org.graalvm.collections.test.LockFreePrefixTreeTest)
      6,364 ms    testAll[TruffleStringBuilderFactory.AppendSubstringByteIndexNodeGen.Uncached@18ece7f4](com.oracle.truffle.api.strings.test.builder.TStringBuilderAppendSubStringTest)
```

[graalvm-community-jdk25u/master](https://github.com/graalvm/graalvm-community-jdk25u/commit/2f3fbb1aa8ad73294febf299e2fb9e0c082dad9d)
```
Time: 386.198

OK (14287 tests)


10 longest running test classes after running 610 of 618 classes:
     41,897 ms    com.oracle.truffle.api.test.polyglot.PolyglotCachingTest
     38,587 ms    com.oracle.truffle.api.bytecode.test.basic_interpreter.BasicInterpreterTest
     36,287 ms    com.oracle.truffle.api.test.polyglot.PolyglotGCTest
     33,994 ms    org.graalvm.collections.test.LockFreePrefixTreeTest
     24,888 ms    com.oracle.truffle.api.test.polyglot.ContextAPITest
     22,040 ms    com.oracle.truffle.api.staticobject.test.InheritanceTest
     20,001 ms    com.oracle.truffle.api.bytecode.test.basic_interpreter.VariadicTest
     18,697 ms    com.oracle.truffle.api.strings.test.ops.TStringSwitchEncodingTest
     14,626 ms    com.oracle.truffle.api.strings.test.builder.TStringBuilderAppendSubStringTest
     11,533 ms    com.oracle.truffle.api.dsl.test.NeverDefaultTest
10 longest running tests:
     29,588 ms    testEngineStrongContextFree(com.oracle.truffle.api.test.polyglot.PolyglotCachingTest)
     14,634 ms    largeMultiThreadedPool(org.graalvm.collections.test.LockFreePrefixTreeTest)
      9,974 ms    testGetCurrentContextEnteredRaceCondition(com.oracle.truffle.api.test.polyglot.ContextAPITest)
      9,560 ms    testAll[TruffleStringFactory.SwitchEncodingNodeGen@1a6c1270, MutableTruffleStringFactory.SwitchEncodingNodeGen@18a136ac](com.oracle.truffle.api.strings.test.ops.TStringSwitchEncodingTest)
      9,379 ms    testGetCurrentContextNotEnteredRaceCondition(com.oracle.truffle.api.test.polyglot.ContextAPITest)
      9,131 ms    testAll[TruffleStringFactory.SwitchEncodingNodeGen.Uncached@77d67cf3, MutableTruffleStringFactory.SwitchEncodingNodeGen.Uncached@6dee4f1b](com.oracle.truffle.api.strings.test.ops.TStringSwitchEncodingTest)
      8,406 ms    deepHashMultiThreadedPool(org.graalvm.collections.test.LockFreePrefixTreeTest)
      7,490 ms    testAll[TruffleStringBuilderFactory.AppendSubstringByteIndexNodeGen@1f760b47](com.oracle.truffle.api.strings.test.builder.TStringBuilderAppendSubStringTest)
      7,002 ms    testFromByteArray(com.oracle.truffle.api.strings.test.TStringConstructorTests)
      6,553 ms    testAll[TruffleStringBuilderFactory.AppendSubstringByteIndexNodeGen.Uncached@18ece7f4](com.oracle.truffle.api.strings.test.builder.TStringBuilderAppendSubStringTest)
```

## mx --primary-suite=substratevm native-unittest

No new test failures between [current tip](https://github.com/graalvm/graalvm-community-jdk25u/commit/2f3fbb1aa8ad73294febf299e2fb9e0c082dad9d) and this branch.
