### PR TITLE
[Backport] [Oracle GraalVM] [GR-73806] Backport to 25.0: An error occurred while writing the heap dump (darwin-aarch64)

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/dump/HeapDumpMetadata.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/dump/HeapDumpMetadata.java
@@ -24,6 +24,9 @@
  */
 package com.oracle.svm.core.heap.dump;
 
+import static com.oracle.svm.core.heap.dump.HeapDumpWriter.HeapDumpException;
+import static com.oracle.svm.core.heap.dump.HeapDumpWriter.HeapDumpError.AllocationFailed;
+
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
@@ -120,7 +123,7 @@ public class HeapDumpMetadata {
         this.data = value;
     }
 
-    public boolean initialize() {
+    public void initialize() {
         assert classInfos.isNull() && fieldInfoTable.isNull() && fieldNameTable.isNull();
 
         Pointer start = NonmovableArrays.getArrayBase(NonmovableArrays.fromImageHeap(data));
@@ -144,19 +147,19 @@ public class HeapDumpMetadata {
         UnsignedWord classInfosSize = Word.unsigned(classInfoCount).multiply(SizeOf.get(ClassInfo.class));
         classInfos = NullableNativeMemory.calloc(classInfosSize, NmtCategory.HeapDump);
         if (classInfos.isNull()) {
-            return false;
+            throw HeapDumpException.throwSingleton(AllocationFailed);
         }
 
         UnsignedWord fieldStartsSize = Word.unsigned(totalFieldCount).multiply(SizeOf.get(FieldInfoPointer.class));
         fieldInfoTable = NullableNativeMemory.calloc(fieldStartsSize, NmtCategory.HeapDump);
         if (fieldInfoTable.isNull()) {
-            return false;
+            throw HeapDumpException.throwSingleton(AllocationFailed);
         }
 
         UnsignedWord fieldNameTableSize = Word.unsigned(fieldNameCount).multiply(SizeOf.get(FieldNamePointer.class));
         fieldNameTable = NullableNativeMemory.calloc(fieldNameTableSize, NmtCategory.HeapDump);
         if (fieldNameTable.isNull()) {
-            return false;
+            throw HeapDumpException.throwSingleton(AllocationFailed);
         }
 
         /* Read the classes and fields. */
@@ -209,7 +212,6 @@ public class HeapDumpMetadata {
                 computeInstanceFieldsDumpSize(classInfo);
             }
         }
-        return true;
     }
 
     /**

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/dump/HeapDumpSupportImpl.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/dump/HeapDumpSupportImpl.java
@@ -38,6 +38,8 @@ import org.graalvm.word.Pointer;
 
 import com.oracle.svm.core.UnmanagedMemoryUtil;
 import com.oracle.svm.core.VMInspectionOptions;
+import com.oracle.svm.core.c.struct.PinnedObjectField;
+import com.oracle.svm.core.heap.dump.HeapDumpWriter.HeapDumpError;
 import com.oracle.svm.core.heap.GCCause;
 import com.oracle.svm.core.heap.Heap;
 import com.oracle.svm.core.heap.RestrictHeapAccess;
@@ -53,6 +55,7 @@ import com.oracle.svm.core.thread.NativeVMOperation;
 import com.oracle.svm.core.thread.NativeVMOperationData;
 import com.oracle.svm.core.thread.VMOperation;
 import com.oracle.svm.core.util.TimeUtils;
+import com.oracle.svm.core.util.VMError;
 
 import jdk.graal.compiler.api.replacements.Fold;
 import jdk.graal.compiler.word.Word;
@@ -110,7 +113,7 @@ public class HeapDumpSupportImpl extends HeapDumping {
     private void dumpHeapOnOutOfMemoryError0() {
         RawFilePath path = outOfMemoryHeapDumpPath;
         if (path.isNull()) {
-            Log.log().string("OutOfMemoryError heap dumping failed because the heap dump file path could not be allocated.").newline();
+            Log.log().string("Out-of-memory heap dumping failed because the heap dump file path could not be allocated.").newline();
             return;
         }
 
@@ -123,12 +126,15 @@ public class HeapDumpSupportImpl extends HeapDumping {
         try {
             Log.log().string("Dumping heap to ").string(outOfMemoryHeapDumpPathText).string(" ...").newline();
             long start = System.nanoTime();
-            if (dumpHeap(fd, false)) {
+            HeapDumpError error = dumpHeap(fd, false);
+            if (error == null) {
                 long fileSize = getFileSupport().size(fd);
                 long elapsedMs = TimeUtils.millisSinceNanos(start);
                 long seconds = elapsedMs / TimeUtils.millisPerSecond;
                 long ms = elapsedMs % TimeUtils.millisPerSecond;
                 Log.log().string("Heap dump file created [").signed(fileSize).string(" bytes in ").signed(seconds).character('.').signed(ms).string(" secs]").newline();
+            } else {
+                Log.log().string("Out-of-memory heap dumping failed: ").string(error.getMessage()).newline();
             }
         } finally {
             getFileSupport().close(fd);
@@ -154,20 +160,20 @@ public class HeapDumpSupportImpl extends HeapDumping {
         }
     }
 
-    private boolean dumpHeap(RawFileDescriptor fd, boolean gcBefore) {
+    private HeapDumpError dumpHeap(RawFileDescriptor fd, boolean gcBefore) {
         int size = SizeOf.get(HeapDumpVMOperationData.class);
         HeapDumpVMOperationData data = StackValue.get(size);
         UnmanagedMemoryUtil.fill((Pointer) data, Word.unsigned(size), (byte) 0);
         data.setGCBefore(gcBefore);
         data.setRawFileDescriptor(fd);
         heapDumpOperation.enqueue(data);
-        return data.getSuccess();
+        return data.getError();
     }
 
     public void writeHeapTo(RawFileDescriptor fd, boolean gcBefore) throws IOException {
-        boolean success = dumpHeap(fd, gcBefore);
-        if (!success) {
-            throw new IOException("An error occurred while writing the heap dump.");
+        HeapDumpError error = dumpHeap(fd, gcBefore);
+        if (error != null) {
+            throw new IOException("Heap dumping failed: " + error.getMessage() + ".");
         }
     }
 
@@ -191,10 +197,12 @@ public class HeapDumpSupportImpl extends HeapDumping {
         void setRawFileDescriptor(RawFileDescriptor fd);
 
         @RawField
-        boolean getSuccess();
+        @PinnedObjectField
+        HeapDumpError getError();
 
         @RawField
-        void setSuccess(boolean value);
+        @PinnedObjectField
+        void setError(HeapDumpError value);
     }
 
     private class HeapDumpOperation extends NativeVMOperation {
@@ -215,11 +223,10 @@ public class HeapDumpSupportImpl extends HeapDumping {
         @RestrictHeapAccess(access = NO_ALLOCATION, reason = "Heap dumping must not allocate.")
         private void dumpHeap(HeapDumpVMOperationData data) {
             try {
-                boolean success = writer.dumpHeap(data.getRawFileDescriptor());
-                data.setSuccess(success);
+                HeapDumpError error = writer.dumpHeap(data.getRawFileDescriptor());
+                data.setError(error);
             } catch (Throwable e) {
-                Log.log().string("An exception occurred during heap dumping. The data in the heap dump file may be corrupt: ").string(e.getClass().getName()).newline();
-                data.setSuccess(false);
+                throw VMError.shouldNotReachHere(e);
             }
         }
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/dump/HeapDumpWriter.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/dump/HeapDumpWriter.java
@@ -25,6 +25,15 @@
 package com.oracle.svm.core.heap.dump;
 
 import static com.oracle.svm.core.heap.RestrictHeapAccess.Access.NO_ALLOCATION;
+import static com.oracle.svm.core.heap.dump.HeapDumpWriter.HeapDumpError.AllocationFailed;
+import static com.oracle.svm.core.heap.dump.HeapDumpWriter.HeapDumpError.AssertionError;
+import static com.oracle.svm.core.heap.dump.HeapDumpWriter.HeapDumpError.FileFlushFailed;
+import static com.oracle.svm.core.heap.dump.HeapDumpWriter.HeapDumpError.FileWriteFailed;
+import static com.oracle.svm.core.heap.dump.HeapDumpWriter.HeapDumpError.GetFilePositionFailed;
+import static com.oracle.svm.core.heap.dump.HeapDumpWriter.HeapDumpError.SetFilePositionFailed;
+import static com.oracle.svm.core.heap.dump.HeapDumpWriter.HeapDumpError.UnexpectedError;
+
+import java.io.Serial;
 
 import org.graalvm.nativeimage.CurrentIsolate;
 import org.graalvm.nativeimage.IsolateThread;
@@ -410,16 +419,15 @@ public class HeapDumpWriter {
     private final HeapDumpMetadata metadata;
 
     private BufferedFile f;
-    private long topLevelRecordBegin = -1;
-    private long subRecordBegin = -1;
-    private boolean error;
+    private long topLevelRecordBegin;
+    private long subRecordBegin;
 
     @Platforms(Platform.HOSTED_ONLY.class)
     public HeapDumpWriter(HeapDumpMetadata metadata) {
         this.metadata = metadata;
     }
 
-    public boolean dumpHeap(RawFileDescriptor fd) {
+    public HeapDumpError dumpHeap(RawFileDescriptor fd) {
         assert VMOperation.isInProgressAtSafepoint();
         assert RecurringCallbackSupport.isCallbackUnsupportedOrTimerSuspended();
 
@@ -432,45 +440,49 @@ public class HeapDumpWriter {
         }
     }
 
-    private boolean dumpHeap0(RawFileDescriptor fd) {
-        boolean initialized = initialize(fd);
+    private HeapDumpError dumpHeap0(RawFileDescriptor fd) {
+        HeapDumpError error = dumpHeap1(fd);
+        /* teardown must always be executed, even if the initialization failed. */
+        teardown(error);
+        return error;
+    }
+
+    private HeapDumpError dumpHeap1(RawFileDescriptor fd) {
         try {
-            if (initialized) {
-                return writeHeapDump();
-            } else {
-                Log.log().string("An error occurred while initializing the heap dump infrastructure. No heap data will be dumped.").newline();
-                return false;
-            }
-        } finally {
-            /* teardown must always be executed, even if the initialization failed. */
-            teardown();
+            initialize(fd);
+            writeHeapDump();
+            return null;
+        } catch (AssertionError e) {
+            return AssertionError;
+        } catch (HeapDumpException e) {
+            return e.getAndClearError();
+        } catch (Throwable e) {
+            return UnexpectedError;
         }
     }
 
