### PR TITLE
[GR-76386] Move 'native-image-utils extract-sbom' to CE

### DIFF
--- a/docs/reference-manual/native-image/guides/use-sbom-support.md
+++ b/docs/reference-manual/native-image/guides/use-sbom-support.md
@@ -70,14 +70,14 @@ syft jwebserver
 ```
 It lists all of the Java libraries included in it.
 
-### Native Image Inspect Tool
+### Native Image Configure Tool
 
-GraalVM Native Image provides the [Inspect Tool](../InspectTool.md) to retrieve an SBOM embedded in a native executable. 
-The Inspect Tool is a viable alternative if you prefer not to install `syft`.
+The `native-image-configure extract-sbom` command retrieves an SBOM embedded in a native executable or shared library that follows the [Native Image SBOM specification](https://www.graalvm.org/dev/security-guide/native-image/sbom/){:target="_blank"}.
+The tool is a viable alternative if you prefer not to install `syft`.
 
-Run the following command to read the SBOM contents using the Inspect Tool:
+Run the following command to read the SBOM contents embedded in a native image:
 ```bash
-native-image-inspect --sbom jwebserver
+native-image-configure extract-sbom --image-path=./jwebserver
 ```
 
 To take it further, you can submit the SBOM to any available vulnerability scanner, and check if the recorded libraries have known security vulnerabilities. 

--- a/docs/security/SBOM.md
+++ b/docs/security/SBOM.md
@@ -23,18 +23,15 @@ The SBOM feature can be disabled with `--enable-sbom=false`.
 
 ## Extracting SBOM Contents
 
-After embedding the compressed SBOM into the executable, the [Native Image Inspect Tool](../reference-manual/native-image/InspectTool.md) is able to extract the compressed SBOM using the `--sbom` parameter accessible through `$JAVA_HOME/bin/native-image-inspect --sbom <path_to_binary>` from both executables and shared libraries.
-It outputs the SBOM in the following format:
-
-After embedding the compressed SBOM into the image, there are two possible ways to extract the SBOM contents:
-- using the [Native Image Inspect Tool](../reference-manual/native-image/InspectTool.md)
+For native images with an embedded SBOM, there are two possible ways to extract the SBOM contents:
+- using the [Native Image Configure Tool](#native-image-configure-tool)
 - using [Syft](https://github.com/anchore/syft){:target="_blank"}
 
-### Native Image Inspect Tool
+### Native Image Configure Tool
 
-The [Native Image Inspect Tool](../reference-manual/native-image/InspectTool.md) is able to extract the compressed SBOM using the `--sbom` parameter, accessible from both executables and shared libraries:
+The Native Image Utils Tool can extract the compressed SBOM using the `extract-sbom` command from native executables and shared libraries.
 ```bash
