### PR TITLE
[Backport] [Oracle GraalVM] [GR-74228] Backport to 25.0: Add callback-based engine cache persistence API

### DIFF
--- a/sdk/src/org.graalvm.polyglot/snapshot.sigtest
+++ b/sdk/src/org.graalvm.polyglot/snapshot.sigtest
@@ -209,6 +209,7 @@ hfds allowAllAccess,allowCreateProcess,allowCreateThread,allowExperimentalOption
 
 CLSS public final org.graalvm.polyglot.Engine
 innr public final Builder
+innr public abstract interface static CancellationCallback
 intf java.lang.AutoCloseable
 meth public !varargs static boolean copyResources(java.nio.file.Path,java.lang.String[]) throws java.io.IOException
 meth public !varargs static org.graalvm.polyglot.Engine create(java.lang.String[])
@@ -217,6 +218,7 @@ meth public boolean storeCache(java.nio.file.Path)
 meth public boolean storeCache(java.nio.file.Path,org.graalvm.nativeimage.c.type.WordPointer)
 meth public java.lang.String getImplementationName()
 meth public java.lang.String getVersion()
+meth public java.nio.ByteBuffer persistCache(org.graalvm.polyglot.Engine$CancellationCallback)
 meth public java.util.Map<java.lang.String,org.graalvm.polyglot.Instrument> getInstruments()
 meth public java.util.Map<java.lang.String,org.graalvm.polyglot.Language> getLanguages()
 meth public java.util.Set<org.graalvm.polyglot.Source> getCachedSources()
@@ -229,6 +231,11 @@ meth public void close(boolean)
 supr java.lang.Object
 hfds EMPTY,ENGINES,creatorEngine,currentAPI,dispatch,initializationException,receiver,shutdownHookInitialized
 hcls APIAccessImpl,CleanableReference,ContextReference,EngineReference,EngineShutDownHook,ImplHolder,PolyglotInvalid
+
+CLSS public abstract interface static org.graalvm.polyglot.Engine$CancellationCallback
+ outer org.graalvm.polyglot.Engine
+ anno 0 java.lang.FunctionalInterface()
+meth public abstract boolean shouldCancel()
 
 CLSS public final org.graalvm.polyglot.Engine$Builder
  outer org.graalvm.polyglot.Engine

