### PR TITLE
Add mx test for SingleCallsiteInliner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,7 +128,7 @@ jobs:
           - os: ubuntu-24.04
             env:
               JDK_VERSION: "25"
-              GATE_TAGS: "build,debuginfotest"
+              GATE_TAGS: "build,debuginfotest,scismoketest"
               PRIMARY: "substratevm"
           - env:
               JDK_VERSION: "25"

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -209,6 +209,7 @@ class Tags(set):
 GraalTags = Tags([
     'helloworld',
     'debuginfotest',
+    'scismoketest',
     'native_unittests',
     'build',
     'benchmarktest',
@@ -423,6 +424,11 @@ def svm_gate_body(args, tasks):
             else:
                 with native_image_context(IMAGE_ASSERTION_FLAGS) as native_image:
                     debuginfotest(['--output-path', svmbuild_dir()] + args.extra_image_builder_arguments)
+
+    with Task('image scismoketest', tasks, tags=[GraalTags.scismoketest]) as t:
+        if t:
+            with native_image_context(IMAGE_ASSERTION_FLAGS) as native_image:
+                scismoketest(['--output-path', svmbuild_dir()] + args.extra_image_builder_arguments)
 
     with Task('image debughelpertest', tasks, tags=[GraalTags.debuginfotest]) as t:
         if t:
@@ -1028,6 +1034,93 @@ def _debuginfotest(native_image, path, build_only, with_isolates_only, args):
         os.environ.update({'debuginfotest_isolates': 'yes'})
         mx.run([os.environ.get('GDB_BIN', 'gdb'), '--nx', '-q', '-iex', 'set pagination off', '-ex', 'python "ISOLATES=True"', '-x', testhello_py, hello_binary])
 
+
+def _run_scismoke_binary(binary_path):
+    expected_output = 'PASS' + os.linesep
+    actual_output = []
+
+    def _collector(x):
+        actual_output.append(x)
+        mx.log(x)
+
+    mx.run([binary_path], out=_collector)
+
+    # Basic correctness check.
+    if ''.join(actual_output) != expected_output:
+        raise Exception('Unexpected output: ' + str(actual_output) + ' != ' + str([expected_output]))
+
+
+class _ScismokeHistogramTracker:
+    _HISTOGRAM_HEADER = 'Code Size; Nodes Parsing'
+    _HISTOGRAM_FOOTER = 'Size all methods'
+
+    def __init__(self):
+        self.in_histogram = False
+        self.has_single = False
+        self.has_multi = False
+        self.verified_histogram = False
+
+    def process_line(self, line):
+        mx.log(line)
+        # Only verify within method histogram bounds.
+        if line.startswith(self._HISTOGRAM_HEADER):
+            self.in_histogram = True
+            self.verified_histogram = True
+        elif self.in_histogram:
+            if line.startswith(self._HISTOGRAM_FOOTER):
+                self.in_histogram = False
+            else:
+                if 'singleCallsiteHelper' in line:
+                    self.has_single = True
+                if 'multiCallsiteHelper' in line:
+                    self.has_multi = True
+
+
+def _build_scismoke_image(native_image, build_args):
+    tracker = _ScismokeHistogramTracker()
+    native_image(build_args, out=tracker.process_line, err=tracker.process_line)
+    if not tracker.verified_histogram:
+        raise Exception('PrintMethodHistogram output not found in native-image build log')
+    return tracker
+
+
+def _assert_scismoke_histogram(tracker, is_sci_enabled, variant_name):
+    if not tracker.has_multi:
+        raise Exception(variant_name + ': multiCallsiteHelper should always appear in histogram')
+    if is_sci_enabled:
+        if tracker.has_single:
+            raise Exception(variant_name + ': singleCallsiteHelper should not appear in histogram with SCI enabled')
+    elif not tracker.has_single:
+        raise Exception(variant_name + ': singleCallsiteHelper should appear in histogram with SCI disabled')
+
+
+def _scismoketest(native_image, path, args):
+    mx_util.ensure_dir_exists(path)
+
+    base_args = [
+        '--native-image-info',
+        '-cp', classpath('com.oracle.svm.test.sci'),
+        '--initialize-at-build-time=com.oracle.svm.test.sci',
+        'com.oracle.svm.test.sci.SciSmoke',
+    ] + args
+
+    def build_and_run(variant_name, sci_flag, is_sci_enabled):
+        variant_path = join(path, variant_name)
+        mx_util.ensure_dir_exists(variant_path)
+        binary_path = join(variant_path, 'scismoke')
+        build_args = base_args + svm_experimental_options([
+            sci_flag,
+            '-H:+PrintMethodHistogram',
+        ]) + [
+            '-o', binary_path,
+        ]
+        mx.log(f'native_image {build_args}')
+        tracker = _build_scismoke_image(native_image, build_args)
+        _assert_scismoke_histogram(tracker, is_sci_enabled, variant_name)
+        _run_scismoke_binary(binary_path)
+
+    build_and_run('sci_on', '-H:+AOTSingleCallsiteInline', True)
+    build_and_run('sci_off', '-H:-AOTSingleCallsiteInline', False)
 
 def _gdbdebughelperstest(native_image, path, with_isolates_only, args):
 
@@ -1696,6 +1789,25 @@ def run_helloworld_command(args, config, command_name):
         config=config,
     )
 
+@mx.command(suite_name=suite.name, command_name='scismoketest', usage_msg='[options]')
+def scismoketest(args, config=None):
+    """
+    Build and run a simple app with AOTSingleCallsiteInline enabled and disabled.
+    The output of the app is verified for correctness.
+    PrintMethodHistogram is parsed to verify the expected inlining happened.
+    """
+    parser = ArgumentParser(prog='mx scismoketest')
+    all_args = ['--output-path', '--build-only']
+    masked_args = [_mask(arg, all_args) for arg in args]
+    parser.add_argument(all_args[0], metavar='<output-path>', nargs=1, help='Path of the generated image', default=[svmbuild_dir()])
+    parser.add_argument('image_args', nargs='*', default=[])
+    parsed = parser.parse_args(masked_args)
+    output_path = unmask(parsed.output_path)[0]
+    native_image_context_run(
+        lambda native_image, a:
+            _scismoketest(native_image, output_path, a), unmask(parsed.image_args),
+        config=config
+    )
 
 @mx.command(suite_name=suite.name, command_name='debuginfotest', usage_msg='[options]')
 def debuginfotest(args, config=None):

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -1152,6 +1152,19 @@ suite = {
             "jacoco" : "exclude",
         },
 
+        "com.oracle.svm.test.sci": {
+            "subDir": "src",
+            "sourceDirs": ["src"],
+            "dependencies": [
+                "SVM",
+            ],
+            "checkstyle": "com.oracle.svm.test",
+            "workingSets": "SVM",
+            "javaCompliance": "22+",
+            "spotbugs": "false",
+            "jacoco": "exclude",
+        },
+
         "com.oracle.svm.with.space.test": {
             "subDir": "src",
             "sourceDirs": ["src"],

--- a/substratevm/src/com.oracle.svm.test.sci/src/com/oracle/svm/test/sci/SciSmoke.java
+++ b/substratevm/src/com.oracle.svm.test.sci/src/com/oracle/svm/test/sci/SciSmoke.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.test.sci;
+
+import com.oracle.svm.core.NeverInlineTrivial;
+
+public class SciSmoke {
+
+    @NeverInlineTrivial(reason = "Avoid trivial inliner interference")
+    private static int singleCallsiteHelper(int value) {
+        return value * 2;
+    }
+
+    @NeverInlineTrivial(reason = "Avoid trivial inliner interference")
+    private static int multiCallsiteHelper(int value) {
+        return value + 2;
+    }
+
+    private static int useSingleCallsite() {
+        return singleCallsiteHelper(1);
+    }
+
+    private static int useMultiCallsite() {
+        return multiCallsiteHelper(2) + multiCallsiteHelper(3);
+    }
+
+    public static void main(String[] args) {
+        if (useSingleCallsite() + useMultiCallsite() == 11) {
+            System.out.println("PASS");
+        } else {
+            System.out.println("FAIL");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a smoke test for the SingleCallsiteInliner. It also enables it in the GHA CI. It can be run using `mx scismoketest` after running `mx build`.

What the test does:

1. Builds the SciSmoke.java test as a Native Image executable with `-H:+AOTSingleCallsiteInline` and `-H:+PrintMethodHistogram`
2. The method histogram is checked to ensure that only the expected methods get inlined.
3. The app is run and its output is compared against the expected result for correctness. 
4. The whole process is repeated with `-H:-AOTSingleCallsiteInline` 