### PR TITLE
[Backport] [Oracle GraalVM] [GR-75755] Initialize JDK Password ConsoleHolder at run time.

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JDKRegistrations.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JDKRegistrations.java
@@ -29,7 +29,9 @@ import java.lang.module.ModuleReader;
 import java.lang.module.ResolvedModule;
 import java.util.Optional;
 
+import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.hosted.RuntimeResourceAccess;
+import org.graalvm.nativeimage.impl.RuntimeClassInitializationSupport;
 
 import com.oracle.svm.core.feature.AutomaticallyRegisteredFeature;
 import com.oracle.svm.core.feature.InternalFeature;
@@ -54,6 +56,11 @@ class JDKRegistrations extends JNIRegistrationUtil implements InternalFeature {
          * and even more after JDK 17.
          */
         initializeAtRunTime(a, "java.io.Console");
+
+        /* Starting with JDK 25.0.3, Password caches Console state in this holder class. */
+        optionalClazz(a, "sun.security.util.Password$ConsoleHolder")
+                        .ifPresent(clazz -> ImageSingletons.lookup(RuntimeClassInitializationSupport.class).initializeAtRunTime(clazz,
+                                        "ConsoleHolder has a static field of type Console, which is initialized at run time"));
 
         /*
          * Holds system and user library paths derived from the `java.library.path` and


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/13567

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:**
- The change reworked to work without JVMCIRuntimeClassInitializationSupport class which was introduced later in graalvm mainline.

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk25u/issues/94