### PR TITLE
[Backport] [Oracle GraalVM] [GR-73812] Backport to 25.0: Fix simplification of x < x + a

### DIFF
--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/nodes/calc/IntegerLowerThanNode.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/nodes/calc/IntegerLowerThanNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -630,7 +630,7 @@ public abstract class IntegerLowerThanNode extends CompareNode {
              * addition not the comparison.
              */
             if (mirrored) {
-                if (aStamp.contains(0)) {
+                if (aStamp.contains(0) || (aStamp.canBeNegative() && aStamp.canBePositive())) {
                     // a may be zero
                     return aStamp.unrestricted();
                 }


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/13079

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** There were no conflicts.

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk25u/issues/70