### PR TITLE
[Backport] [Oracle GraalVM] [GR-74299] Backport to 25.0: Fix missing reflection registration for ICU4J.

### DIFF
--- a/truffle/src/org.graalvm.shadowed.com.ibm.icu/src/META-INF/native-image/org.graalvm.shadowed/icu4j/reflect-config.json
+++ b/truffle/src/org.graalvm.shadowed.com.ibm.icu/src/META-INF/native-image/org.graalvm.shadowed/icu4j/reflect-config.json
@@ -14,6 +14,13 @@
     "name":"org.graalvm.shadowed.com.ibm.icu.impl.LocaleDisplayNamesImpl",
     "methods":[
       {
+        "name": "getInstance",
+        "parameterTypes": [
+          "org.graalvm.shadowed.com.ibm.icu.util.ULocale",
+          "org.graalvm.shadowed.com.ibm.icu.text.LocaleDisplayNames$DialectHandling"
+        ]
+      },
+      {
         "name":"getInstance",
         "parameterTypes":[
           "org.graalvm.shadowed.com.ibm.icu.util.ULocale",


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/13192

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:** There were no conflicts.

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk25u/issues/80