### PR TITLE
[Backport] [Oracle GraalVM] [GR-75182] Backport to 25.0: Create dummy source with non-zero line number.

### DIFF
--- a/truffle/src/com.oracle.truffle.api.exception/src/com/oracle/truffle/api/exception/HostStackTraceElementObject.java
+++ b/truffle/src/com.oracle.truffle.api.exception/src/com/oracle/truffle/api/exception/HostStackTraceElementObject.java
@@ -82,7 +82,8 @@ final class HostStackTraceElementObject implements TruffleObject {
         int lineNumber = stackTraceElement.getLineNumber();
         if (lineNumber >= 0) {
             Source dummySource = Source.newBuilder("host", "", stackTraceElement.getFileName()).content(Source.CONTENT_NONE).cached(false).build();
-            return dummySource.createSection(lineNumber);
+            int nonZeroLineNumber = Math.max(1, lineNumber);
+            return dummySource.createSection(nonZeroLineNumber, 1, nonZeroLineNumber, 1);
         }
         throw UnsupportedMessageException.create();
     }

--- a/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/host/HostExceptionTest.java
+++ b/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/host/HostExceptionTest.java
@@ -682,6 +682,53 @@ public class HostExceptionTest {
         assertThat(polyglotException.getPolyglotStackTrace().iterator().next().getRootName(), containsString("newExceptionWithCause"));
     }
 
+    @Test
+    public void testHostExceptionStackTraceElementWithLineZeroSourceLocation() {
+        @SuppressWarnings("serial")
+        final class LineZeroStackTraceException extends RuntimeException {
+            @Override
+            public StackTraceElement[] getStackTrace() {
+                return new StackTraceElement[]{new StackTraceElement(HostExceptionTest.class.getName(), "lineZeroHostFrame", "HostExceptionTest.java", 0)};
+            }
+        }
+
+        TruffleTestAssumptions.assumeWeakEncapsulation();
+        expectedException = LineZeroStackTraceException.class;
+        Value catcher = context.eval(ProxyLanguage.ID, CATCHER);
+        Runnable thrower = () -> {
+            throw new LineZeroStackTraceException();
+        };
+
+        customExceptionVerifier = (hostEx) -> {
+            assertTrue(INTEROP.isException(hostEx));
+            try {
+                Object stackTrace = INTEROP.getExceptionStackTrace(hostEx);
+                long length = INTEROP.getArraySize(stackTrace);
+                boolean foundLineZeroHostFrame = false;
+                for (long i = 0; i < length; i++) {
+                    Object stackTraceElement = INTEROP.readArrayElement(stackTrace, i);
+                    if (!INTEROP.hasDeclaringMetaObject(stackTraceElement) || !INTEROP.hasExecutableName(stackTraceElement)) {
+                        continue;
+                    }
+                    String className = INTEROP.asString(INTEROP.getMetaQualifiedName(INTEROP.getDeclaringMetaObject(stackTraceElement)));
+                    String methodName = INTEROP.asString(INTEROP.getExecutableName(stackTraceElement));
+                    if (!HostExceptionTest.class.getName().equals(className) || !"lineZeroHostFrame".equals(methodName)) {
+                        continue;
+                    }
+                    foundLineZeroHostFrame = true;
+                    assertTrue(INTEROP.hasSourceLocation(stackTraceElement));
+                    assertNotNull(INTEROP.getSourceLocation(stackTraceElement));
+                    break;
+                }
+                assertTrue("Expected a host stack trace element with line number 0", foundLineZeroHostFrame);
+            } catch (UnsupportedMessageException | InvalidArrayIndexException e) {
+                throw new AssertionError(e);
+            }
+        };
+
+        assertHostException(catcher.execute(thrower), LineZeroStackTraceException.class);
+    }
+
     private static Value hostApply(Value[] args) {
         return args[0].execute((Object[]) Arrays.copyOfRange(args, 1, args.length));
     }


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/13409

**Conflicts:**

```cpp
<<<<<<< HEAD
            return dummySource.createSection(lineNumber);
=======
            int nonZeroLineNumber = Math.max(1, lineNumber);
            return dummySource.createSection(nonZeroLineNumber, 1, nonZeroLineNumber, 1);
>>>>>>> bc7cba4ee44 (Create dummy source with non-zero line number.)
```
- reason: upstream switched to 4-arg createSection (see https://github.com/oracle/graal/commit/e5ffeb279e, not yet in 25u); cherry-pick conflicts on top of that
- resolution: accept incoming - Math.max fix + 4-arg form (seems harmless and avoids future conflicts)

`
CONFLICT (modify/delete): truffle/docs/OneCompilationPerBytecodeHandler.md deleted in HEAD and modified in aa4db4c9f33`
- reason: modify/delete conflict - file exists upstream but not yet backported to 25u master; cherry-pick modifies it
- resolution: accept a whole incoming documentation file

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk25u/issues/75