--- a/sdk/src/org.graalvm.polyglot/src/org/graalvm/polyglot/Engine.java
+++ b/sdk/src/org.graalvm.polyglot/src/org/graalvm/polyglot/Engine.java
@@ -400,8 +400,8 @@ public final class Engine implements AutoCloseable {
      * Truffle's enterprise extensions.
      * <p>
      * If {@code callback} is non-null, it is polled periodically to request cancellation.
-     * Cancellation support during the low-level auxiliary image persistence phase is only
-     * available on hosts that support it; otherwise callback cancellation is limited to the
+     * Cancellation support during the low-level auxiliary image persistence phase is only available
+     * on hosts that support it; otherwise callback cancellation is limited to the
      * compilation-preparation phase. Implementations that cannot support the callback semantics may
      * throw {@link UnsupportedOperationException}.
      *
@@ -2233,8 +2233,8 @@ public final class Engine implements AutoCloseable {
      * A callback that is invoked repeatedly while persisting the auxiliary engine cache.
      * <p>
      * The callback may be polled during compilation preparation. Some hosts may also support
-     * low-level auxiliary image persistence cancellation for host-specific callback
-     * implementations with additional runtime constraints.
+     * low-level auxiliary image persistence cancellation for host-specific callback implementations
+     * with additional runtime constraints.
      *
      * @since 25.1
      */

--- a/sdk/src/org.graalvm.polyglot/src/org/graalvm/polyglot/Engine.java
+++ b/sdk/src/org.graalvm.polyglot/src/org/graalvm/polyglot/Engine.java
@@ -56,6 +56,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.net.URL;
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -322,6 +323,7 @@ public final class Engine implements AutoCloseable {
      * Stores the auxiliary engine cache to the targetFile without cancellation.
      *
      * @see #storeCache(Path, WordPointer)
+     * @see #persistCache(CancellationCallback)
      * @throws UnsupportedOperationException if this engine or the host virtual machine does not
      *             support storing the cache.
      * @since 25.0
@@ -386,6 +388,33 @@ public final class Engine implements AutoCloseable {
      */
     public boolean storeCache(Path targetFile, WordPointer cancelledWord) throws CancellationException, UnsupportedOperationException {
         return dispatch.storeCache(receiver, targetFile, cancelledWord.rawValue());
+    }
+
+    /**
+     * Persists the auxiliary engine cache into an in-memory buffer. The option
+     * <code>engine.CacheStoreEnabled</code> must be set to <code>true</code> to use this feature.
+     * The returned buffer contains the cache image bytes and can be written to a file by the
+     * caller.
+     * <p>
+     * Note that this feature is experimental and only supported on native-image hosts with
+     * Truffle's enterprise extensions.
+     * <p>
+     * If {@code callback} is non-null, it is polled periodically to request cancellation.
+     * Cancellation support during the low-level auxiliary image persistence phase is only
+     * available on hosts that support it; otherwise callback cancellation is limited to the
+     * compilation-preparation phase. Implementations that cannot support the callback semantics may
+     * throw {@link UnsupportedOperationException}.
+     *
+     * @param callback callback used to request cancellation, or {@code null} for no cancellation
+     * @return a buffer containing the persisted cache image, or {@code null} if no image was
+     *         produced, for example because the configured maximum image size was exceeded
+     * @throws CancellationException if the persist operation was cancelled via the callback
+     * @throws UnsupportedOperationException if this engine or host virtual machine does not support
+     *             in-memory cache persistence
+     * @since 25.1
+     */
+    public ByteBuffer persistCache(CancellationCallback callback) {
+        return dispatch.persistCache(receiver, callback);
     }
 
     /**
@@ -2198,5 +2227,24 @@ public final class Engine implements AutoCloseable {
                 dispatch.onContextCollected(target);
             }
         }
+    }
+
+    /**
+     * A callback that is invoked repeatedly while persisting the auxiliary engine cache.
+     * <p>
+     * The callback may be polled during compilation preparation. Some hosts may also support
+     * low-level auxiliary image persistence cancellation for host-specific callback
+     * implementations with additional runtime constraints.
+     *
+     * @since 25.1
+     */
+    @FunctionalInterface
+    public interface CancellationCallback {
+
+        /**
+         * @return whether auxiliary engine cache persistence should be cancelled.
+         * @since 25.1
+         */
+        boolean shouldCancel();
     }
 }

--- a/sdk/src/org.graalvm.polyglot/src/org/graalvm/polyglot/impl/AbstractPolyglotImpl.java
+++ b/sdk/src/org.graalvm.polyglot/src/org/graalvm/polyglot/impl/AbstractPolyglotImpl.java
@@ -55,6 +55,7 @@ import java.lang.reflect.Type;
 import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
+import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
@@ -853,6 +854,8 @@ public abstract class AbstractPolyglotImpl {
         public abstract void onEngineCollected(Object engineReceiver);
 
         public abstract boolean storeCache(Object engineReceiver, Path targetFile, long cancelledWord);
+
+        public abstract ByteBuffer persistCache(Object engineReceiver, Engine.CancellationCallback callback);
 
     }
 

--- a/truffle/CHANGELOG.md
+++ b/truffle/CHANGELOG.md
@@ -3,6 +3,7 @@
 This changelog summarizes major changes between Truffle versions relevant to languages implementors building upon the Truffle framework. The main focus is on APIs exported by Truffle.
 
 ## Version 25.0
+* GR-73900: Added `Engine.persistCache(Engine.CancellationCallback)` to persist the auxiliary engine cache into an in-memory `ByteBuffer` with callback-based cancellation support.
 * GR-31495 Added ability to specify language and instrument specific options using `Source.Builder.option(String, String)`. Languages may describe available source options by implementing `TruffleLanguage.getSourceOptionDescriptors()` and `TruffleInstrument.getSourceOptionDescriptors()` respectively.
 * GR-61493 Added `RootNode.prepareForCall` which allows root nodes to prepare themselves for use as a call target (or to validate whether they can be used as a call target).
 * GR-57063 Bytecode DSL: Improved variadic support. Variadic operands compile and execute now more efficiently with fewer reallocations.

--- a/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/wrapper/HostEngineDispatch.java
+++ b/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/wrapper/HostEngineDispatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -43,6 +43,7 @@ package com.oracle.truffle.api.test.wrapper;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.ref.Reference;
+import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.time.ZoneId;
 import java.util.Map;
@@ -192,6 +193,11 @@ public class HostEngineDispatch extends AbstractEngineDispatch {
 
     @Override
     public boolean storeCache(Object engineReceiver, Path targetFile, long cancelledWord) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ByteBuffer persistCache(Object engineReceiver, Engine.CancellationCallback callback) {
         throw new UnsupportedOperationException();
     }
 

--- a/truffle/src/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
+++ b/truffle/src/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -51,6 +51,7 @@ import java.lang.reflect.Type;
 import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.time.ZoneId;
@@ -77,6 +78,7 @@ import org.graalvm.options.OptionDescriptors;
 import org.graalvm.options.OptionKey;
 import org.graalvm.options.OptionValues;
 import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Engine;
 import org.graalvm.polyglot.HostAccess.TargetMappingPrecedence;
 import org.graalvm.polyglot.SandboxPolicy;
 import org.graalvm.polyglot.impl.AbstractPolyglotImpl;
@@ -1301,6 +1303,8 @@ public abstract class Accessor {
         public abstract boolean onEngineClosing(Object runtimeData);
 
         public abstract boolean onStoreCache(Object runtimeData, Path targetPath, long cancelledWord);
+
+        public abstract ByteBuffer persistCache(Object runtimeData, Engine.CancellationCallback callback);
 
         public abstract void onEngineClosed(Object runtimeData);
 

--- a/truffle/src/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/DefaultRuntimeAccessor.java
+++ b/truffle/src/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/DefaultRuntimeAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -40,6 +40,7 @@
  */
 package com.oracle.truffle.api.impl;
 
+import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -47,6 +48,7 @@ import java.util.function.Supplier;
 
 import org.graalvm.options.OptionDescriptors;
 import org.graalvm.options.OptionValues;
+import org.graalvm.polyglot.Engine;
 import org.graalvm.polyglot.SandboxPolicy;
 
 import com.oracle.truffle.api.Assumption;
@@ -258,6 +260,11 @@ final class DefaultRuntimeAccessor extends Accessor {
 
         @Override
         public boolean onStoreCache(Object runtimeData, Path targetPath, long cancelledWord) {
+            throw new UnsupportedOperationException("Persisting an engine is not supported with the the Truffle fallback runtime. It is only supported on native-image hosts.");
+        }
+
+        @Override
+        public ByteBuffer persistCache(Object runtimeData, Engine.CancellationCallback callback) {
             throw new UnsupportedOperationException("Persisting an engine is not supported with the the Truffle fallback runtime. It is only supported on native-image hosts.");
         }
 

--- a/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/PolyglotEngineDispatch.java
+++ b/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/PolyglotEngineDispatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -43,6 +43,7 @@ package com.oracle.truffle.polyglot;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.ref.Reference;
+import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -333,6 +334,12 @@ final class PolyglotEngineDispatch extends AbstractEngineDispatch {
     public boolean storeCache(Object engineReceiver, Path targetFile, long cancelledWord) {
         PolyglotEngineImpl engine = ((PolyglotEngineImpl) engineReceiver);
         return engine.storeCache(targetFile, cancelledWord);
+    }
+
+    @Override
+    public ByteBuffer persistCache(Object engineReceiver, Engine.CancellationCallback callback) {
+        PolyglotEngineImpl engine = ((PolyglotEngineImpl) engineReceiver);
+        return engine.persistCache(callback);
     }
 
 }

--- a/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/PolyglotEngineImpl.java
+++ b/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/PolyglotEngineImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -1259,19 +1259,33 @@ final class PolyglotEngineImpl implements com.oracle.truffle.polyglot.PolyglotIm
         }
 
         synchronized (this.lock) {
-            if (closingThread != null || closed) {
-                throw new IllegalStateException("The engine is already closed and cannot be cancelled or persisted.");
-            }
-            if (!storeEngine) {
-                throw new IllegalStateException(
-                                "In order to store the cache the option 'engine.CacheStoreEnabled' must be set to 'true'.");
-            }
-            List<PolyglotContextImpl> localContexts = collectAliveContexts();
-            if (!localContexts.isEmpty()) {
-                throw new IllegalStateException("There are still alive contexts that need to be closed or cancelled before the engine can be persisted.");
-            }
-
+            validateStoreCacheState();
             return RUNTIME.onStoreCache(this.runtimeData, targetPath, cancelledWord);
+        }
+    }
+
+    ByteBuffer persistCache(Engine.CancellationCallback callback) {
+        if (!TruffleOptions.AOT) {
+            throw new UnsupportedOperationException("Persisting the engine cache is only supported on native-image hosts.");
+        }
+
+        synchronized (this.lock) {
+            validateStoreCacheState();
+            return RUNTIME.persistCache(this.runtimeData, callback);
+        }
+    }
+
+    private void validateStoreCacheState() {
+        if (closingThread != null || closed) {
+            throw new IllegalStateException("The engine is already closed and cannot be cancelled or persisted.");
+        }
+        if (!storeEngine) {
+            throw new IllegalStateException(
+                            "In order to store the cache the option 'engine.CacheStoreEnabled' must be set to 'true'.");
+        }
+        List<PolyglotContextImpl> localContexts = collectAliveContexts();
+        if (!localContexts.isEmpty()) {
+            throw new IllegalStateException("There are still alive contexts that need to be closed or cancelled before the engine can be persisted.");
         }
     }
 

--- a/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/EngineCacheSupport.java
+++ b/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/EngineCacheSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -40,11 +40,13 @@
  */
 package com.oracle.truffle.runtime;
 
+import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.util.function.Function;
 
 import org.graalvm.options.OptionDescriptors;
 import org.graalvm.options.OptionValues;
+import org.graalvm.polyglot.Engine;
 
 import com.oracle.truffle.api.TruffleLogger;
 
@@ -58,6 +60,11 @@ public interface EngineCacheSupport extends OptimizedRuntimeServiceProvider {
 
     @SuppressWarnings("unused")
     default boolean onStoreCache(EngineData e, Path path, long cancelledWord) {
+        throw new UnsupportedOperationException("Engine persist ist not yet supported on this JDK. Please update to resolve this problem.");
+    }
+
+    @SuppressWarnings("unused")
+    default ByteBuffer persistCache(EngineData e, Engine.CancellationCallback callback) {
         throw new UnsupportedOperationException("Engine persist ist not yet supported on this JDK. Please update to resolve this problem.");
     }
 

--- a/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/EngineCacheSupport.java
+++ b/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/EngineCacheSupport.java
@@ -60,12 +60,12 @@ public interface EngineCacheSupport extends OptimizedRuntimeServiceProvider {
 
     @SuppressWarnings("unused")
     default boolean onStoreCache(EngineData e, Path path, long cancelledWord) {
-        throw new UnsupportedOperationException("Engine persist ist not yet supported on this JDK. Please update to resolve this problem.");
+        throw new UnsupportedOperationException("Engine persist is not yet supported on this JDK. Please update to resolve this problem.");
     }
 
     @SuppressWarnings("unused")
     default ByteBuffer persistCache(EngineData e, Engine.CancellationCallback callback) {
-        throw new UnsupportedOperationException("Engine persist ist not yet supported on this JDK. Please update to resolve this problem.");
+        throw new UnsupportedOperationException("Engine persist is not yet supported on this JDK. Please update to resolve this problem.");
     }
 
     void onEngineClosed(EngineData e);

--- a/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/EngineData.java
+++ b/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/EngineData.java
@@ -91,12 +91,14 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.nio.ByteBuffer;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.logging.Level;
 
 import org.graalvm.collections.Pair;
 import org.graalvm.options.OptionValues;
+import org.graalvm.polyglot.Engine;
 import org.graalvm.polyglot.SandboxPolicy;
 
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
@@ -310,6 +312,10 @@ public final class EngineData {
 
     public boolean onStoreCache(Path targetPath, long cancelledWord) {
         return getRuntime().getEngineCacheSupport().onStoreCache(this, targetPath, cancelledWord);
+    }
+
+    public ByteBuffer persistCache(Engine.CancellationCallback callback) {
+        return getRuntime().getEngineCacheSupport().persistCache(this, callback);
     }
 
     private void loadOptions(OptionValues options, SandboxPolicy sandboxPolicy) {

--- a/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/OptimizedRuntimeSupport.java
+++ b/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/OptimizedRuntimeSupport.java
@@ -40,6 +40,7 @@
  */
 package com.oracle.truffle.runtime;
 
+import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -47,6 +48,7 @@ import java.util.function.Supplier;
 
 import org.graalvm.options.OptionDescriptors;
 import org.graalvm.options.OptionValues;
+import org.graalvm.polyglot.Engine;
 import org.graalvm.polyglot.SandboxPolicy;
 
 import com.oracle.truffle.api.Assumption;
@@ -357,6 +359,11 @@ final class OptimizedRuntimeSupport extends RuntimeSupport {
     @Override
     public boolean onStoreCache(Object runtimeData, Path targetPath, long cancelledWord) {
         return ((EngineData) runtimeData).onStoreCache(targetPath, cancelledWord);
+    }
+
+    @Override
+    public ByteBuffer persistCache(Object runtimeData, Engine.CancellationCallback callback) {
+        return ((EngineData) runtimeData).persistCache(callback);
     }
 
     @Override


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/13310

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** There were no conflicts.

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk25u/issues/67