-native-image-inspect --sbom <path_to_binary>
+native-image-configure extract-sbom --image-path=<path_to_binary>
 ```
 
 It outputs the contents in the JSON format:

--- a/substratevm/CHANGELOG.md
+++ b/substratevm/CHANGELOG.md
@@ -3,6 +3,7 @@
 This changelog summarizes major changes to GraalVM Native Image.
 
 ## GraalVM for JDK 25
+* (GR-76386) Move `native-image-configure extract-sbom` to GraalVM Community Edition.
 * (GR-52276) (GR-61959) Add support for Arena.ofShared().
 * (GR-58668) Enabled [Whole-Program Sparse Conditional Constant Propagation (WP-SCCP)](https://github.com/oracle/graal/pull/9821) by default, improving the precision of points-to analysis in Native Image. This optimization enhances static analysis accuracy and scalability, potentially reducing the size of the final native binary.
 * (GR-59313) Deprecated class-level metadata extraction using `native-image-inspect` and removed option `DumpMethodsData`. Use class-level SBOMs instead by passing `--enable-sbom=class-level,export` to the `native-image` builder. The default value of option `IncludeMethodData` was changed to `false`.

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/ConfigurationTool.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/ConfigurationTool.java
@@ -38,6 +38,7 @@ import com.oracle.svm.configure.command.ConfigurationGenerateFiltersCommand;
 import com.oracle.svm.configure.command.ConfigurationHelpCommand;
 import com.oracle.svm.configure.command.ConfigurationProcessTraceCommand;
 import com.oracle.svm.configure.command.ConfigurationUnknownCommand;
+import com.oracle.svm.configure.command.SBOMExtractorCommand;
 
 public class ConfigurationTool {
     private static final int USAGE_ERROR_CODE = 2;
@@ -53,6 +54,7 @@ public class ConfigurationTool {
         ConfigurationCommand processTraceCommand = new ConfigurationProcessTraceCommand();
         ConfigurationCommand generateFiltersCommand = new ConfigurationGenerateFiltersCommand();
         ConfigurationCommand conditionalsCommand = new ConfigurationGenerateConditionalsCommand();
+        ConfigurationCommand sbomExtractorCommand = new SBOMExtractorCommand();
 
         commands.put(helpCommand.getName(), helpCommand);
         commands.put(generateCommand.getName(), generateCommand);
@@ -60,6 +62,7 @@ public class ConfigurationTool {
         commands.put(processTraceCommand.getName(), processTraceCommand);
         commands.put(conditionalsCommand.getName(), conditionalsCommand);
         commands.put(generateFiltersCommand.getName(), generateFiltersCommand);
+        commands.put(sbomExtractorCommand.getName(), sbomExtractorCommand);
     }
 
     public static Collection<ConfigurationCommand> getCommands() {

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/command/SBOMExtractorCommand.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/command/SBOMExtractorCommand.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.configure.command;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Iterator;
+
+import com.oracle.svm.configure.ConfigurationUsageException;
+import com.oracle.svm.configure.extractor.ResourceExtractor;
+
+/**
+ * Implements an `extract-sbom` command for extracting embedded SBOMs from native images.
+ *
+ * Embedded SBOMs are stored in gzip format and have two associated exported symbols. One symbol
+ * points to the start of the SBOM ("sbom") and another symbol points to the size of the SBOM
+ * ("sbom_length").
+ *
+ * To extract an embedded SBOM:
+ *
+ * <pre>
+ * // Prints SBOM content to stdout
+ * $ native-image-utils extract-sbom --image-path=<image-path>
+ *
+ * // Writes SBOM content to the output file
+ * $ native-image-utils extract-sbom --image-path=<image-path> --output-file=<output-path>
+ * </pre>
+ *
+ * Note: If the need arises to extract other resources that are embedded in images, we can easily
+ * implement that since the {@link ResourceExtractor} is already symbol-agnostic. But since SBOMs
+ * are currently the only resource that is embedded, we made the command SBOM specific to keep the
+ * API descriptive and minimal.
+ */
+public class SBOMExtractorCommand extends ConfigurationCommand {
+    private static final String OPTION_IMAGE_PATH = "--image-path";
+    private static final String OPTION_OUTPUT_FILE = "--output-file";
+    private static final String SBOM_SYMBOL = "sbom";
+
+    private record Arguments(Path imagePath, Path outputPath) {
+        static Arguments parse(Iterator<String> argumentsIterator) throws IOException {
+            Arguments args = parseImpl(argumentsIterator);
+            validate(args);
+            return args;
+        }
+
+        private static Arguments parseImpl(Iterator<String> argumentsIterator) throws IOException {
+            Path imagePath = null;
+            Path outputPath = null;
+
+            while (argumentsIterator.hasNext()) {
+                String argument = argumentsIterator.next();
+                String[] parts = argument.split("=", 2);
+                if (parts.length != 2) {
+                    throw new ConfigurationUsageException(String.format("Invalid option format: %s", argument));
+                }
+                String option = parts[0];
+                String value = parts[1];
+                switch (option) {
+                    case OPTION_IMAGE_PATH -> imagePath = Path.of(value);
+                    case OPTION_OUTPUT_FILE -> outputPath = getOrCreateFile(option, value);
+                    default -> throw new ConfigurationUsageException(String.format("Unknown option: %s", option));
+                }
+            }
+
+            return new Arguments(imagePath, outputPath);
+        }
+
+        private static void validate(Arguments args) throws IOException {
+            if (args.imagePath == null) {
+                throw new ConfigurationUsageException(String.format(
+                                "The image path was not specified. Specify the image path using the %s=<path> option.", OPTION_IMAGE_PATH));
+            }
+            if (!Files.exists(args.imagePath)) {
+                throw new ConfigurationUsageException(String.format("The image path does not exist: %s", args.imagePath));
+            }
+            if (Files.isDirectory(args.imagePath)) {
+                throw new ConfigurationUsageException(String.format("The image path points to a directory: %s", args.imagePath));
+            }
+            if (Files.size(args.imagePath) == 0) {
+                throw new ConfigurationUsageException(String.format("The image path points to an empty file: %s", args.imagePath));
+            }
+        }
+    }
+
+    @Override
+    public String getName() {
+        return "extract-sbom";
+    }
+
+    @Override
+    public void apply(Iterator<String> argumentsIterator) throws IOException {
+        Arguments args = Arguments.parse(argumentsIterator);
+
+        try {
+            extractEmbeddedSBOM(args);
+        } catch (IOException | ConfigurationUsageException e) {
+            String errorMessage = """
+                            Failed to extract embedded SBOM from '%s'. Reason: %s
+
+                            Verify the following:
+                            - The file was generated by GraalVM Native Image.
+                            - The SBOM feature was enabled when building the image.
+
+                            Oracle GraalVM 25 and above embeds SBOMs by default. For earlier Oracle GraalVM versions, ensure '--enable-sbom' is passed to 'native-image'.
+                            """
+                            .formatted(args.imagePath, e.getMessage());
+            throw new ConfigurationUsageException(errorMessage);
+        }
+    }
+
+    private static void extractEmbeddedSBOM(Arguments args) throws IOException {
+        if (args.outputPath == null) {
+            ResourceExtractor.extract(args.imagePath, SBOM_SYMBOL, System.out);
+        } else {
+            try (OutputStream out = Files.newOutputStream(args.outputPath)) {
+                ResourceExtractor.extract(args.imagePath, SBOM_SYMBOL, out);
+            }
+        }
+    }
+
+    @Override
+    protected String getDescription0() {
+        return String.format("""
+                                      extract embedded SBOMs from native images.
+                            %s=<path>
+                                                  the path to the Native Image executable or shared library
+                                                  containing the embedded SBOM.
+                            %s=<path>
+                                                  writes the extracted SBOM to <path> if specified;
+                                                  otherwise to stdout.
+                        """, OPTION_IMAGE_PATH, OPTION_OUTPUT_FILE).replace("\n", System.lineSeparator());
+    }
+}

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/extractor/ElfResourceLocator.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/extractor/ElfResourceLocator.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.configure.extractor;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteOrder;
+
+import com.oracle.svm.configure.ConfigurationUsageException;
+
+/**
+ * Resource locator for ELF 64-bit images.
+ */
+final class ElfResourceLocator extends ResourceLocator {
+    private static final byte[] MAGIC = {0x7F, 'E', 'L', 'F'};
+    private static final int ELFCLASS64 = 2;
+    private static final int ELFDATA2LSB = 1;
+    private static final int ET_EXEC = 2;
+    private static final int ET_DYN = 3;
+
+    private static final class SectionNames {
+        static final String SHSTRTAB = ".shstrtab";
+        static final String DYNSTR = ".dynstr";
+        static final String DYNSYM = ".dynsym";
+        static final String DATA = ".data";
+    }
+
+    private record HeaderInfo(long sectionHeaderTableOffset, long sectionHeaderEntrySize, long numberOfSections, long sectionHeaderStringIndex) {
+        static final int EI_CLASS_OFFSET = 0x4;
+        static final int EI_DATA_OFFSET = 0x5;
+        static final int E_TYPE_OFFSET = 0x10;
+        static final int E_SHOFF_OFFSET = 0x28;
+        static final int E_SHENTSIZE_OFFSET = 0x3A;
+        static final int E_SHNUM_OFFSET = 0x3C;
+        static final int E_SHSTRNDX_OFFSET = 0x3E;
+    }
+
+    private record SectionHeaderInfo(long nameIndex, long type, long virtualAddress, long fileOffset, long size, long entrySize) {
+        static final long SIZE = 64;
+
+        static final int NAME_OFFSET = 0x0;
+        static final int TYPE_OFFSET = 0x4;
+        static final int ADDR_OFFSET = 0x10;
+        static final int OFFSET_OFFSET = 0x18;
+        static final int SIZE_OFFSET = 0x20;
+        static final int ENTSIZE_OFFSET = 0x38;
+
+        static final int SHT_PROGBITS = 1;
+        static final int SHT_STRTAB = 3;
+        static final int SHT_DYNSYM = 11;
+    }
+
+    private record SymbolInfo(long nameIndex, int info, long value) {
+        static final int NAME_OFFSET = 0x0;
+        static final int INFO_OFFSET = 0x4;
+        static final int VALUE_OFFSET = 0x8;
+
+        static final int STB_GLOBAL = 1;
+        static final int STT_OBJECT = 1;
+    }
+
+    private record StringTableInfo(long offset, long size) {
+    }
+
+    private record SymbolTableInfo(long offset, long size, long entrySize) {
+    }
+
+    private record DataSectionInfo(long virtualAddress, long fileOffset, long size) {
+    }
+
+    private record SectionsInfo(StringTableInfo shstrtab, StringTableInfo dynstr, SymbolTableInfo dynsym, DataSectionInfo data) {
+    }
+
+    ElfResourceLocator(MemorySegment segment) {
+        super(segment);
+    }
+
+    @Override
+    String getSupportedFileFormat() {
+        return "ELF 64-bit";
+    }
+
+    @Override
+    ByteOrder getByteOrder() {
+        return ByteOrder.LITTLE_ENDIAN;
+    }
+
+    @Override
+    boolean matchesMagic() {
+        if (segment.byteSize() < MAGIC.length) {
+            return false;
+        }
+        for (int i = 0; i < MAGIC.length; i++) {
+            if (getUInt8(i) != MAGIC[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    protected ResourceLocation locateResourceImpl(String symbol) {
+        HeaderInfo headerInfo = parseHeader();
+        SectionsInfo sectionsInfo = parseSections(headerInfo);
+        SymbolAddresses symbolAddresses = findSymbolAddresses(symbol, sectionsInfo);
+        return computeResourceLocation(sectionsInfo, symbolAddresses);
+    }
+
+    private HeaderInfo parseHeader() {
+        if (getUInt8(HeaderInfo.EI_CLASS_OFFSET) != ELFCLASS64) {
+            throw new ConfigurationUsageException("Only ELF64 is supported.");
+        }
+        if (getUInt8(HeaderInfo.EI_DATA_OFFSET) != ELFDATA2LSB) {
+            throw new ConfigurationUsageException("Only little-endian ELF is supported.");
+        }
+        int eType = getUInt16(HeaderInfo.E_TYPE_OFFSET);
+        if (eType != ET_EXEC && eType != ET_DYN) {
+            throw new ConfigurationUsageException("Not an executable or shared object.");
+        }
+
+        long sectionHeaderTableOffset = getUInt64(HeaderInfo.E_SHOFF_OFFSET);
+        long sectionHeaderEntrySize = getUInt16(HeaderInfo.E_SHENTSIZE_OFFSET);
+        long numberOfSections = getUInt16(HeaderInfo.E_SHNUM_OFFSET);
+        long sectionHeaderStringIndex = getUInt16(HeaderInfo.E_SHSTRNDX_OFFSET);
+
+        if (sectionHeaderEntrySize < SectionHeaderInfo.SIZE) {
+            throw new ConfigurationUsageException("Invalid section header size.");
+        }
+        long sectionHeaderTableSize = Math.multiplyExact(numberOfSections, sectionHeaderEntrySize);
+        validateRange(sectionHeaderTableOffset, sectionHeaderTableSize);
+
+        return new HeaderInfo(sectionHeaderTableOffset, sectionHeaderEntrySize, numberOfSections, sectionHeaderStringIndex);
+    }
+
+    private SectionsInfo parseSections(HeaderInfo headerInfo) {
+        StringTableInfo shstrtab = parseShstrtab(headerInfo);
+        StringTableInfo dynstr = null;
+        SymbolTableInfo dynsym = null;
+        DataSectionInfo data = null;
+
+        for (long sectionIndex = 0; sectionIndex < headerInfo.numberOfSections(); sectionIndex++) {
+            long sectionHeaderOffset = Math.addExact(headerInfo.sectionHeaderTableOffset(), Math.multiplyExact(sectionIndex, headerInfo.sectionHeaderEntrySize()));
+            validateRange(sectionHeaderOffset, headerInfo.sectionHeaderEntrySize());
+
+            SectionHeaderInfo sectionHeader = parseSectionHeader(sectionHeaderOffset);
+            long nameOffset = Math.addExact(shstrtab.offset(), sectionHeader.nameIndex());
+            if (sectionHeader.nameIndex() >= shstrtab.size()) {
+                // Invalid name index
+                continue;
+            }
+            String sectionName = getNullTerminatedString(nameOffset, shstrtab.size() - sectionHeader.nameIndex());
+
+            if (sectionHeader.type() == SectionHeaderInfo.SHT_STRTAB && SectionNames.DYNSTR.equals(sectionName)) {
+                dynstr = new StringTableInfo(sectionHeader.fileOffset(), sectionHeader.size());
+                validateRange(dynstr.offset(), dynstr.size());
+            } else if (sectionHeader.type() == SectionHeaderInfo.SHT_DYNSYM && SectionNames.DYNSYM.equals(sectionName)) {
+                dynsym = new SymbolTableInfo(sectionHeader.fileOffset(), sectionHeader.size(), sectionHeader.entrySize());
+                validateRange(dynsym.offset(), dynsym.size());
+            } else if (sectionHeader.type() == SectionHeaderInfo.SHT_PROGBITS && SectionNames.DATA.equals(sectionName)) {
+                data = new DataSectionInfo(sectionHeader.virtualAddress(), sectionHeader.fileOffset(), sectionHeader.size());
+            }
+        }
+
+        if (dynstr == null) {
+            throw new ConfigurationUsageException("Could not find %s.".formatted(SectionNames.DYNSTR));
+        }
+        if (dynsym == null) {
+            throw new ConfigurationUsageException("Could not find %s.".formatted(SectionNames.DYNSYM));
+        }
+        if (data == null) {
+            throw new ConfigurationUsageException("Could not find %s.".formatted(SectionNames.DATA));
+        }
+
+        return new SectionsInfo(shstrtab, dynstr, dynsym, data);
+    }
+
+    private StringTableInfo parseShstrtab(HeaderInfo headerInfo) {
+        long shstrHeaderOffset = Math.addExact(headerInfo.sectionHeaderTableOffset(), Math.multiplyExact(headerInfo.sectionHeaderStringIndex(), headerInfo.sectionHeaderEntrySize()));
+        validateRange(shstrHeaderOffset, headerInfo.sectionHeaderEntrySize());
+
+        SectionHeaderInfo shstrHeader = parseSectionHeader(shstrHeaderOffset);
+        if (shstrHeader.type() != SectionHeaderInfo.SHT_STRTAB) {
+            throw new ConfigurationUsageException("Invalid %s type.".formatted(SectionNames.SHSTRTAB));
+        }
+        long shstrOffset = shstrHeader.fileOffset();
+        long shstrSize = shstrHeader.size();
+        validateRange(shstrOffset, shstrSize);
+        return new StringTableInfo(shstrOffset, shstrSize);
+    }
+
+    private SectionHeaderInfo parseSectionHeader(long offset) {
+        long nameIndex = getUInt32(offset + SectionHeaderInfo.NAME_OFFSET);
+        long type = getUInt32(offset + SectionHeaderInfo.TYPE_OFFSET);
+        long virtualAddress = getUInt64(offset + SectionHeaderInfo.ADDR_OFFSET);
+        long fileOffset = getUInt64(offset + SectionHeaderInfo.OFFSET_OFFSET);
+        long size = getUInt64(offset + SectionHeaderInfo.SIZE_OFFSET);
+        long entrySize = getUInt64(offset + SectionHeaderInfo.ENTSIZE_OFFSET);
+        return new SectionHeaderInfo(nameIndex, type, virtualAddress, fileOffset, size, entrySize);
+    }
+
+    private SymbolAddresses findSymbolAddresses(String symbol, SectionsInfo sectionsInfo) {
+        SymbolTableInfo dynsym = sectionsInfo.dynsym();
+        StringTableInfo dynstr = sectionsInfo.dynstr();
+
+        if (dynsym.entrySize() == 0 || dynsym.size() % dynsym.entrySize() != 0) {
+            throw new ConfigurationUsageException("Invalid .dynsym entry size.");
+        }
+        long numberOfSymbols = dynsym.size() / dynsym.entrySize();
+
+        String lengthSymbolName = lengthSymbolName(symbol);
+        long resourceVirtualAddress = -1;
+        long lengthVirtualAddress = -1;
+
+        for (long symbolIndex = 0; symbolIndex < numberOfSymbols; symbolIndex++) {
+            long symbolOffset = Math.addExact(dynsym.offset(), Math.multiplyExact(symbolIndex, dynsym.entrySize()));
+            validateRange(symbolOffset, dynsym.entrySize());
+
+            long nameIndex = getUInt32(symbolOffset + SymbolInfo.NAME_OFFSET);
+            if (nameIndex >= dynstr.size()) {
+                continue;
+            }
+            int info = getUInt8(symbolOffset + SymbolInfo.INFO_OFFSET);
+            int bind = (info >> 4);
+            int type = (info & 0xF);
+            if (type != SymbolInfo.STT_OBJECT || bind != SymbolInfo.STB_GLOBAL) {
+                continue;
+            }
+
+            String name = getNullTerminatedString(dynstr.offset() + nameIndex, dynstr.size() - nameIndex);
+            long value = getUInt64(symbolOffset + SymbolInfo.VALUE_OFFSET);
+
+            if (symbol.equals(name)) {
+                resourceVirtualAddress = value;
+            } else if (lengthSymbolName.equals(name)) {
+                lengthVirtualAddress = value;
+            }
+        }
+
+        if (resourceVirtualAddress == -1 || lengthVirtualAddress == -1) {
+            throw symbolsNotFoundException(symbol, lengthSymbolName(symbol));
+        }
+
+        return new SymbolAddresses(resourceVirtualAddress, lengthVirtualAddress);
+    }
+
+    private ResourceLocation computeResourceLocation(SectionsInfo sectionsInfo, SymbolAddresses symbolAddresses) {
+        DataSectionInfo data = sectionsInfo.data();
+
+        if (symbolAddresses.resourceVirtualAddress() < data.virtualAddress() || symbolAddresses.lengthVirtualAddress() < data.virtualAddress()) {
+            throw new ConfigurationUsageException("Invalid offset or address.");
+        }
+
+        long resourceOffset = Math.addExact(data.fileOffset(), symbolAddresses.resourceVirtualAddress() - data.virtualAddress());
+        long lengthOffset = Math.addExact(data.fileOffset(), symbolAddresses.lengthVirtualAddress() - data.virtualAddress());
+        long length = getUInt64(lengthOffset);
+        return new ResourceLocation(resourceOffset, length);
+    }
+}

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/extractor/MachOResourceLocator.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/extractor/MachOResourceLocator.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.configure.extractor;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteOrder;
+
+import com.oracle.svm.configure.ConfigurationUsageException;
+
+/**
+ * Resource locator for Mach-O 64-bit images.
+ */
+final class MachOResourceLocator extends ResourceLocator {
+    private static final int MAGIC = 0xFEEDFACF;
+    private static final int MAGIC_SIZE = 4;
+
+    private record HeaderInfo(long numberOfCommands, long sizeOfCommands) {
+        static final int SIZE = 32;
+
+        static final int NCMDS_OFFSET = 0x10;
+        static final int SIZEOFCMDS_OFFSET = 0x14;
+    }
+
+    private record LoadCommand(long kind, long size) {
+        static final int SIZE = 8;
+        static final long SYMTAB_KIND = 0x2;
+        static final long SEGMENT_64_KIND = 0x19;
+
+        static final int KIND_OFFSET = 0x0;
+        static final int SIZE_OFFSET = 0x4;
+    }
+
+    private record Segment(long virtualMemoryAddress, long fileOffset) {
+        static final int SIZE = 72;
+        static final String DATA_SEGMENT = "__DATA";
+
+        static final int SEGNAME_OFFSET = 0x8;
+        static final int VMADDR_OFFSET = 0x18;
+        static final int FILEOFF_OFFSET = 0x28;
+        static final int SEGNAME_SIZE = VMADDR_OFFSET - SEGNAME_OFFSET;
+    }
+
+    private record Symtab(long symbolTableOffset, long numberOfSymbols, long stringTableOffset, long stringTableSize) {
+        private static final int NLIST_64_SIZE = 16;
+
+        static final int SYMOFF_OFFSET = 0x8;
+        static final int NSYMS_OFFSET = 0xC;
+        static final int STROFF_OFFSET = 0x10;
+        static final int STRSIZE_OFFSET = 0x14;
+
+        static final int SYMBOL_STRX_OFFSET = 0x0;
+        static final int SYMBOL_VALUE_OFFSET = 0x8;
+    }
+
+    private record LoadCommandsInfo(Segment segment, Symtab symtab) {
+    }
+
+    MachOResourceLocator(MemorySegment segment) {
+        super(segment);
+    }
+
+    @Override
+    String getSupportedFileFormat() {
+        return "Mach-O 64-bit";
+    }
+
+    @Override
+    ByteOrder getByteOrder() {
+        return ByteOrder.LITTLE_ENDIAN;
+    }
+
+    @Override
+    boolean matchesMagic() {
+        validateRange(0, MAGIC_SIZE);
+        return getUInt32(0) == Integer.toUnsignedLong(MAGIC);
+    }
+
+    /**
+     * Parses the Mach-O file and returns the resource offset and length for the given symbol.
+     *
+     * The symbol is automatically prefixed with "_" when searching. For example, given "sbom" we
+     * search for "_sbom" since Mach-O files export symbols with an underscore as prefix.
+     *
+     * @param symbol the name of the symbol to locate (without underscore).
+     * @return a ResourceLocation with offset and length.
+     * @throws ConfigurationUsageException on parsing errors with messages matching the C spec.
+     */
+    @Override
+    protected ResourceLocation locateResourceImpl(String symbol) {
+        HeaderInfo header = parseHeader();
+        LoadCommandsInfo loadCommandsInfo = parseLoadCommands(header);
+        SymbolAddresses symbolAddresses = findSymbolAddresses(symbol, loadCommandsInfo);
+        return computeResourceLocation(loadCommandsInfo, symbolAddresses);
+    }
+
+    private HeaderInfo parseHeader() {
+        validateRange(0, HeaderInfo.SIZE);
+        long numberOfCommands = getUInt32(HeaderInfo.NCMDS_OFFSET);
+        long sizeOfCommands = getUInt32(HeaderInfo.SIZEOFCMDS_OFFSET);
+        validateRange(HeaderInfo.SIZE, sizeOfCommands);
+        return new HeaderInfo(numberOfCommands, sizeOfCommands);
+    }
+
+    private LoadCommandsInfo parseLoadCommands(HeaderInfo headerInfo) {
+        Segment dataSegment = null;
+        Symtab symtab = null;
+
+        long currentOffset = HeaderInfo.SIZE;
+        for (long commandIndex = 0; commandIndex < headerInfo.numberOfCommands(); commandIndex++) {
+            LoadCommand loadCommand = parseLoadCommand(currentOffset);
+            if (loadCommand.kind() == LoadCommand.SEGMENT_64_KIND && dataSegment == null) {
+                Segment seg = parseSegmentCommand(currentOffset);
+                String segmentName = getNullTerminatedString(currentOffset + Segment.SEGNAME_OFFSET, Segment.SEGNAME_SIZE).trim();
+                if (segmentName.equals(Segment.DATA_SEGMENT)) {
+                    dataSegment = seg;
+                }
+            } else if (loadCommand.kind() == LoadCommand.SYMTAB_KIND && symtab == null) {
+                symtab = parseSymtabCommand(currentOffset);
+            }
+            currentOffset = Math.addExact(currentOffset, loadCommand.size());
+        }
+
+        if (dataSegment == null) {
+            throw new ConfigurationUsageException("Unable to detect %s segment.".formatted(Segment.DATA_SEGMENT));
+        }
+        if (symtab == null) {
+            throw new ConfigurationUsageException("Could not find LC_SYMTAB.");
+        }
+
+        return new LoadCommandsInfo(dataSegment, symtab);
+    }
+
+    private Segment parseSegmentCommand(long offset) {
+        validateRange(offset, Segment.SIZE);
+        long virtualMemoryAddress = getUInt64(offset + Segment.VMADDR_OFFSET);
+        long fileOffset = getUInt64(offset + Segment.FILEOFF_OFFSET);
+        return new Segment(virtualMemoryAddress, fileOffset);
+    }
+
+    private Symtab parseSymtabCommand(long offset) {
+        long symbolTableOffset = getUInt32(offset + Symtab.SYMOFF_OFFSET);
+        long numberOfSymbols = getUInt32(offset + Symtab.NSYMS_OFFSET);
+        long stringTableOffset = getUInt32(offset + Symtab.STROFF_OFFSET);
+        long stringTableSize = getUInt32(offset + Symtab.STRSIZE_OFFSET);
+
+        long symtabEnd = Math.addExact(symbolTableOffset, Math.multiplyExact(numberOfSymbols, Symtab.NLIST_64_SIZE));
+        validateRange(symbolTableOffset, symtabEnd - symbolTableOffset);
+        validateRange(stringTableOffset, stringTableSize);
+
+        return new Symtab(symbolTableOffset, numberOfSymbols, stringTableOffset, stringTableSize);
+    }
+
+    private LoadCommand parseLoadCommand(long offset) {
+        validateRange(offset, LoadCommand.SIZE);
+        long kind = getUInt32(offset + LoadCommand.KIND_OFFSET);
+        long size = getUInt32(offset + LoadCommand.SIZE_OFFSET);
+        validateRange(offset, size);
+        return new LoadCommand(kind, size);
+    }
+
+    private SymbolAddresses findSymbolAddresses(String symbol, LoadCommandsInfo loadCommandsInfo) {
+        Symtab symtab = loadCommandsInfo.symtab();
+        Segment seg = loadCommandsInfo.segment();
+
+        String dataSymbol = "_" + symbol;
+        String lengthSymbol = lengthSymbolName(dataSymbol);
+        long resourceVirtualMemoryAddress = -1;
+        long lengthVirtualMemoryAddress = -1;
+
+        for (long i = 0; i < symtab.numberOfSymbols(); i++) {
+            long entryOffset = Math.addExact(symtab.symbolTableOffset(), Math.multiplyExact(i, Symtab.NLIST_64_SIZE));
+            validateRange(entryOffset, Symtab.NLIST_64_SIZE);
+
+            long nStrx = getUInt32(entryOffset + Symtab.SYMBOL_STRX_OFFSET);
+            if (nStrx >= symtab.stringTableSize()) {
+                throw new ConfigurationUsageException("Invalid offset or address.");
+            }
+
+            long nameOffset = Math.addExact(symtab.stringTableOffset(), nStrx);
+            String name = getNullTerminatedString(nameOffset, symtab.stringTableSize() - nStrx);
+            long nValue = getUInt64(entryOffset + Symtab.SYMBOL_VALUE_OFFSET);
+
+            if (dataSymbol.equals(name)) {
+                resourceVirtualMemoryAddress = nValue;
+            } else if (lengthSymbol.equals(name)) {
+                lengthVirtualMemoryAddress = nValue;
+            }
+        }
+
+        if (resourceVirtualMemoryAddress == -1 || lengthVirtualMemoryAddress == -1) {
+            throw symbolsNotFoundException(dataSymbol, lengthSymbol);
+        }
+
+        if (resourceVirtualMemoryAddress < seg.virtualMemoryAddress() || lengthVirtualMemoryAddress < seg.virtualMemoryAddress()) {
+            throw new ConfigurationUsageException("Invalid offset or address.");
+        }
+
+        return new SymbolAddresses(resourceVirtualMemoryAddress, lengthVirtualMemoryAddress);
+    }
+
+    private ResourceLocation computeResourceLocation(LoadCommandsInfo loadCommandsInfo, SymbolAddresses symbolAddresses) {
+        Segment segmentInfo = loadCommandsInfo.segment();
+        long resourceOffset = Math.addExact(segmentInfo.fileOffset(), symbolAddresses.resourceVirtualAddress() - segmentInfo.virtualMemoryAddress());
+        long lengthOffset = Math.addExact(segmentInfo.fileOffset(), symbolAddresses.lengthVirtualAddress() - segmentInfo.virtualMemoryAddress());
+        long length = getUInt64(lengthOffset);
+        return new ResourceLocation(resourceOffset, length);
+    }
+}

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/extractor/PECoffResourceLocator.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/extractor/PECoffResourceLocator.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.configure.extractor;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.oracle.svm.configure.ConfigurationUsageException;
+
+/**
+ * Resource locator for PE/COFF 64-bit images targeting AMD64.
+ */
+final class PECoffResourceLocator extends ResourceLocator {
+    private static final int MAGIC = 0x5A4D;
+    private static final int MACHINE_AMD64 = 0x8664;
+
+    private static final int EXPORT_NAME_RVA_SIZE = 4;
+    private static final int EXPORT_ORDINAL_SIZE = 2;
+    private static final int EXPORT_FUNCTION_RVA_SIZE = 4;
+
+    private record DOSHeaderInfo(long peHeaderOffset) {
+        static final int SIZE = 64;
+
+        /**
+         * Points to the start of {@link PEHeaderInfo}.
+         */
+        static final int E_LFANEW_OFFSET = 0x3C;
+    }
+
+    private record PEHeaderInfo(long machine, long numberOfSections, long optionalHeaderOffset, long optionalHeaderSize) {
+        static final int SIZE = 24;
+        static final long PE_SIGNATURE = 0x4550;
+
+        static final int SIGNATURE_OFFSET = 0x0;
+        static final int MACHINE_OFFSET = 0x4;
+        static final int NUMBER_OF_SECTIONS_OFFSET = 0x6;
+        static final int OPTIONAL_HEADER_SIZE_OFFSET = 0x14;
+    }
+
+    private record OptionalHeaderInfo(DataDirectoryInfo exportDataDirectory) {
+        static final int MAGIC = 0x20B;
+
+        static final int MAGIC_OFFSET = 0x0;
+        static final int DATA_DIRECTORIES_ARRAY_OFFSET = 0x70;
+    }
+
+    private record DataDirectoryInfo(long virtualAddress, long size) {
+        static final int SIZE = 8;
+
+        static final int VA_OFFSET = 0x0;
+        static final int SIZE_OFFSET = 0x4;
+    }
+
+    private record SectionInfo(String name, long virtualAddress, long virtualSize, long pointerToRawData, long sizeOfRawData) {
+        static final long SIZE = 40;
+
+        static final int NAME_OFFSET = 0x0;
+        static final int NAME_LENGTH = 8;
+        static final int VIRTUAL_SIZE_OFFSET = 0x8;
+        static final int VIRTUAL_ADDRESS_OFFSET = 0xC;
+        static final int SIZE_OF_RAW_DATA_OFFSET = 0x10;
+        static final int POINTER_TO_RAW_DATA_OFFSET = 0x14;
+    }
+
+    private record SectionsInfo(List<SectionInfo> sections) {
+    }
+
+    private record ExportDirectoryInfo(long numberOfFunctions, long numberOfNames, long addressOfFunctions, long addressOfNames, long addressOfNameOrdinals) {
+        static final int SIZE = 40;
+
+        static final int NUMBER_OF_FUNCTIONS_OFFSET = 0x14;
+        static final int NUMBER_OF_NAMES_OFFSET = 0x18;
+        static final int ADDRESS_OF_FUNCTIONS_OFFSET = 0x1C;
+        static final int ADDRESS_OF_NAMES_OFFSET = 0x20;
+        static final int ADDRESS_OF_NAME_ORDINALS_OFFSET = 0x24;
+    }
+
+    PECoffResourceLocator(MemorySegment segment) {
+        super(segment);
+    }
+
+    @Override
+    String getSupportedFileFormat() {
+        return "PE/COFF 64-bit";
+    }
+
+    @Override
+    ByteOrder getByteOrder() {
+        return ByteOrder.LITTLE_ENDIAN;
+    }
+
+    @Override
+    boolean matchesMagic() {
+        return getUInt16(0) == MAGIC;
+    }
+
+    @Override
+    protected ResourceLocation locateResourceImpl(String symbol) {
+        DOSHeaderInfo dosHeader = parseDOSHeader();
+        PEHeaderInfo peHeader = parsePEHeader(dosHeader);
+        OptionalHeaderInfo optionalHeader = parseOptionalHeader(peHeader);
+        SectionsInfo sectionsInfo = parseSections(dosHeader, peHeader);
+        SymbolAddresses symbolAddresses = findSymbolAddresses(symbol, optionalHeader, sectionsInfo);
+        return computeResourceLocation(sectionsInfo, symbolAddresses);
+    }
+
+    private DOSHeaderInfo parseDOSHeader() {
+        validateRange(0, DOSHeaderInfo.SIZE);
+        long peHeaderOffset = getUInt32(DOSHeaderInfo.E_LFANEW_OFFSET);
+        return new DOSHeaderInfo(peHeaderOffset);
+    }
+
+    private PEHeaderInfo parsePEHeader(DOSHeaderInfo dosHeader) {
+        long baseOffset = dosHeader.peHeaderOffset();
+        validateRange(baseOffset, PEHeaderInfo.SIZE);
+
+        long peSignature = getUInt32(baseOffset + PEHeaderInfo.SIGNATURE_OFFSET);
+        if (peSignature != PEHeaderInfo.PE_SIGNATURE) {
+            throw new ConfigurationUsageException("Missing PE signature.");
+        }
+
+        long machine = getUInt16(baseOffset + PEHeaderInfo.MACHINE_OFFSET);
+        if (machine != MACHINE_AMD64) {
+            throw new ConfigurationUsageException("Only AMD64 PE is supported.");
+        }
+        long numberOfSections = getUInt16(baseOffset + PEHeaderInfo.NUMBER_OF_SECTIONS_OFFSET);
+        long optionalHeaderOffset = baseOffset + PEHeaderInfo.SIZE;
+        long optionalHeaderSize = getUInt16(baseOffset + PEHeaderInfo.OPTIONAL_HEADER_SIZE_OFFSET);
+        return new PEHeaderInfo(machine, numberOfSections, optionalHeaderOffset, optionalHeaderSize);
+    }
+
+    private OptionalHeaderInfo parseOptionalHeader(PEHeaderInfo peHeader) {
+        long baseOffset = peHeader.optionalHeaderOffset();
+        int optionalMagic = getUInt16(baseOffset + OptionalHeaderInfo.MAGIC_OFFSET);
+        if (optionalMagic != OptionalHeaderInfo.MAGIC) {
+            throw new ConfigurationUsageException("Missing optional header.");
+        }
+
+        long dataDirOffset = baseOffset + OptionalHeaderInfo.DATA_DIRECTORIES_ARRAY_OFFSET;
+        validateRange(dataDirOffset, DataDirectoryInfo.SIZE);
+        long exportRVA = getUInt32(dataDirOffset + DataDirectoryInfo.VA_OFFSET);
+        long exportSize = getUInt32(dataDirOffset + DataDirectoryInfo.SIZE_OFFSET);
+        if (exportRVA == 0 || exportSize == 0) {
+            throw new ConfigurationUsageException("No export table found.");
+        }
+        DataDirectoryInfo exportDataDirectory = new DataDirectoryInfo(exportRVA, exportSize);
+        return new OptionalHeaderInfo(exportDataDirectory);
+    }
+
+    private SectionsInfo parseSections(DOSHeaderInfo dosHeader, PEHeaderInfo peHeader) {
+        long sectionsOffset = peHeader.optionalHeaderOffset() + peHeader.optionalHeaderSize();
+        assert sectionsOffset == dosHeader.peHeaderOffset() + PEHeaderInfo.SIZE + peHeader.optionalHeaderSize();
+        List<SectionInfo> sections = new ArrayList<>();
+        for (long i = 0; i < peHeader.numberOfSections(); i++) {
+            long baseOffset = Math.addExact(sectionsOffset, i * SectionInfo.SIZE);
+            validateRange(baseOffset, SectionInfo.SIZE);
+            String name = getFixedLengthString(baseOffset + SectionInfo.NAME_OFFSET, SectionInfo.NAME_LENGTH);
+            long virtualSize = getUInt32(baseOffset + SectionInfo.VIRTUAL_SIZE_OFFSET);
+            long virtualAddress = getUInt32(baseOffset + SectionInfo.VIRTUAL_ADDRESS_OFFSET);
+            long sizeOfRawData = getUInt32(baseOffset + SectionInfo.SIZE_OF_RAW_DATA_OFFSET);
+            long pointerToRawData = getUInt32(baseOffset + SectionInfo.POINTER_TO_RAW_DATA_OFFSET);
+            sections.add(new SectionInfo(name, virtualAddress, virtualSize, pointerToRawData, sizeOfRawData));
+        }
+        return new SectionsInfo(sections);
+    }
+
+    private SymbolAddresses findSymbolAddresses(String symbol, OptionalHeaderInfo optionalHeader, SectionsInfo sectionsInfo) {
+        long exportOffset = rvaToOffset(optionalHeader.exportDataDirectory().virtualAddress(), sectionsInfo.sections());
+
+        validateRange(exportOffset, ExportDirectoryInfo.SIZE);
+        long numberOfFunctions = getUInt32(exportOffset + ExportDirectoryInfo.NUMBER_OF_FUNCTIONS_OFFSET);
+        long numberOfNames = getUInt32(exportOffset + ExportDirectoryInfo.NUMBER_OF_NAMES_OFFSET);
+        long addressOfFunctions = getUInt32(exportOffset + ExportDirectoryInfo.ADDRESS_OF_FUNCTIONS_OFFSET);
+        long addressOfNames = getUInt32(exportOffset + ExportDirectoryInfo.ADDRESS_OF_NAMES_OFFSET);
+        long addressOfNameOrdinals = getUInt32(exportOffset + ExportDirectoryInfo.ADDRESS_OF_NAME_ORDINALS_OFFSET);
+
+        long functionsOffset = rvaToOffset(addressOfFunctions, sectionsInfo.sections());
+        long namesOffset = rvaToOffset(addressOfNames, sectionsInfo.sections());
+        long ordinalsOffset = rvaToOffset(addressOfNameOrdinals, sectionsInfo.sections());
+        validateRange(namesOffset, numberOfNames * EXPORT_NAME_RVA_SIZE);
+        validateRange(functionsOffset, numberOfFunctions * EXPORT_FUNCTION_RVA_SIZE);
+        validateRange(ordinalsOffset, numberOfNames * EXPORT_ORDINAL_SIZE);
+
+        String lengthSymbol = lengthSymbolName(symbol);
+        long resourceRVA = -1;
+        long lengthRVA = -1;
+        for (long i = 0; i < numberOfNames; i++) {
+            long nameRVAOffset = Math.addExact(namesOffset, i * EXPORT_NAME_RVA_SIZE);
+            long nameRVA = getUInt32(nameRVAOffset);
+            long nameOffset = rvaToOffset(nameRVA, sectionsInfo.sections());
+            String name = getNullTerminatedString(nameOffset).trim();
+            if (name.equals(symbol) || name.equals(lengthSymbol)) {
+                long ordinalOffset = Math.addExact(ordinalsOffset, i * EXPORT_ORDINAL_SIZE);
+                int ordinal = getUInt16(ordinalOffset);
+                if (ordinal < 0 || ordinal >= numberOfFunctions) {
+                    continue;
+                }
+                long funcRVAOffset = Math.addExact(functionsOffset, (long) ordinal * EXPORT_FUNCTION_RVA_SIZE);
+                long funcRVA = getUInt32(funcRVAOffset);
+                if (name.equals(symbol)) {
+                    resourceRVA = funcRVA;
+                } else {
+                    lengthRVA = funcRVA;
+                }
+            }
+        }
+
+        if (resourceRVA == -1 || lengthRVA == -1) {
+            throw symbolsNotFoundException(symbol, lengthSymbol);
+        }
+
+        return new SymbolAddresses(resourceRVA, lengthRVA);
+    }
+
+    private ResourceLocation computeResourceLocation(SectionsInfo sectionsInfo, SymbolAddresses symbolAddresses) {
+        long resourceOffset = rvaToOffset(symbolAddresses.resourceVirtualAddress(), sectionsInfo.sections());
+        long lengthOffset = rvaToOffset(symbolAddresses.lengthVirtualAddress(), sectionsInfo.sections());
+        long length = getUInt64(lengthOffset);
+        return new ResourceLocation(resourceOffset, length);
+    }
+
+    private long rvaToOffset(long rva, List<SectionInfo> sections) {
+        for (SectionInfo sec : sections) {
+            if (rva >= sec.virtualAddress() && rva < Math.addExact(sec.virtualAddress(), sec.virtualSize())) {
+                long delta = rva - sec.virtualAddress();
+                if (delta >= sec.sizeOfRawData()) {
+                    throw new ConfigurationUsageException("Failed to convert RVA to file offset.");
+                }
+                long offset = Math.addExact(sec.pointerToRawData(), delta);
+                validateRange(offset, 1);
+                return offset;
+            }
+        }
+        throw new ConfigurationUsageException("Failed to convert RVA to file offset.");
+    }
+}

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/extractor/ResourceExtractor.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/extractor/ResourceExtractor.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.configure.extractor;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.zip.GZIPInputStream;
+
+import com.oracle.svm.configure.ConfigurationUsageException;
+
+/**
+ * Class responsible for extracting compressed embedded resources from native images.
+ */
+public class ResourceExtractor {
+
+    /**
+     * Extract a gzipped resource and writes the content to the output stream.
+     *
+     * The image must export two symbols: one pointing to the start of the gzipped resource data
+     * (e.g., "sbom"), and another pointing to its size (e.g., "sbom_length"). The argument "symbol"
+     * refers to the symbol name that points to the start of the gzipped resource data. The size
+     * symbol name is always the concatenation of the symbol name with "_length". These symbols are
+     * used to locate the resource in the executable's or shared object's data section.
+     *
+     * This is implemented by memory mapping the image, finding the resource location in the image
+     * using a {@link ResourceLocator}, extracting the gzipped resource slice, decompressing, and
+     * writing to the provided output stream. {@link MemorySegment Memory segments} are used instead
+     * of {@link java.nio.ByteBuffer byte buffers} to allow memory mapping images larger than 2 GB.
+     *
+     * @param image the path to the native image
+     * @param symbol the symbol of the resource to extract
+     * @param out the output stream to write the extracted resource to
+     * @throws ConfigurationUsageException if there is an issue with the input file or parsing
+     * @throws IOException if there is an I/O error during extraction or decompression
+     */
+    public static void extract(Path image, String symbol, OutputStream out) throws ConfigurationUsageException, IOException {
+        try (FileChannel channel = FileChannel.open(image, StandardOpenOption.READ); Arena arena = Arena.ofConfined()) {
+            MemorySegment memorySegment = channel.map(FileChannel.MapMode.READ_ONLY, 0, channel.size(), arena);
+            ResourceLocation resourceLocation = locateResourceLocation(symbol, memorySegment);
+
+            MemorySegment compressedResource = memorySegment.asSlice(resourceLocation.offset(), resourceLocation.size());
+            decompressAndWrite(compressedResource, out);
+        }
+    }
+
+    private static ResourceLocation locateResourceLocation(String symbol, MemorySegment segment) {
+        ResourceLocatorFactory resourceLocatorFactory = new ResourceLocatorFactory();
+        ResourceLocator resourceLocator = resourceLocatorFactory.create(segment);
+        return resourceLocator.locateResource(symbol);
+    }
+
+    private static void decompressAndWrite(MemorySegment segment, OutputStream out) throws IOException {
+        try (InputStream segmentInputStream = new MemorySegmentInputStream(segment);
+                        InputStream gzipInputStream = new GZIPInputStream(segmentInputStream)) {
+            gzipInputStream.transferTo(out);
+        }
+    }
+
+    private static class MemorySegmentInputStream extends InputStream {
+        private final MemorySegment segment;
+        private long position = 0;
+
+        MemorySegmentInputStream(MemorySegment segment) {
+            this.segment = segment;
+        }
+
+        @Override
+        public int read() {
+            if (position >= segment.byteSize()) {
+                return -1;
+            }
+            byte b = segment.get(ValueLayout.JAVA_BYTE, position);
+            position++;
+            // Convert signed byte to unsigned int
+            return b & 0xFF;
+        }
+
+        @Override
+        public void close() {
+            // Segment closed by Arena
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/extractor/ResourceLocation.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/extractor/ResourceLocation.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.configure.extractor;
+
+/**
+ * Defines the location of an embedded resource within a native image. This is the return type of
+ * {@link ResourceLocator#locateResource(String)}.
+ *
+ * @param offset the starting byte offset in the image where the compressed resource data begins.
+ * @param size the size in bytes of the compressed resource data.
+ */
+record ResourceLocation(long offset, long size) {
+}

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/extractor/ResourceLocator.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/extractor/ResourceLocator.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.configure.extractor;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.ByteOrder;
+
+import com.oracle.svm.configure.ConfigurationUsageException;
+
+/**
+ * Abstract class that locates the offset and size of an embedded resource in an image. The embedded
+ * resource has exported symbols pointing to its location and size. A {@link ResourceLocator} parses
+ * the file format to find the file offset and size of the resource.
+ */
+abstract class ResourceLocator {
+    protected final MemorySegment segment;
+    private final long fileSize;
+    private static final String SYMBOL_LENGTH_SUFFIX = "_length";
+
+    protected record SymbolAddresses(long resourceVirtualAddress, long lengthVirtualAddress) {
+    }
+
+    ResourceLocator(MemorySegment segment) {
+        this.segment = segment;
+        this.fileSize = segment.byteSize();
+    }
+
+    /**
+     * Checks if the provided memory segment matches the magic bytes for this locator's supported
+     * format. This must be checked to return true before calling {@link #locateResource(String)} on
+     * this instance.
+     *
+     * @return true if the segment matches this locator's format, false otherwise
+     */
+    abstract boolean matchesMagic();
+
+    /**
+     * Parses the image to locate the offset and size of the resource identifiable by its symbol.
+     *
+     * Check the magic before calling this method via {@link ResourceLocator#matchesMagic()}. Use
+     * the {@link ResourceLocatorFactory} to create a suitable {@link ResourceLocator resource
+     * locator}.
+     *
+     * @param symbol the name of the symbol to locate
+     * @return a {@link ResourceLocation} containing the resource offset and size
+     * @throws ConfigurationUsageException if parsing fails or symbols are not found
+     */
+    ResourceLocation locateResource(String symbol) throws ConfigurationUsageException {
+        assert matchesMagic() : "Magic does not match the expected value for file format %s.".formatted(getSupportedFileFormat());
+        ResourceLocation resourceLocation = locateResourceImpl(symbol);
+        validateResourceLocation(resourceLocation);
+        return resourceLocation;
+    }
+
+    protected abstract ResourceLocation locateResourceImpl(String symbol) throws ConfigurationUsageException;
+
+    /**
+     * Returns a human-readable description of the file format(s) supported by this locator.
+     *
+     * @return the supported file format(s), e.g., "Mach-O 64-bit"
+     */
+    abstract String getSupportedFileFormat();
+
+    /**
+     * Determines the endianness used for the {@code getUInt} methods.
+     */
+    abstract ByteOrder getByteOrder();
+
+    /**
+     * Returns the symbol name that points to the resource size in bytes.
+     */
+    protected static String lengthSymbolName(String symbol) {
+        return symbol + SYMBOL_LENGTH_SUFFIX;
+    }
+
+    protected int getUInt8(long pos) {
+        return getUInt8(segment, pos, getByteOrder());
+    }
+
+    private static int getUInt8(MemorySegment segment, long pos, ByteOrder byteOrder) {
+        return Byte.toUnsignedInt(segment.get(ValueLayout.JAVA_BYTE.withOrder(byteOrder), pos));
+    }
+
+    protected int getUInt16(long pos) {
+        return getUInt16(segment, pos, getByteOrder());
+    }
+
+    private static int getUInt16(MemorySegment segment, long pos, ByteOrder byteOrder) {
+        return Short.toUnsignedInt(segment.get(ValueLayout.JAVA_SHORT.withOrder(byteOrder), pos));
+    }
+
+    protected long getUInt32(long pos) {
+        return getUInt32(segment, pos, getByteOrder());
+    }
+
+    private static long getUInt32(MemorySegment segment, long pos, ByteOrder byteOrder) {
+        return Integer.toUnsignedLong(segment.get(ValueLayout.JAVA_INT.withOrder(byteOrder), pos));
+    }
+
+    protected long getUInt64(long pos) {
+        return segment.get(ValueLayout.JAVA_LONG.withOrder(getByteOrder()), pos);
+    }
+
+    protected String getNullTerminatedString(long pos) {
+        try {
+            return getNullTerminatedString(pos, Long.MAX_VALUE, false);
+        } catch (IndexOutOfBoundsException e) {
+            throw new ConfigurationUsageException("String was not null-terminated.");
+        }
+    }
+
+    protected String getNullTerminatedString(long pos, long maxLength) {
+        return getNullTerminatedString(pos, maxLength, true);
+    }
+
+    /**
+     * Reads a null-terminated string starting at the given position, up to the specified maximum
+     * length.
+     *
+     * @param pos the starting position in the memory segment
+     * @param maxLength the maximum number of bytes to read before throwing an exception if no null
+     *            terminator is found
+     * @param validateRange boolean deciding if range verification performed on pos and maxLength
+     * @return the string read from the segment
+     * @throws ConfigurationUsageException if no null terminator is found within maxLength or if
+     *             offsets are invalid
+     */
+    protected String getNullTerminatedString(long pos, long maxLength, boolean validateRange) {
+        if (validateRange) {
+            validateRange(pos, maxLength);
+        }
+        StringBuilder sb = new StringBuilder();
+        for (long i = 0; i < maxLength; i++) {
+            long charPos = Math.addExact(pos, i);
+            byte b = segment.get(ValueLayout.JAVA_BYTE, charPos);
+            if (b == 0) {
+                return sb.toString();
+            }
+            sb.append((char) b);
+        }
+        throw new ConfigurationUsageException("Expected null terminated string was not null terminated.");
+    }
+
+    protected String getFixedLengthString(long pos, int length) {
+        validateRange(pos, length);
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < length; i++) {
+            long charPos = Math.addExact(pos, i);
+            byte b = segment.get(ValueLayout.JAVA_BYTE, charPos);
+            sb.append((char) b);
+        }
+        return sb.toString();
+    }
+
+    protected static ConfigurationUsageException symbolsNotFoundException(String resourceSymbol, String resourceLengthSymbol) {
+        return new ConfigurationUsageException("Could not find '%s' and '%s' symbols. This likely means the image does not contain the embedded resource."
+                        .formatted(resourceSymbol, resourceLengthSymbol));
+    }
+
+    private void validateResourceLocation(ResourceLocation resourceLocation) {
+        validateRange(resourceLocation.offset(), resourceLocation.size());
+        if (resourceLocation.size() <= 0) {
+            throw new ConfigurationUsageException("Invalid resource size: %s.".formatted(resourceLocation.size()));
+        }
+    }
+
+    protected void validateRange(long offset, long length) {
+        validateRange(offset, length, fileSize);
+    }
+
+    /**
+     * Validates that the given offset and length form a valid range within the file's size.
+     *
+     * @param offset the starting offset
+     * @param length the length of the range
+     * @param fileSize the total size of the file
+     * @throws ConfigurationUsageException if the range is invalid (negative, overflow, or exceeds
+     *             file size)
+     */
+    private static void validateRange(long offset, long length, long fileSize) {
+        try {
+            if (offset < 0) {
+                throw new ConfigurationUsageException("Negative offset.");
+            }
+            if (length < 0) {
+                throw new ConfigurationUsageException("Negative length.");
+            }
+            long addedOffset = Math.addExact(offset, length);
+            if (addedOffset > fileSize) {
+                throw new ConfigurationUsageException("Offset exceeds file size (%s > %s).".formatted(addedOffset, fileSize));
+            }
+        } catch (ArithmeticException e) {
+            throw new ConfigurationUsageException("Invalid offset or address.");
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/extractor/ResourceLocatorFactory.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/extractor/ResourceLocatorFactory.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.configure.extractor;
+
+import java.lang.foreign.MemorySegment;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import com.oracle.svm.configure.ConfigurationUsageException;
+
+/**
+ * Factory for {@link ResourceLocator resource locators}.
+ */
+class ResourceLocatorFactory {
+    /**
+     * Defines the factories of the supported {@link ResourceLocator resource locators}. Append to
+     * this list to add support for new file formats.
+     */
+    private final List<Function<MemorySegment, ResourceLocator>> supportedResourceLocatorFactories = List.of(
+                    MachOResourceLocator::new,
+                    ElfResourceLocator::new,
+                    PECoffResourceLocator::new);
+
+    /**
+     * Creates and returns a {@link ResourceLocator} for the given memory segment by detecting the
+     * file format through magic byte matching.
+     *
+     * @param segment the memory segment holding the image
+     * @return a {@link ResourceLocator} instance suitable for the detected file format
+     * @throws ConfigurationUsageException if no matching file format is found
+     */
+    ResourceLocator create(MemorySegment segment) throws ConfigurationUsageException {
+        List<ResourceLocator> locators = new ArrayList<>();
+        for (var locatorFactory : supportedResourceLocatorFactories) {
+            ResourceLocator locator = locatorFactory.apply(segment);
+            if (locator.matchesMagic()) {
+                return locator;
+            }
+            locators.add(locator);
+        }
+
+        throw new ConfigurationUsageException("Unrecognized file format. Supported formats: %s."
+                        .formatted(supportedFileFormats(locators)));
+    }
+
+    private static String supportedFileFormats(List<ResourceLocator> resourceLocators) {
+        return resourceLocators.stream()
+                        .map(ResourceLocator::getSupportedFileFormat)
+                        .collect(Collectors.joining(", "));
+    }
+}


### PR DESCRIPTION
**This PR backports:**

- https://github.com/oracle/graal/pull/13726

**Conflicts:**

The mainline patch didn't apply cleanly mostly because of documentation changes done since and because `native-image-utils` is `native-image-configure` in 25.0. I've tested this by building it in the mandrel configuration and trying out the `native-image-configure` binary on a native-image that has an SBOM embedded.

This refrains from bumping the compliance level of `com.oracle.svm.configure` to JDK 22+ (it now uses `MemorySegment` in the `extract-sbom` command code). But this causes more issues than is worth for the gates. See #84 for the details. I guess this could potentially break some agent usages on an older JDKs (than 25), but I suspect the use cases for that are negligible. After all, this is GraalVM 25.

Details are:
```
Conflicts:
 docs/reference-manual/native-image/guides/use-sbom-support.md
 docs/security/SBOM.md
 substratevm/CHANGELOG.md
 -> Doc changes adjusted manually
 substratevm/mx.substratevm/suite.py
 -> java compliance level - edit it manually
 substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/ConfigurationTool.java
 -> import change only
```

Closes: https://github.com/graalvm/graalvm-community-jdk25u/issues/62