### PR TITLE
[Backport] [Oracle GraalVM] [GR-74942] Backport to 25.0: Ensure ArchiveSupport extracts to intended directory

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/util/ArchiveSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/util/ArchiveSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -102,14 +102,18 @@ public class ArchiveSupport {
     }
 
     public void expandJarToDir(Function<Path, Path> relativizeEntry, Path inputJarFilePath, Path outputDir, BooleanSupplier outputDirDeleted) {
+        Path normalizedOutputDir = outputDir.toAbsolutePath().normalize();
         try {
             try (JarFile archive = new JarFile(inputJarFilePath.toFile())) {
                 Enumeration<JarEntry> jarEntries = archive.entries();
                 while (jarEntries.hasMoreElements() && !outputDirDeleted.getAsBoolean()) {
                     JarEntry jarEntry = jarEntries.nextElement();
                     Path originalEntry = outputDir.resolve(jarEntry.getName());
-                    Path targetEntry = relativizeEntry.apply(originalEntry);
+                    Path targetEntry = relativizeEntry.apply(originalEntry).toAbsolutePath().normalize();
                     try {
+                        if (!targetEntry.startsWith(normalizedOutputDir)) {
+                            throw VMError.shouldNotReachHere("Archive entry '" + jarEntry.getName() + "' resolves outside of " + normalizedOutputDir);
+                        }
                         Path targetParent = targetEntry.getParent();
                         if (targetParent != null) {
                             Files.createDirectories(targetParent);


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/13345

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** There were no conflicts.

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk25u/issues/68