### PR TITLE
Windows JFR CI tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -239,7 +239,7 @@ jobs:
       run: ${MX_PATH}/mx --primary-suite-path ${PRIMARY} --java-home=${JAVA_HOME} gate --strict-mode ${{ matrix.env.GATE_OPTS }}
       if: ${{ matrix.env.GATE_TAGS == '' }}
   build-graalvm-windows:
-    name: /substratevm on Windows
+    name: /substratevm on Windows + JFR tests
     runs-on: windows-2022
     timeout-minutes: 60
     env:
@@ -284,3 +284,8 @@ jobs:
       run: |
         native-image --version
         native-image -m jdk.httpserver
+    - name: JFR unit tests
+      shell: cmd
+      run: |
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+        call ${{ env.MX_PATH }}\mx.cmd -p substratevm native-unittest com.oracle.svm.test.jfr


### PR DESCRIPTION
Closes: [Windows CI tests](https://github.com/graalvm/graalvm-community-jdk25u/issues/95)

Unfortunately there are no direct tests for heap dumps too. The `jcmd` unit tests test heap dumping functionality, but `jcmd` doesn't work on windows. 

I added these JFR tests onto the existing Windows jdk.httpserver build test. This way we avoid building GraalVM again.

If these tests add too much noise / consume too much resources, we can close this PR. This PR is essentially just a suggestion. 