-    private boolean initialize(RawFileDescriptor fd) {
-        assert topLevelRecordBegin == -1 && subRecordBegin == -1 && !error;
+    private void initialize(RawFileDescriptor fd) {
+        topLevelRecordBegin = -1;
+        subRecordBegin = -1;
 
-        this.f = file().allocate(fd, NmtCategory.HeapDump);
+        f = file().allocate(fd, NmtCategory.HeapDump);
         if (f.isNull()) {
-            return false;
+            throw HeapDumpException.throwSingleton(AllocationFailed);
         }
-        return metadata.initialize();
+        metadata.initialize();
     }
 
-    private void teardown() {
+    private void teardown(HeapDumpError error) {
+
         metadata.teardown();
 
-        assert f.isNull() || error || file().getUnflushedDataSize(f) == 0;
+        assert f.isNull() || error != null || file().getUnflushedDataSize(f) == 0;
         file().free(f);
         this.f = Word.nullPointer();
-
-        this.topLevelRecordBegin = -1;
-        this.subRecordBegin = -1;
-        this.error = false;
     }
 
     @NeverInline("Starting a stack walk in the caller frame.")
-    private boolean writeHeapDump() {
+    private void writeHeapDump() {
         /*
          * Only read the stack pointer for the current thread once. This ensures consistency for all
          * the information that we dump about the stack of the current thread.
@@ -496,12 +508,6 @@ public class HeapDumpWriter {
         endTopLevelRecord();
 
         flush();
-
-        if (error) {
-            Log.log().string("An error occurred while writing the heap dump data. The data in the heap dump file may be corrupt.").newline();
-            return false;
-        }
-        return true;
     }
 
     private void writeHeader() {
@@ -1033,37 +1039,37 @@ public class HeapDumpWriter {
 
     private void writeByte(byte value) {
         boolean success = file().writeByte(f, value);
-        handleError(success);
+        throwOnError(success, FileWriteFailed);
     }
 
     private void writeShort(short value) {
         boolean success = file().writeShort(f, value);
-        handleError(success);
+        throwOnError(success, FileWriteFailed);
     }
 
     private void writeChar(char value) {
         boolean success = file().writeChar(f, value);
-        handleError(success);
+        throwOnError(success, FileWriteFailed);
     }
 
     private void writeInt(int value) {
         boolean success = file().writeInt(f, value);
-        handleError(success);
+        throwOnError(success, FileWriteFailed);
     }
 
     private void writeLong(long value) {
         boolean success = file().writeLong(f, value);
-        handleError(success);
+        throwOnError(success, FileWriteFailed);
     }
 
     private void writeFloat(float value) {
         boolean success = file().writeFloat(f, value);
-        handleError(success);
+        throwOnError(success, FileWriteFailed);
     }
 
     private void writeDouble(double value) {
         boolean success = file().writeDouble(f, value);
-        handleError(success);
+        throwOnError(success, FileWriteFailed);
     }
 
     private void writeType(HProfType type) {
@@ -1112,7 +1118,7 @@ public class HeapDumpWriter {
             assert wordSize() == 4;
             success = file().writeInt(f, (int) value);
         }
-        handleError(success);
+        throwOnError(success, FileWriteFailed);
     }
 
     private void writeUTF8(String value) {
@@ -1121,33 +1127,33 @@ public class HeapDumpWriter {
 
     private void writeUTF8(String value, CharReplacer replacer) {
         boolean success = file().writeUTF8(f, value, replacer);
-        handleError(success);
+        throwOnError(success, FileWriteFailed);
     }
 
     private void write(Pointer data, UnsignedWord size) {
         boolean success = file().write(f, data, size);
-        handleError(success);
+        throwOnError(success, FileWriteFailed);
     }
 
     private long getPosition() {
         long result = file().position(f);
-        handleError(result >= 0);
+        throwOnError(result >= 0, GetFilePositionFailed);
         return result;
     }
 
     private void setPosition(long newPos) {
         boolean success = file().seek(f, newPos);
-        handleError(success);
+        throwOnError(success, SetFilePositionFailed);
     }
 
     private void flush() {
         boolean success = file().flush(f);
-        handleError(success);
+        throwOnError(success, FileFlushFailed);
     }
 
-    private void handleError(boolean success) {
+    private static void throwOnError(boolean success, HeapDumpError error) {
         if (!success) {
-            error = true;
+            throw HeapDumpException.throwSingleton(error);
         }
     }
 
@@ -1191,7 +1197,6 @@ public class HeapDumpWriter {
 
         @SuppressWarnings("hiding")
         public void initialize(int threadSerialNum, long nextFrameId, boolean markGCRoots) {
-            assert nextFrameId > 0;
             assert threadSerialNum > 0;
             assert nextFrameId > 0;
 
@@ -1475,5 +1480,50 @@ public class HeapDumpWriter {
     }
 
     private static final class UnknownClass {
+    }
+
+    static final class HeapDumpException extends RuntimeException {
+        @Serial private static final long serialVersionUID = 1;
+        private static final HeapDumpException SINGLETON = new HeapDumpException();
+
+        private HeapDumpError error;
+
+        @Platforms(Platform.HOSTED_ONLY.class)
+        private HeapDumpException() {
+        }
+
+        public static HeapDumpException throwSingleton(HeapDumpError value) {
+            assert SINGLETON.error == null;
+            SINGLETON.error = value;
+            throw SINGLETON;
+        }
+
+        public HeapDumpError getAndClearError() {
+            HeapDumpError result = error;
+            error = null;
+
+            assert result != null;
+            return result;
+        }
+    }
+
+    public enum HeapDumpError {
+        AllocationFailed("Insufficient native memory"),
+        FileWriteFailed("I/O error while writing heap dump file"),
+        FileFlushFailed("I/O error while flushing heap dump file"),
+        GetFilePositionFailed("I/O error while getting position in heap dump file"),
+        SetFilePositionFailed("I/O error while setting position in heap dump file"),
+        AssertionError("An AssertionError occurred"),
+        UnexpectedError("An unexpected error occurred");
+
+        private final String message;
+
+        HeapDumpError(String message) {
+            this.message = message;
+        }
+
+        public String getMessage() {
+            return message;
+        }
     }
 }


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/12820

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:**
```
<<<<<<< HEAD
        return metadata.initialize();
    }

    private void teardown() {
        metadata.teardown();
=======
        HeapDumpMetadata.singleton().initialize();
    }

    private void teardown(HeapDumpError error) {
        HeapDumpMetadata.singleton().teardown();
>>>>>>> b3581d91d42 (Improve error output for heap dumping.)
```
- cause: metod body is a bit different `metadata.teardown();` - vs - `HeapDumpMetadata.singleton().initialize();`
- resolution: follow the change: add the parameter, update the assert, but leave the method body intact

```
<<<<<<< HEAD
=======
import com.oracle.svm.core.heap.dump.HeapDumpWriter.HeapDumpError;
import com.oracle.svm.core.imagelayer.ImageLayerBuildingSupport;
>>>>>>> b3581d91d42 (Improve error output for heap dumping.)
```
- resolution: add manually HeapDumpWriter import to the list

```
<<<<<<< HEAD
            Log.log().string("Out-of-memory heap dumping failed because the heap dump file could not be created: ").string(outOfMemoryHeapDumpPathText).newline();
=======
            Log.log().string("Out-of-memory heap dumping failed because the heap dump file could not be created: ").string(path).newline();
>>>>>>> b3581d91d42 (Improve error output for heap dumping.)
```
- cause: in a local repostory `outOfMemoryHeapDumpPathText` field is used instead of `path` parameter
- resolution: kept local `outOfMemoryHeapDumpPathText` instead of upstream's `path` (CCharPointer); text improvement ("OutOfMemoryError" -> "Out-of-memory") taken from the backported change


<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk25u/issues/72