### PR TITLE
[Backport] [Oracle GraalVM] [GR-73934] Backport to 25.0: Race condition in ThreadStatusTransition.fromNativeToJava(...).

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/graal/snippets/SafepointSnippets.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/graal/snippets/SafepointSnippets.java
@@ -78,7 +78,7 @@ public final class SafepointSnippets extends SubstrateTemplates implements Snipp
     private static void safepointSnippet() {
         final boolean needSlowPath = SafepointCheckNode.test();
         if (BranchProbabilityNode.probability(BranchProbabilityNode.VERY_SLOW_PATH_PROBABILITY, needSlowPath)) {
-            callSlowPathSafepointCheck(SafepointSlowpath.ENTER_SLOW_PATH_SAFEPOINT_CHECK);
+            callSlowPathSafepointCheck(SafepointSlowpath.ENTER_SLOW_PATH_SAFEPOINT_CHECK_CALLEE_SAVED_CCONV);
         }
     }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Safepoint.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Safepoint.java
@@ -327,7 +327,7 @@ public final class Safepoint {
             restoreCounter(thread);
 
             /* Skip suspended threads so that they remain in STATUS_IN_SAFEPOINT. */
-            if (ThreadSuspendSupport.isSuspended(thread)) {
+            if (ThreadSuspendSupport.shouldBlock(thread)) {
                 continue;
             }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/SafepointSlowpath.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/SafepointSlowpath.java
@@ -59,7 +59,7 @@ public class SafepointSlowpath {
     /*
      * For all safepoint-related foreign calls, we must assume that they kill the TLAB locations
      * because those might be modified by a GC. We ignore all other writes as those need to use
-     * volatile semantics anyways (to prevent normal race conditions). For performance reasons, we
+     * volatile semantics anyway (to prevent normal race conditions). For performance reasons, we
      * need to assume that recurring callbacks don't do any writes that interfere in a problematic
      * way with the read elimination that is done for the application (otherwise, we would have to
      * kill all memory locations at every safepoint).
@@ -67,25 +67,29 @@ public class SafepointSlowpath {
      * NOTE: all locations that are killed by safepoint slowpath calls must also be killed by most
      * other foreign calls because the call target may contain a safepoint.
      */
-    public static final SubstrateForeignCallDescriptor ENTER_SLOW_PATH_SAFEPOINT_CHECK = SnippetRuntime.findForeignCall(SafepointSlowpath.class,
-                    "enterSlowPathSafepointCheck", NO_SIDE_EFFECT);
+    public static final SubstrateForeignCallDescriptor ENTER_SLOW_PATH_SAFEPOINT_CHECK_CALLEE_SAVED_CCONV = SnippetRuntime.findForeignCall(SafepointSlowpath.class,
+                    "enterSlowPathSafepointCheckCalleeSavedCCONV", NO_SIDE_EFFECT);
+    static final SubstrateForeignCallDescriptor ENTER_SLOW_PATH_SAFEPOINT_CHECK_REGULAR_CCONV = SnippetRuntime.findForeignCall(SafepointSlowpath.class,
+                    "enterSlowPathSafepointCheckRegularCCONV", NO_SIDE_EFFECT);
     public static final SubstrateForeignCallDescriptor ENTER_SLOW_PATH_TRANSITION_FROM_NATIVE_TO_NEW_STATUS = SnippetRuntime.findForeignCall(SafepointSlowpath.class,
                     "enterSlowPathTransitionFromNativeToNewStatus", NO_SIDE_EFFECT);
     static final SubstrateForeignCallDescriptor SLOW_PATH_RUN_PENDING_ACTIONS = SnippetRuntime.findForeignCall(SafepointSlowpath.class,
                     "enterSlowPathRunPendingActions", NO_SIDE_EFFECT);
 
     public static final SubstrateForeignCallDescriptor[] FOREIGN_CALLS = new SubstrateForeignCallDescriptor[]{
-                    ENTER_SLOW_PATH_SAFEPOINT_CHECK,
+                    ENTER_SLOW_PATH_SAFEPOINT_CHECK_CALLEE_SAVED_CCONV,
+                    ENTER_SLOW_PATH_SAFEPOINT_CHECK_REGULAR_CCONV,
                     ENTER_SLOW_PATH_TRANSITION_FROM_NATIVE_TO_NEW_STATUS,
                     SLOW_PATH_RUN_PENDING_ACTIONS,
     };
 
     /**
      * Runs any {@link ActionOnTransitionToJavaSupport pending transition actions}.
-     *
+     * <p>
      * This method cannot use the {@link StubCallingConvention} with callee saved registers: the
      * reference map of the C call and this slow-path call must be the same. This is only guaranteed
      * when both the C call and the call to this slow path do not use callee saved registers.
+     * Otherwise, the reference map validation will fail at build-time.
      */
     @SubstrateForeignCallTarget(stubCallingConvention = false, fullyUninterruptible = true)
     @Uninterruptible(reason = "Must not contain safepoint checks.")
@@ -97,7 +101,17 @@ public class SafepointSlowpath {
 
     @SubstrateForeignCallTarget(stubCallingConvention = true)
     @Uninterruptible(reason = "Must not contain safepoint checks")
-    private static void enterSlowPathSafepointCheck() throws Throwable {
+    private static void enterSlowPathSafepointCheckCalleeSavedCCONV() throws Throwable {
+        slowPathSafepointCheck();
+    }
+
+    /**
+     * See {@link #enterSlowPathRunPendingActions} for more details on why this can't use the stub
+     * calling convention.
+     */
+    @SubstrateForeignCallTarget(stubCallingConvention = false)
+    @Uninterruptible(reason = "Must not contain safepoint checks")
+    private static void enterSlowPathSafepointCheckRegularCCONV() throws Throwable {
         slowPathSafepointCheck();
     }
 
@@ -115,9 +129,8 @@ public class SafepointSlowpath {
     }
 
     /**
-     * This method cannot use the {@link StubCallingConvention} with callee saved registers: the
-     * reference map of the C call and this slow-path call must be the same. This is only guaranteed
-     * when both the C call and the call to this slow path do not use callee saved registers.
+     * See {@link #enterSlowPathRunPendingActions} for more details on why this can't use the stub
+     * calling convention.
      */
     @SubstrateForeignCallTarget(stubCallingConvention = false)
     @Uninterruptible(reason = "Must not contain safepoint checks")
@@ -164,7 +177,7 @@ public class SafepointSlowpath {
             assert RecurringCallbackSupport.isCallbackUnsupportedOrTimerSuspended();
         } else {
             do {
-                if (Safepoint.singleton().isPendingOrInProgress() || ThreadSuspendSupport.isCurrentThreadSuspended()) {
+                if (Safepoint.singleton().isPendingOrInProgress() || ThreadSuspendSupport.shouldBlock()) {
                     freezeAtSafepoint(newStatus, callerHasJavaFrameAnchor);
                     assert StatusSupport.getStatusVolatile() == newStatus : "Transition to the new thread status must have been successful.";
                 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/ThreadStatusTransition.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/ThreadStatusTransition.java
@@ -24,6 +24,9 @@
  */
 package com.oracle.svm.core.thread;
 
+import static com.oracle.svm.core.thread.SafepointSlowpath.ENTER_SLOW_PATH_SAFEPOINT_CHECK_REGULAR_CCONV;
+import static com.oracle.svm.core.thread.SafepointSlowpath.ENTER_SLOW_PATH_TRANSITION_FROM_NATIVE_TO_NEW_STATUS;
+import static com.oracle.svm.core.thread.SafepointSlowpath.SLOW_PATH_RUN_PENDING_ACTIONS;
 import static jdk.graal.compiler.nodes.extended.BranchProbabilityNode.VERY_FAST_PATH_PROBABILITY;
 import static jdk.graal.compiler.nodes.extended.BranchProbabilityNode.VERY_SLOW_PATH_PROBABILITY;
 import static jdk.graal.compiler.nodes.extended.BranchProbabilityNode.probability;
@@ -71,21 +74,30 @@ public class ThreadStatusTransition {
         StatusSupport.assertStatusNativeOrSafepoint();
         int newStatus = StatusSupport.STATUS_IN_JAVA;
 
-        if (probability(VERY_FAST_PATH_PROBABILITY, !VMThreads.ActionOnTransitionToJavaSupport.isActionPending()) &&
-                        probability(VERY_FAST_PATH_PROBABILITY, !RecurringCallbackSupport.needsNativeToJavaSlowpath()) &&
-                        probability(VERY_FAST_PATH_PROBABILITY, StatusSupport.compareAndSetNativeToNewStatus(newStatus))) {
+        if (probability(VERY_FAST_PATH_PROBABILITY, StatusSupport.compareAndSetNativeToNewStatus(newStatus))) {
+            /* Prevent reads from floating before the status transition. */
+            MembarNode.memoryBarrier(MembarNode.FenceKind.NONE, LocationIdentity.ANY_LOCATION);
+
             if (popFrameAnchor) {
                 JavaFrameAnchors.popFrameAnchor();
             }
-        } else {
-            callSlowPathNativeToNewStatus(SafepointSlowpath.ENTER_SLOW_PATH_TRANSITION_FROM_NATIVE_TO_NEW_STATUS, newStatus, popFrameAnchor);
-        }
 
-        /*
-         * Kill all memory locations to ensure that no floating reads are scheduled before the
-         * thread is properly transitioned into Java.
-         */
-        MembarNode.memoryBarrier(MembarNode.FenceKind.NONE, LocationIdentity.ANY_LOCATION);
+            /*
+             * Another thread may have executed a VM operation in the meanwhile that modified the
+             * thread locals of this thread. It is guaranteed that this thread sees the latest
+             * values for its thread-locals because the atomic status transition above emits the
+             * necessary memory barriers.
+             */
+            if (probability(VERY_SLOW_PATH_PROBABILITY, VMThreads.ActionOnTransitionToJavaSupport.isActionPending()) ||
+                            probability(VERY_SLOW_PATH_PROBABILITY, RecurringCallbackSupport.needsNativeToJavaSlowpath())) {
+                call(ENTER_SLOW_PATH_SAFEPOINT_CHECK_REGULAR_CCONV);
+            }
+        } else {
+            call(ENTER_SLOW_PATH_TRANSITION_FROM_NATIVE_TO_NEW_STATUS, newStatus, popFrameAnchor);
+
+            /* Prevent reads from floating before the status transition. */
+            MembarNode.memoryBarrier(MembarNode.FenceKind.NONE, LocationIdentity.ANY_LOCATION);
+        }
     }
 
     /**
@@ -108,7 +120,7 @@ public class ThreadStatusTransition {
         int newStatus = StatusSupport.STATUS_IN_VM;
         boolean needSlowPath = !StatusSupport.compareAndSetNativeToNewStatus(newStatus);
         if (probability(VERY_SLOW_PATH_PROBABILITY, needSlowPath)) {
-            callSlowPathNativeToNewStatus(SafepointSlowpath.ENTER_SLOW_PATH_TRANSITION_FROM_NATIVE_TO_NEW_STATUS, newStatus, false);
+            call(ENTER_SLOW_PATH_TRANSITION_FROM_NATIVE_TO_NEW_STATUS, newStatus, false);
         }
     }
 
@@ -128,7 +140,7 @@ public class ThreadStatusTransition {
         /* Only execute pending actions but don't do a safepoint slowpath call. */
         boolean needSlowPath = VMThreads.ActionOnTransitionToJavaSupport.isActionPending();
         if (probability(VERY_SLOW_PATH_PROBABILITY, needSlowPath)) {
-            callRunPendingActions(SafepointSlowpath.SLOW_PATH_RUN_PENDING_ACTIONS);
+            call(SLOW_PATH_RUN_PENDING_ACTIONS);
         }
     }
 
@@ -155,8 +167,8 @@ public class ThreadStatusTransition {
     }
 
     @Node.NodeIntrinsic(value = ForeignCallNode.class)
-    private static native void callRunPendingActions(@Node.ConstantNodeParameter ForeignCallDescriptor descriptor);
+    private static native void call(@Node.ConstantNodeParameter ForeignCallDescriptor descriptor);
 
     @Node.NodeIntrinsic(value = ForeignCallNode.class)
-    private static native void callSlowPathNativeToNewStatus(@Node.ConstantNodeParameter ForeignCallDescriptor descriptor, int newThreadStatus, boolean popFrameAnchor);
+    private static native void call(@Node.ConstantNodeParameter ForeignCallDescriptor descriptor, int newThreadStatus, boolean popFrameAnchor);
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/ThreadSuspendSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/ThreadSuspendSupport.java
@@ -37,6 +37,8 @@ import com.oracle.svm.core.threadlocal.FastThreadLocalFactory;
 import com.oracle.svm.core.threadlocal.FastThreadLocalInt;
 import com.oracle.svm.core.util.VMError;
 
+import jdk.graal.compiler.api.directives.GraalDirectives;
+
 /**
  * Support for suspending and resuming threads.
  * <p>
@@ -116,21 +118,32 @@ public final class ThreadSuspendSupport {
         }
     }
 
+    /** {@link #shouldBlock(IsolateThread)} for the current thread. */
     @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
-    public static boolean isCurrentThreadSuspended() {
-        return isSuspended(CurrentIsolate.getCurrentThread());
+    public static boolean shouldBlock() {
+        return shouldBlock(CurrentIsolate.getCurrentThread());
     }
 
+    /**
+     * Checks whether the specified thread should block in the safepoint slowpath due to a pending
+     * suspension request.
+     * <p>
+     * This method uses a non-volatile read of the suspension flag for performance reasons, even
+     * though the flag may be updated concurrently by other threads. Callers may therefore need to
+     * use additional memory barriers or synchronization to see the latest values.
+     */
     @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
-    public static boolean isSuspended(IsolateThread thread) {
-        assert VMThreads.THREAD_MUTEX.isOwner() || thread == CurrentIsolate.getCurrentThread();
-        return suspendedTL.getVolatile(thread) > 0;
+    public static boolean shouldBlock(IsolateThread thread) {
+        if (!GraalDirectives.inIntrinsic()) {
+            assert VMThreads.THREAD_MUTEX.isOwner() || thread == CurrentIsolate.getCurrentThread();
+        }
+        return suspendedTL.get(thread) > 0;
     }
 
     @Uninterruptible(reason = "Must not contain safepoint checks.")
     public static void blockCurrentThreadIfSuspended() {
         assert VMThreads.THREAD_MUTEX.isOwner();
-        while (ThreadSuspendSupport.isCurrentThreadSuspended()) {
+        while (ThreadSuspendSupport.shouldBlock()) {
             COND_SUSPEND.blockNoTransition();
         }
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/VMThreads.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/VMThreads.java
@@ -1030,6 +1030,13 @@ public abstract class VMThreads implements InitialLayerOnlyImageSingleton {
         /** Code synchronization should be performed due to newly installed code. */
         private static final int SYNCHRONIZE_CODE = NO_ACTION + 1;
 
+        /**
+         * Checks whether an action is pending for the current thread.
+         * <p>
+         * This method uses a non-volatile read for performance reasons, even though the value may
+         * be updated concurrently by other threads. Callers may therefore need to use additional
+         * memory barriers or synchronization to see the latest values.
+         */
         @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
         public static boolean isActionPending() {
             if (!isAarch64()) {


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/13113

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:**

```cpp
<<<<<<< HEAD
    public static boolean isSuspended(IsolateThread thread) {
        assert VMThreads.THREAD_MUTEX.isOwner() || thread == CurrentIsolate.getCurrentThread();
        return suspendedTL.getVolatile(thread) > 0;
=======
    public static boolean shouldBlock(IsolateThread thread) {
        if (!GraalDirectives.inIntrinsic()) {
            assert VMThreads.SAFEPOINT_MUTEX.isOwner() || thread == CurrentIsolate.getCurrentThread();
        }
        return suspendedTL.get(thread) > 0;
>>>>>>> 883322d361a (Fix a race condition in ThreadStatusTransition.fromNativeToJava().)
```
- head: assert VMThreads.THREAD_MUTEX.isOwner() || thread == CurrentIsolate.getCurrentThread();
- remote: assert VMThreads.SAFEPOINT_MUTEX.isOwner() || thread == CurrentIsolate.getCurrentThread();
- solution: apply the change, but use THREAD_MUTEX

```cpp
<<<<<<< HEAD
        assert VMThreads.THREAD_MUTEX.isOwner();
        while (ThreadSuspendSupport.isCurrentThreadSuspended()) {
=======
        assert VMThreads.SAFEPOINT_MUTEX.isOwner();
        while (ThreadSuspendSupport.shouldBlock()) {
>>>>>>> 883322d361a (Fix a race condition in ThreadStatusTransition.fromNativeToJava().)
```
- head:          assert VMThreads.THREAD_MUTEX.isOwner();
- remote:       assert VMThreads.SAFEPOINT_MUTEX.isOwner();
- solution:
    - change `while` condition as the change proposes
    - keep assert with THREAD_MUTEX (SAFEPOINT_MUTEX does not exist locally)

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk25u/issues/71

