### PR TITLE
[Backport] [Oracle GraalVM] [GR-75268] Backport to 25.0: TRegex: escape Truffle Source name in TRegexExecutorRootNode.toString.

### DIFF
--- a/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/RegexBodyNode.java
+++ b/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/RegexBodyNode.java
@@ -52,6 +52,7 @@ import com.oracle.truffle.api.nodes.ExecutableNode;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.source.SourceSection;
 import com.oracle.truffle.regex.tregex.string.Encodings;
+import com.oracle.truffle.regex.tregex.util.DebugUtil;
 
 @GenerateWrapper
 public abstract class RegexBodyNode extends ExecutableNode implements InstrumentableNode {
@@ -94,7 +95,7 @@ public abstract class RegexBodyNode extends ExecutableNode implements Instrument
     public SourceSection getSourceSection() {
         if (sourceSection == null) {
             String patternSrc = source.toStringEscaped();
-            String name = patternSrc.length() > 30 ? patternSrc.substring(0, 30) + "..." : patternSrc;
+            String name = DebugUtil.pruneToSize(patternSrc, 30);
             Source src = Source.newBuilder(RegexLanguage.ID, patternSrc, name).internal(true).mimeType("application/js-regex").build();
             sourceSection = src.createSection(0, patternSrc.length());
         }

--- a/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/tregex/TRegexCompilationRequest.java
+++ b/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/tregex/TRegexCompilationRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -503,6 +503,6 @@ public final class TRegexCompilationRequest {
     }
 
     private JsonObject.JsonObjectProperty patternToJson() {
-        return Json.prop("pattern", source.getPattern().length() > 200 ? source.getPattern().substring(0, 200) + "..." : source.getPattern());
+        return Json.prop("pattern", DebugUtil.pruneToSize(source.getPattern(), 200));
     }
 }

--- a/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/tregex/nodes/TRegexExecutorEntryNode.java
+++ b/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/tregex/nodes/TRegexExecutorEntryNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -55,6 +55,7 @@ import com.oracle.truffle.api.strings.TruffleString;
 import com.oracle.truffle.regex.RegexLanguage;
 import com.oracle.truffle.regex.RegexRootNode;
 import com.oracle.truffle.regex.tregex.TRegexOptions;
+import com.oracle.truffle.regex.tregex.util.DebugUtil;
 
 /**
  * This class wraps {@link TRegexExecutorNode} and specializes on the type of the input strings
@@ -90,7 +91,8 @@ public abstract class TRegexExecutorEntryNode extends Node {
         @Override
         public String toString() {
             String src = executor.getSource().toStringEscaped();
-            return "tregex " + executor.getSource().getSource().getName() + " " + executor.getName() + " " + codeRange + ": " + (src.length() > 30 ? src.substring(0, 30) + "..." : src);
+            String name = DebugUtil.javaStringEscape(executor.getSource().getSource().getName());
+            return "tregex " + DebugUtil.pruneToSize(name, 30) + " " + executor.getName() + " " + codeRange + ": " + DebugUtil.pruneToSize(src, 30);
         }
     }
 

--- a/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/tregex/util/DebugUtil.java
+++ b/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/tregex/util/DebugUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -84,6 +84,10 @@ public class DebugUtil {
 
     public static String javaStringEscape(String string) {
         return javaStringEscape(new StringBuilder(string.length()), string).toString();
+    }
+
+    public static String pruneToSize(String s, int maxLength) {
+        return s.length() > maxLength ? s.substring(0, maxLength) + "..." : s;
     }
 
     private static StringBuilder javaStringEscape(StringBuilder sb, String string) {


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/13413
  - commit#4: https://github.com/oracle/graal/pull/13413/changes/9cc390e560b6b2417af50e979c046da38a358210 

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:**
```
<<<<<<< HEAD
import com.oracle.truffle.regex.tregex.string.Encodings;
=======
import com.oracle.truffle.regex.tregex.string.Encoding;
import com.oracle.truffle.regex.tregex.util.DebugUtil;
>>>>>>> 9cc390e560b (TRegex: escape Truffle Source name in TRegexExecutorRootNode.toString)
```
- reason: upstream refactored tregex.string.Encodings into a top-level tregex.string.Encoding; 25u still uses the inner class, so the import differs
- resolution: keep Encodings import unchanged, add DebugUtil import from the incoming commit
  
```cpp
<<<<<<< HEAD
            String patternSrc = source.toStringEscaped();
            String name = patternSrc.length() > 30 ? patternSrc.substring(0, 30) + "..." : patternSrc;
=======
            String patternSrc = getSource().toStringEscaped();
            String name = DebugUtil.pruneToSize(patternSrc, 30);
>>>>>>> 9cc390e560b (TRegex: escape Truffle Source name in TRegexExecutorRootNode.toString)
```
- reason: upstream changed source.toStringEscaped() to getSource().toStringEscaped() as a style change unrelated to this fix; 25u uses direct field access
- resolution: keep local field access (source.toStringEscaped()), apply only the functional change (DebugUtil.pruneToSize)

```cpp
<<<<<<< HEAD
=======
    public String toNodeName() {
        return "tregex " + DebugUtil.pruneToSize(toStringEscaped(), 30);
    }

    @TruffleBoundary
>>>>>>> 9cc390e560b (TRegex: escape Truffle Source name in TRegexExecutorRootNode.toString)
```
- reason: upstream added toNodeName() as a helper for callers that don't exist in 25u yet
- resolution: skip - method has no callers in this branch


<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk25u/issues/73
