### PR TITLE
[Backport] [Oracle GraalVM] [GR-75171] Backport to 25.0: Omit statically required modules from the native image builder module path.

### DIFF
--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -1958,6 +1958,7 @@ public class NativeImage {
 
     private static Set<String> getRequiredModules(ModuleReference mref) {
         return mref.descriptor().requires().stream()
+                        .filter(r -> !r.modifiers().contains(ModuleDescriptor.Requires.Modifier.STATIC))
                         .map(ModuleDescriptor.Requires::name)
                         .collect(Collectors.toSet());
     }


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/13155

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:**
```cpp
<<<<<<< HEAD
=======
                        .map(r -> Objects.requireNonNull(r, () -> "ModuleReference " + mref + " requires-Set has null-entries"))
                        .filter(r -> !r.modifiers().contains(ModuleDescriptor.Requires.Modifier.STATIC))
>>>>>>> 24bf4108e52 (Do not include statically required modules in the builder module path)
```
- reason: new lines were added inside an existing stream chain; graal mainline contains an additional Objects.requireNonNull call (see https://github.com/oracle/graal/commit/3bbeef69a2659a6735966f087db4445f864c573b)
- resolution:
  - accept incoming - adds the core fix (filter out STATIC requires)
  - skip Objects.requireNonNull call - it belongs to a separate change

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk25u/issues/74