### PR TITLE
[Backport] [GR-75058] Ensure that WASI does not follow symlinks out of preopened dirs.

### DIFF
--- a/wasm/src/org.graalvm.wasm.test/src/org/graalvm/wasm/test/regress/GR75058Test.java
+++ b/wasm/src/org.graalvm.wasm.test/src/org/graalvm/wasm/test/regress/GR75058Test.java
@@ -166,6 +166,50 @@ public class GR75058Test {
         }
     }
 
+    // Verifies that LOOKUP_SYMLINK_FOLLOW still rejects paths that escape through an intermediate
+    // symlink before reaching a final symlink.
+    @Test
+    public void testPathOpenFollowRejectsIntermediateEscapeBeforeFinalSymlink() throws IOException, InterruptedException {
+        Path tempRoot = Files.createTempDirectory("gr-75058-");
+        try {
+            assumeSymbolicLinksSupported(tempRoot);
+            Path preopenedDirectory = Files.createDirectory(tempRoot.resolve("preopen"));
+            Path outsideDirectory = Files.createDirectory(tempRoot.resolve("outside"));
+            Path insideTarget = preopenedDirectory.resolve("inside.txt");
+            Files.writeString(insideTarget, "inside", StandardCharsets.UTF_8);
+            Files.createSymbolicLink(outsideDirectory.resolve("final-link"), insideTarget.toAbsolutePath());
+            Files.createSymbolicLink(preopenedDirectory.resolve("escape"), outsideDirectory.toAbsolutePath());
+
+            ByteSequence binary = ByteSequence.create(compileWat("main", """
+                            (module
+                              (import "wasi_snapshot_preview1" "path_open"
+                                (func $path_open (param i32 i32 i32 i32 i32 i64 i64 i32 i32) (result i32)))
+                              (memory 1)
+                              (data (i32.const 0) "escape/final-link")
+                              (export "memory" (memory 0))
+                              (func (export "followEscapedFinalLink") (result i32)
+                                (call $path_open
+                                  (i32.const 3)   ;; fd
+                                  (i32.const 1)   ;; dirflags: LOOKUP_SYMLINK_FOLLOW
+                                  (i32.const 0)   ;; path pointer: "escape/final-link"
+                                  (i32.const 17)  ;; path length
+                                  (i32.const 0)   ;; oflags: none
+                                  (i64.const 0)   ;; rights base: none
+                                  (i64.const 0)   ;; rights inheriting: none
+                                  (i32.const 0)   ;; fdflags: none
+                                  (i32.const 64)  ;; fd address
+                                )))
+                            """));
+
+            try (Context context = contextForPreopenedDirectory(preopenedDirectory)) {
+                Value exports = context.eval(Source.newBuilder(WasmLanguage.ID, binary, "main").build()).newInstance().getMember("exports");
+                assertEquals(Errno.Noent.ordinal(), exports.getMember("followEscapedFinalLink").execute().asInt());
+            }
+        } finally {
+            deleteTree(tempRoot);
+        }
+    }
+
     // Verifies that paths which normalize to the preopened directory itself remain accessible.
     @Test
     public void testPathOpsCanAddressThePreopenedDirectoryItself() throws IOException, InterruptedException {
@@ -220,7 +264,8 @@ public class GR75058Test {
         }
     }
 
-    // Verifies that path_open rejects final symlinks by default and only follows them when asked.
+    // Verifies that path_open rejects final symlinks by default and only follows them when asked,
+    // including dangling and looping final links.
     @Test
     public void testPathOpenHandlesFinalSymlinksAccordingToLookupFlags() throws IOException, InterruptedException {
         Path tempRoot = Files.createTempDirectory("gr-75058-");
@@ -230,10 +275,13 @@ public class GR75058Test {
             Path outsideDirectory = Files.createDirectory(tempRoot.resolve("outside"));
             Path insideTarget = preopenedDirectory.resolve("inside.txt");
             Path outsideTarget = outsideDirectory.resolve("secret.txt");
+            Path missingTarget = preopenedDirectory.resolve("missing.txt");
             Files.writeString(insideTarget, "inside", StandardCharsets.UTF_8);
             Files.writeString(outsideTarget, "secret", StandardCharsets.UTF_8);
             Files.createSymbolicLink(preopenedDirectory.resolve("inside-link"), insideTarget.toAbsolutePath());
             Files.createSymbolicLink(preopenedDirectory.resolve("outside-link"), outsideTarget.toAbsolutePath());
+            Files.createSymbolicLink(preopenedDirectory.resolve("dangling-link"), missingTarget.toAbsolutePath());
+            Files.createSymbolicLink(preopenedDirectory.resolve("loop-link"), Path.of("loop-link"));
 
             ByteSequence binary = ByteSequence.create(compileWat("main", """
                             (module
@@ -242,6 +290,8 @@ public class GR75058Test {
                               (memory 1)
                               (data (i32.const 0) "inside-link")
                               (data (i32.const 16) "outside-link")
+                              (data (i32.const 32) "dangling-link")
+                              (data (i32.const 48) "loop-link")
                               (export "memory" (memory 0))
                               (func (export "nofollowInside") (result i32)
                                 (call $path_open
@@ -278,6 +328,42 @@ public class GR75058Test {
                                   (i64.const 0)   ;; rights inheriting: none
                                   (i32.const 0)   ;; fdflags: none
                                   (i32.const 64)  ;; fd address
+                                ))
+                              (func (export "nofollowDangling") (result i32)
+                                (call $path_open
+                                  (i32.const 3)   ;; fd
+                                  (i32.const 0)   ;; dirflags: none
+                                  (i32.const 32)  ;; path pointer: "dangling-link"
+                                  (i32.const 13)  ;; path length
+                                  (i32.const 0)   ;; oflags: none
+                                  (i64.const 0)   ;; rights base: none
+                                  (i64.const 0)   ;; rights inheriting: none
+                                  (i32.const 0)   ;; fdflags: none
+                                  (i32.const 64)  ;; fd address
+                                ))
+                              (func (export "followDangling") (result i32)
+                                (call $path_open
+                                  (i32.const 3)   ;; fd
+                                  (i32.const 1)   ;; dirflags: LOOKUP_SYMLINK_FOLLOW
+                                  (i32.const 32)  ;; path pointer: "dangling-link"
+                                  (i32.const 13)  ;; path length
+                                  (i32.const 0)   ;; oflags: none
+                                  (i64.const 0)   ;; rights base: none
+                                  (i64.const 0)   ;; rights inheriting: none
+                                  (i32.const 0)   ;; fdflags: none
+                                  (i32.const 64)  ;; fd address
+                                ))
+                              (func (export "followLoop") (result i32)
+                                (call $path_open
+                                  (i32.const 3)   ;; fd
+                                  (i32.const 1)   ;; dirflags: LOOKUP_SYMLINK_FOLLOW
+                                  (i32.const 48)  ;; path pointer: "loop-link"
+                                  (i32.const 9)   ;; path length
+                                  (i32.const 0)   ;; oflags: none
+                                  (i64.const 0)   ;; rights base: none
+                                  (i64.const 0)   ;; rights inheriting: none
+                                  (i32.const 0)   ;; fdflags: none
+                                  (i32.const 64)  ;; fd address
                                 )))
                             """));
 
@@ -286,13 +372,78 @@ public class GR75058Test {
                 assertEquals(Errno.Loop.ordinal(), exports.getMember("nofollowInside").execute().asInt());
                 assertEquals(Errno.Success.ordinal(), exports.getMember("followInside").execute().asInt());
                 assertEquals(Errno.Noent.ordinal(), exports.getMember("followOutside").execute().asInt());
+                assertEquals(Errno.Loop.ordinal(), exports.getMember("nofollowDangling").execute().asInt());
+                assertEquals(Errno.Noent.ordinal(), exports.getMember("followDangling").execute().asInt());
+                assertEquals(Errno.Loop.ordinal(), exports.getMember("followLoop").execute().asInt());
             }
         } finally {
             deleteTree(tempRoot);
         }
     }
 
-    // Verifies that path_filestat_get inspects the final symlink itself unless follow is requested.
+    // Verifies that path_open with LOOKUP_SYMLINK_FOLLOW preserves O_CREAT and O_EXCL semantics on
+    // dangling final symlinks.
+    @Test
+    public void testPathOpenCreateFollowsDanglingFinalSymlinks() throws IOException, InterruptedException {
+        Path tempRoot = Files.createTempDirectory("gr-75058-");
+        try {
+            assumeSymbolicLinksSupported(tempRoot);
+            Path preopenedDirectory = Files.createDirectory(tempRoot.resolve("preopen"));
+            Path targetsDirectory = Files.createDirectory(preopenedDirectory.resolve("targets"));
+            Path createTarget = targetsDirectory.resolve("created.txt");
+            Path exclTarget = targetsDirectory.resolve("excl.txt");
+            Files.createSymbolicLink(preopenedDirectory.resolve("create-link"), Path.of("targets", "created.txt"));
+            Files.createSymbolicLink(preopenedDirectory.resolve("excl-link"), Path.of("targets", "excl.txt"));
+
+            ByteSequence binary = ByteSequence.create(compileWat("main", """
+                            (module
+                              (import "wasi_snapshot_preview1" "path_open"
+                                (func $path_open (param i32 i32 i32 i32 i32 i64 i64 i32 i32) (result i32)))
+                              (memory 1)
+                              (data (i32.const 0) "create-link")
+                              (data (i32.const 16) "excl-link")
+                              (export "memory" (memory 0))
+                              (func (export "createThroughDanglingLink") (result i32)
+                                (call $path_open
+                                  (i32.const 3)   ;; fd
+                                  (i32.const 1)   ;; dirflags: LOOKUP_SYMLINK_FOLLOW
+                                  (i32.const 0)   ;; path pointer: "create-link"
+                                  (i32.const 11)  ;; path length
+                                  (i32.const 1)   ;; oflags: CREAT
+                                  (i64.const 0)   ;; rights base: none
+                                  (i64.const 0)   ;; rights inheriting: none
+                                  (i32.const 0)   ;; fdflags: none
+                                  (i32.const 64)  ;; fd address
+                                ))
+                              (func (export "createExclusiveThroughDanglingLink") (result i32)
+                                (call $path_open
+                                  (i32.const 3)   ;; fd
+                                  (i32.const 1)   ;; dirflags: LOOKUP_SYMLINK_FOLLOW
+                                  (i32.const 16)  ;; path pointer: "excl-link"
+                                  (i32.const 9)   ;; path length
+                                  (i32.const 5)   ;; oflags: CREAT | EXCL
+                                  (i64.const 0)   ;; rights base: none
+                                  (i64.const 0)   ;; rights inheriting: none
+                                  (i32.const 0)   ;; fdflags: none
+                                  (i32.const 64)  ;; fd address
+                                )))
+                            """));
+
+            try (Context context = contextForPreopenedDirectory(preopenedDirectory)) {
+                Value exports = context.eval(Source.newBuilder(WasmLanguage.ID, binary, "main").build()).newInstance().getMember("exports");
+                assertEquals(Errno.Success.ordinal(), exports.getMember("createThroughDanglingLink").execute().asInt());
+                assertEquals(Errno.Exist.ordinal(), exports.getMember("createExclusiveThroughDanglingLink").execute().asInt());
+            }
+
+            assertTrue(Files.exists(createTarget));
+            assertEquals(false, Files.exists(exclTarget));
+        } finally {
+            deleteTree(tempRoot);
+        }
+    }
+
+    // Verifies that path_filestat_get inspects the final symlink itself unless follow is requested,
+    // including for dangling final links.
     @Test
     public void testPathFilestatGetDoesNotFollowFinalSymlinkByDefault() throws IOException, InterruptedException {
         Path tempRoot = Files.createTempDirectory("gr-75058-");
@@ -301,8 +452,10 @@ public class GR75058Test {
             Path preopenedDirectory = Files.createDirectory(tempRoot.resolve("preopen"));
             Path outsideDirectory = Files.createDirectory(tempRoot.resolve("outside"));
             Path outsideTarget = outsideDirectory.resolve("secret.txt");
+            Path missingTarget = preopenedDirectory.resolve("missing.txt");
             Files.writeString(outsideTarget, "secret", StandardCharsets.UTF_8);
             Files.createSymbolicLink(preopenedDirectory.resolve("final-link"), outsideTarget.toAbsolutePath());
+            Files.createSymbolicLink(preopenedDirectory.resolve("dangling-link"), missingTarget.toAbsolutePath());
 
             ByteSequence binary = ByteSequence.create(compileWat("main", """
                             (module
@@ -310,8 +463,9 @@ public class GR75058Test {
                                 (func $path_filestat_get (param i32 i32 i32 i32 i32) (result i32)))
                               (memory 1)
                               (data (i32.const 0) "final-link")
+                              (data (i32.const 16) "dangling-link")
                               (export "memory" (memory 0))
-                              (func (export "nofollow") (result i32) (local $ret i32)
+                              (func (export "nofollowOutside") (result i32) (local $ret i32)
                                 (local.set $ret
                                   (call $path_filestat_get
                                     (i32.const 3)   ;; fd
@@ -331,13 +485,36 @@ public class GR75058Test {
                                   (i32.const 10)  ;; path length
                                   (i32.const 32)  ;; result address
                                 )
+                                )
+                              (func (export "nofollowDangling") (result i32) (local $ret i32)
+                                (local.set $ret
+                                  (call $path_filestat_get
+                                    (i32.const 3)   ;; fd
+                                    (i32.const 0)   ;; flags: none
+                                    (i32.const 16)  ;; path pointer: "dangling-link"
+                                    (i32.const 13)  ;; path length
+                                    (i32.const 32)  ;; result address
+                                  ))
+                                (if (i32.ne (local.get $ret) (i32.const 0))
+                                  (then (return (local.get $ret))))
+                                (i32.load8_u (i32.const 48)))
+                              (func (export "followDangling") (result i32)
+                                (call $path_filestat_get
+                                  (i32.const 3)   ;; fd
+                                  (i32.const 1)   ;; flags: LOOKUP_SYMLINK_FOLLOW
+                                  (i32.const 16)  ;; path pointer: "dangling-link"
+                                  (i32.const 13)  ;; path length
+                                  (i32.const 32)  ;; result address
+                                )
                                 ))
                             """));
 
             try (Context context = contextForPreopenedDirectory(preopenedDirectory)) {
                 Value exports = context.eval(Source.newBuilder(WasmLanguage.ID, binary, "main").build()).newInstance().getMember("exports");
-                assertEquals(Filetype.SymbolicLink.ordinal(), exports.getMember("nofollow").execute().asInt());
+                assertEquals(Filetype.SymbolicLink.ordinal(), exports.getMember("nofollowOutside").execute().asInt());
                 assertEquals(Errno.Noent.ordinal(), exports.getMember("follow").execute().asInt());
+                assertEquals(Filetype.SymbolicLink.ordinal(), exports.getMember("nofollowDangling").execute().asInt());
+                assertEquals(Errno.Noent.ordinal(), exports.getMember("followDangling").execute().asInt());
             }
         } finally {
             deleteTree(tempRoot);

--- a/wasm/src/org.graalvm.wasm.test/src/org/graalvm/wasm/test/regress/GR75058Test.java
+++ b/wasm/src/org.graalvm.wasm.test/src/org/graalvm/wasm/test/regress/GR75058Test.java
@@ -43,10 +43,12 @@ package org.graalvm.wasm.test.regress;
 import static org.graalvm.wasm.utils.WasmBinaryTools.compileWat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 import java.util.Comparator;
@@ -64,6 +66,7 @@ import org.graalvm.wasm.predefined.wasi.types.Filetype;
 import org.junit.Test;
 
 public class GR75058Test {
+    // Verifies that path_open rejects intermediate symlink traversal outside the preopen root.
     @Test
     public void testPathOpenCannotEscapePreopenedDirectoryThroughSymlink() throws IOException, InterruptedException {
         Path tempRoot = Files.createTempDirectory("gr-75058-");
@@ -85,25 +88,25 @@ public class GR75058Test {
                               (func (export "direct") (result i32)
                                 (call $path_open
                                   (i32.const 3)   ;; fd
-                                  (i32.const 0)   ;; dirflags
-                                  (i32.const 0)   ;; path pointer
+                                  (i32.const 0)   ;; dirflags: none
+                                  (i32.const 0)   ;; path pointer: "inside.txt"
                                   (i32.const 10)  ;; path length
-                                  (i32.const 0)   ;; oflags
-                                  (i64.const 0)   ;; rights base
-                                  (i64.const 0)   ;; rights inheriting
-                                  (i32.const 0)   ;; fdflags
+                                  (i32.const 0)   ;; oflags: none
+                                  (i64.const 0)   ;; rights base: none
+                                  (i64.const 0)   ;; rights inheriting: none
+                                  (i32.const 0)   ;; fdflags: none
                                   (i32.const 64)  ;; fd address
                                 ))
                               (func (export "escaped") (result i32)
                                 (call $path_open
                                   (i32.const 3)   ;; fd
-                                  (i32.const 0)   ;; dirflags
-                                  (i32.const 16)  ;; path pointer
+                                  (i32.const 0)   ;; dirflags: none
+                                  (i32.const 16)  ;; path pointer: "escape/secret.txt"
                                   (i32.const 17)  ;; path length
-                                  (i32.const 0)   ;; oflags
-                                  (i64.const 0)   ;; rights base
-                                  (i64.const 0)   ;; rights inheriting
-                                  (i32.const 0)   ;; fdflags
+                                  (i32.const 0)   ;; oflags: none
+                                  (i64.const 0)   ;; rights base: none
+                                  (i64.const 0)   ;; rights inheriting: none
+                                  (i32.const 0)   ;; fdflags: none
                                   (i32.const 64)  ;; fd address
                                 )))
                             """));
@@ -119,14 +122,87 @@ public class GR75058Test {
         }
     }
 
+    // Verifies that path_open rejects final symlinks by default and only follows them when asked.
+    @Test
+    public void testPathOpenHandlesFinalSymlinksAccordingToLookupFlags() throws IOException, InterruptedException {
+        Path tempRoot = Files.createTempDirectory("gr-75058-");
+        try {
+            Path preopenedDirectory = Files.createDirectory(tempRoot.resolve("preopen"));
+            Path outsideDirectory = Files.createDirectory(tempRoot.resolve("outside"));
+            Path insideTarget = preopenedDirectory.resolve("inside.txt");
+            Path outsideTarget = outsideDirectory.resolve("secret.txt");
+            Files.writeString(insideTarget, "inside", StandardCharsets.UTF_8);
+            Files.writeString(outsideTarget, "secret", StandardCharsets.UTF_8);
+            Files.createSymbolicLink(preopenedDirectory.resolve("inside-link"), insideTarget.toAbsolutePath());
+            Files.createSymbolicLink(preopenedDirectory.resolve("outside-link"), outsideTarget.toAbsolutePath());
+
+            ByteSequence binary = ByteSequence.create(compileWat("main", """
+                            (module
+                              (import "wasi_snapshot_preview1" "path_open"
+                                (func $path_open (param i32 i32 i32 i32 i32 i64 i64 i32 i32) (result i32)))
+                              (memory 1)
+                              (data (i32.const 0) "inside-link")
+                              (data (i32.const 16) "outside-link")
+                              (export "memory" (memory 0))
+                              (func (export "nofollowInside") (result i32)
+                                (call $path_open
+                                  (i32.const 3)   ;; fd
+                                  (i32.const 0)   ;; dirflags: none
+                                  (i32.const 0)   ;; path pointer: "inside-link"
+                                  (i32.const 11)  ;; path length
+                                  (i32.const 0)   ;; oflags: none
+                                  (i64.const 0)   ;; rights base: none
+                                  (i64.const 0)   ;; rights inheriting: none
+                                  (i32.const 0)   ;; fdflags: none
+                                  (i32.const 64)  ;; fd address
+                                ))
+                              (func (export "followInside") (result i32)
+                                (call $path_open
+                                  (i32.const 3)   ;; fd
+                                  (i32.const 1)   ;; dirflags: LOOKUP_SYMLINK_FOLLOW
+                                  (i32.const 0)   ;; path pointer: "inside-link"
+                                  (i32.const 11)  ;; path length
+                                  (i32.const 0)   ;; oflags: none
+                                  (i64.const 0)   ;; rights base: none
+                                  (i64.const 0)   ;; rights inheriting: none
+                                  (i32.const 0)   ;; fdflags: none
+                                  (i32.const 64)  ;; fd address
+                                ))
+                              (func (export "followOutside") (result i32)
+                                (call $path_open
+                                  (i32.const 3)   ;; fd
+                                  (i32.const 1)   ;; dirflags: LOOKUP_SYMLINK_FOLLOW
+                                  (i32.const 16)  ;; path pointer: "outside-link"
+                                  (i32.const 12)  ;; path length
+                                  (i32.const 0)   ;; oflags: none
+                                  (i64.const 0)   ;; rights base: none
+                                  (i64.const 0)   ;; rights inheriting: none
+                                  (i32.const 0)   ;; fdflags: none
+                                  (i32.const 64)  ;; fd address
+                                )))
+                            """));
+
+            try (Context context = contextForPreopenedDirectory(preopenedDirectory)) {
+                Value exports = context.eval(Source.newBuilder(WasmLanguage.ID, binary, "main").build()).newInstance().getMember("exports");
+                assertEquals(Errno.Loop.ordinal(), exports.getMember("nofollowInside").execute().asInt());
+                assertEquals(Errno.Success.ordinal(), exports.getMember("followInside").execute().asInt());
+                assertEquals(Errno.Noent.ordinal(), exports.getMember("followOutside").execute().asInt());
+            }
+        } finally {
+            deleteTree(tempRoot);
+        }
+    }
+
+    // Verifies that path_filestat_get inspects the final symlink itself unless follow is requested.
     @Test
     public void testPathFilestatGetDoesNotFollowFinalSymlinkByDefault() throws IOException, InterruptedException {
         Path tempRoot = Files.createTempDirectory("gr-75058-");
         try {
             Path preopenedDirectory = Files.createDirectory(tempRoot.resolve("preopen"));
             Path outsideDirectory = Files.createDirectory(tempRoot.resolve("outside"));
-            Files.writeString(outsideDirectory.resolve("secret.txt"), "secret", StandardCharsets.UTF_8);
-            Files.createSymbolicLink(preopenedDirectory.resolve("final-link"), outsideDirectory.resolve("secret.txt").toAbsolutePath());
+            Path outsideTarget = outsideDirectory.resolve("secret.txt");
+            Files.writeString(outsideTarget, "secret", StandardCharsets.UTF_8);
+            Files.createSymbolicLink(preopenedDirectory.resolve("final-link"), outsideTarget.toAbsolutePath());
 
             ByteSequence binary = ByteSequence.create(compileWat("main", """
                             (module
@@ -138,21 +214,23 @@ public class GR75058Test {
                               (func (export "nofollow") (result i32) (local $ret i32)
                                 (local.set $ret
                                   (call $path_filestat_get
-                                    (i32.const 3)
-                                    (i32.const 0)
-                                    (i32.const 0)
-                                    (i32.const 10)
-                                    (i32.const 32)))
+                                    (i32.const 3)   ;; fd
+                                    (i32.const 0)   ;; flags: none
+                                    (i32.const 0)   ;; path pointer: "final-link"
+                                    (i32.const 10)  ;; path length
+                                    (i32.const 32)  ;; result address
+                                  ))
                                 (if (i32.ne (local.get $ret) (i32.const 0))
                                   (then (return (local.get $ret))))
                                 (i32.load8_u (i32.const 48)))
                               (func (export "follow") (result i32)
                                 (call $path_filestat_get
-                                  (i32.const 3)
-                                  (i32.const 1)
-                                  (i32.const 0)
-                                  (i32.const 10)
-                                  (i32.const 32))
+                                  (i32.const 3)   ;; fd
+                                  (i32.const 1)   ;; flags: LOOKUP_SYMLINK_FOLLOW
+                                  (i32.const 0)   ;; path pointer: "final-link"
+                                  (i32.const 10)  ;; path length
+                                  (i32.const 32)  ;; result address
+                                )
                                 ))
                             """));
 
@@ -166,6 +244,7 @@ public class GR75058Test {
         }
     }
 
+    // Verifies that path_filestat_set_times does not mutate the final symlink target by default.
     @Test
     public void testPathFilestatSetTimesDoesNotMutateSymlinkTargetByDefault() throws IOException, InterruptedException {
         Path tempRoot = Files.createTempDirectory("gr-75058-");
@@ -188,13 +267,14 @@ public class GR75058Test {
                               (export "memory" (memory 0))
                               (func (export "nofollow") (result i32)
                                 (call $path_filestat_set_times
-                                  (i32.const 3)
-                                  (i32.const 0)
-                                  (i32.const 0)
-                                  (i32.const 10)
-                                  (i64.const 0)
-                                  (i64.const 9000000000000)
-                                  (i32.const 4))))
+                                  (i32.const 3)               ;; fd
+                                  (i32.const 0)               ;; flags: none
+                                  (i32.const 0)               ;; path pointer: "final-link"
+                                  (i32.const 10)              ;; path length
+                                  (i64.const 0)               ;; atim
+                                  (i64.const 9000000000000)   ;; mtim
+                                  (i32.const 4)               ;; fstflags: MTIM
+                                )))
                             """));
 
             try (Context context = contextForPreopenedDirectory(preopenedDirectory)) {
@@ -203,6 +283,83 @@ public class GR75058Test {
             }
 
             assertEquals(observedInitialTime.to(TimeUnit.MILLISECONDS), Files.getLastModifiedTime(outsideTarget).to(TimeUnit.MILLISECONDS));
+        } finally {
+            deleteTree(tempRoot);
+        }
+    }
+
+    // Verifies that path_unlink_file removes the symlink itself instead of its target.
+    @Test
+    public void testPathUnlinkFileUnlinksFinalSymlinkWithoutTouchingTarget() throws IOException, InterruptedException {
+        Path tempRoot = Files.createTempDirectory("gr-75058-");
+        try {
+            Path preopenedDirectory = Files.createDirectory(tempRoot.resolve("preopen"));
+            Path outsideDirectory = Files.createDirectory(tempRoot.resolve("outside"));
+            Path outsideTarget = outsideDirectory.resolve("secret.txt");
+            Path symlink = preopenedDirectory.resolve("final-link");
+            Files.writeString(outsideTarget, "secret", StandardCharsets.UTF_8);
+            Files.createSymbolicLink(symlink, outsideTarget.toAbsolutePath());
+
+            ByteSequence binary = ByteSequence.create(compileWat("main", """
+                            (module
+                              (import "wasi_snapshot_preview1" "path_unlink_file"
+                                (func $path_unlink_file (param i32 i32 i32) (result i32)))
+                              (memory 1)
+                              (data (i32.const 0) "final-link")
+                              (export "memory" (memory 0))
+                              (func (export "unlink") (result i32)
+                                (call $path_unlink_file
+                                  (i32.const 3)   ;; fd
+                                  (i32.const 0)   ;; path pointer: "final-link"
+                                  (i32.const 10)  ;; path length
+                                )))
+                            """));
+
+            try (Context context = contextForPreopenedDirectory(preopenedDirectory)) {
+                Value exports = context.eval(Source.newBuilder(WasmLanguage.ID, binary, "main").build()).newInstance().getMember("exports");
+                assertEquals(Errno.Success.ordinal(), exports.getMember("unlink").execute().asInt());
+            }
+
+            assertEquals(false, Files.exists(symlink, LinkOption.NOFOLLOW_LINKS));
+            assertTrue(Files.exists(outsideTarget));
+        } finally {
+            deleteTree(tempRoot);
+        }
+    }
+
+    // Verifies that path_remove_directory rejects a final symlink instead of acting on its target.
+    @Test
+    public void testPathRemoveDirectoryRejectsFinalSymlinkToDirectory() throws IOException, InterruptedException {
+        Path tempRoot = Files.createTempDirectory("gr-75058-");
+        try {
+            Path preopenedDirectory = Files.createDirectory(tempRoot.resolve("preopen"));
+            Path outsideDirectory = Files.createDirectory(tempRoot.resolve("outside"));
+            Path outsideTarget = Files.createDirectory(outsideDirectory.resolve("target-dir"));
+            Path symlink = preopenedDirectory.resolve("final-link");
+            Files.createSymbolicLink(symlink, outsideTarget.toAbsolutePath());
+
+            ByteSequence binary = ByteSequence.create(compileWat("main", """
+                            (module
+                              (import "wasi_snapshot_preview1" "path_remove_directory"
+                                (func $path_remove_directory (param i32 i32 i32) (result i32)))
+                              (memory 1)
+                              (data (i32.const 0) "final-link")
+                              (export "memory" (memory 0))
+                              (func (export "remove") (result i32)
+                                (call $path_remove_directory
+                                  (i32.const 3)   ;; fd
+                                  (i32.const 0)   ;; path pointer: "final-link"
+                                  (i32.const 10)  ;; path length
+                                )))
+                            """));
+
+            try (Context context = contextForPreopenedDirectory(preopenedDirectory)) {
+                Value exports = context.eval(Source.newBuilder(WasmLanguage.ID, binary, "main").build()).newInstance().getMember("exports");
+                assertEquals(Errno.Notdir.ordinal(), exports.getMember("remove").execute().asInt());
+            }
+
+            assertTrue(Files.exists(symlink, LinkOption.NOFOLLOW_LINKS));
+            assertTrue(Files.exists(outsideTarget));
         } finally {
             deleteTree(tempRoot);
         }

--- a/wasm/src/org.graalvm.wasm.test/src/org/graalvm/wasm/test/regress/GR75058Test.java
+++ b/wasm/src/org.graalvm.wasm.test/src/org/graalvm/wasm/test/regress/GR75058Test.java
@@ -48,7 +48,9 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
 import java.util.Comparator;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import org.graalvm.polyglot.Context;
@@ -58,6 +60,7 @@ import org.graalvm.polyglot.io.ByteSequence;
 import org.graalvm.polyglot.io.IOAccess;
 import org.graalvm.wasm.WasmLanguage;
 import org.graalvm.wasm.predefined.wasi.types.Errno;
+import org.graalvm.wasm.predefined.wasi.types.Filetype;
 import org.junit.Test;
 
 public class GR75058Test {
@@ -106,8 +109,7 @@ public class GR75058Test {
                             """));
 
             Source source = Source.newBuilder(WasmLanguage.ID, binary, "main").build();
-            try (Context context = Context.newBuilder(WasmLanguage.ID).allowExperimentalOptions(true).allowIO(IOAccess.ALL).option("wasm.Builtins", "wasi_snapshot_preview1").option("wasm.WasiMapDirs",
-                            "test::" + preopenedDirectory.toAbsolutePath()).build()) {
+            try (Context context = contextForPreopenedDirectory(preopenedDirectory)) {
                 Value exports = context.eval(source).newInstance().getMember("exports");
                 assertEquals(Errno.Success.ordinal(), exports.getMember("direct").execute().asInt());
                 assertNotEquals(Errno.Success.ordinal(), exports.getMember("escaped").execute().asInt());
@@ -115,6 +117,104 @@ public class GR75058Test {
         } finally {
             deleteTree(tempRoot);
         }
+    }
+
+    @Test
+    public void testPathFilestatGetDoesNotFollowFinalSymlinkByDefault() throws IOException, InterruptedException {
+        Path tempRoot = Files.createTempDirectory("gr-75058-");
+        try {
+            Path preopenedDirectory = Files.createDirectory(tempRoot.resolve("preopen"));
+            Path outsideDirectory = Files.createDirectory(tempRoot.resolve("outside"));
+            Files.writeString(outsideDirectory.resolve("secret.txt"), "secret", StandardCharsets.UTF_8);
+            Files.createSymbolicLink(preopenedDirectory.resolve("final-link"), outsideDirectory.resolve("secret.txt").toAbsolutePath());
+
+            ByteSequence binary = ByteSequence.create(compileWat("main", """
+                            (module
+                              (import "wasi_snapshot_preview1" "path_filestat_get"
+                                (func $path_filestat_get (param i32 i32 i32 i32 i32) (result i32)))
+                              (memory 1)
+                              (data (i32.const 0) "final-link")
+                              (export "memory" (memory 0))
+                              (func (export "nofollow") (result i32) (local $ret i32)
+                                (local.set $ret
+                                  (call $path_filestat_get
+                                    (i32.const 3)
+                                    (i32.const 0)
+                                    (i32.const 0)
+                                    (i32.const 10)
+                                    (i32.const 32)))
+                                (if (i32.ne (local.get $ret) (i32.const 0))
+                                  (then (return (local.get $ret))))
+                                (i32.load8_u (i32.const 48)))
+                              (func (export "follow") (result i32)
+                                (call $path_filestat_get
+                                  (i32.const 3)
+                                  (i32.const 1)
+                                  (i32.const 0)
+                                  (i32.const 10)
+                                  (i32.const 32))
+                                ))
+                            """));
+
+            try (Context context = contextForPreopenedDirectory(preopenedDirectory)) {
+                Value exports = context.eval(Source.newBuilder(WasmLanguage.ID, binary, "main").build()).newInstance().getMember("exports");
+                assertEquals(Filetype.SymbolicLink.ordinal(), exports.getMember("nofollow").execute().asInt());
+                assertEquals(Errno.Noent.ordinal(), exports.getMember("follow").execute().asInt());
+            }
+        } finally {
+            deleteTree(tempRoot);
+        }
+    }
+
+    @Test
+    public void testPathFilestatSetTimesDoesNotMutateSymlinkTargetByDefault() throws IOException, InterruptedException {
+        Path tempRoot = Files.createTempDirectory("gr-75058-");
+        try {
+            Path preopenedDirectory = Files.createDirectory(tempRoot.resolve("preopen"));
+            Path outsideDirectory = Files.createDirectory(tempRoot.resolve("outside"));
+            Path outsideTarget = outsideDirectory.resolve("secret.txt");
+            Files.writeString(outsideTarget, "secret", StandardCharsets.UTF_8);
+            FileTime initialTime = FileTime.from(1_000_000L, TimeUnit.MILLISECONDS);
+            Files.setLastModifiedTime(outsideTarget, initialTime);
+            FileTime observedInitialTime = Files.getLastModifiedTime(outsideTarget);
+            Files.createSymbolicLink(preopenedDirectory.resolve("final-link"), outsideTarget.toAbsolutePath());
+
+            ByteSequence binary = ByteSequence.create(compileWat("main", """
+                            (module
+                              (import "wasi_snapshot_preview1" "path_filestat_set_times"
+                                (func $path_filestat_set_times (param i32 i32 i32 i32 i64 i64 i32) (result i32)))
+                              (memory 1)
+                              (data (i32.const 0) "final-link")
+                              (export "memory" (memory 0))
+                              (func (export "nofollow") (result i32)
+                                (call $path_filestat_set_times
+                                  (i32.const 3)
+                                  (i32.const 0)
+                                  (i32.const 0)
+                                  (i32.const 10)
+                                  (i64.const 0)
+                                  (i64.const 9000000000000)
+                                  (i32.const 4))))
+                            """));
+
+            try (Context context = contextForPreopenedDirectory(preopenedDirectory)) {
+                Value exports = context.eval(Source.newBuilder(WasmLanguage.ID, binary, "main").build()).newInstance().getMember("exports");
+                exports.getMember("nofollow").execute();
+            }
+
+            assertEquals(observedInitialTime.to(TimeUnit.MILLISECONDS), Files.getLastModifiedTime(outsideTarget).to(TimeUnit.MILLISECONDS));
+        } finally {
+            deleteTree(tempRoot);
+        }
+    }
+
+    private static Context contextForPreopenedDirectory(Path preopenedDirectory) {
+        Context.Builder contextBuilder = Context.newBuilder(WasmLanguage.ID);
+        contextBuilder.allowExperimentalOptions(true);
+        contextBuilder.allowIO(IOAccess.ALL);
+        contextBuilder.option("wasm.Builtins", "wasi_snapshot_preview1");
+        contextBuilder.option("wasm.WasiMapDirs", "test::" + preopenedDirectory.toAbsolutePath());
+        return contextBuilder.build();
     }
 
     private static void deleteTree(Path root) throws IOException {

--- a/wasm/src/org.graalvm.wasm.test/src/org/graalvm/wasm/test/regress/GR75058Test.java
+++ b/wasm/src/org.graalvm.wasm.test/src/org/graalvm/wasm/test/regress/GR75058Test.java
@@ -122,6 +122,47 @@ public class GR75058Test {
         }
     }
 
+    // Verifies that path_open allows intermediate symlinks when their resolved target stays inside
+    // the preopen root.
+    @Test
+    public void testPathOpenAllowsIntermediateSymlinkInsidePreopenedDirectory() throws IOException, InterruptedException {
+        Path tempRoot = Files.createTempDirectory("gr-75058-");
+        try {
+            Path preopenedDirectory = Files.createDirectory(tempRoot.resolve("preopen"));
+            Path releasesDirectory = Files.createDirectories(preopenedDirectory.resolve("releases/v1"));
+            Files.writeString(releasesDirectory.resolve("log.txt"), "inside", StandardCharsets.UTF_8);
+            Files.createSymbolicLink(preopenedDirectory.resolve("current"), releasesDirectory.toAbsolutePath());
+
+            ByteSequence binary = ByteSequence.create(compileWat("main", """
+                            (module
+                              (import "wasi_snapshot_preview1" "path_open"
+                                (func $path_open (param i32 i32 i32 i32 i32 i64 i64 i32 i32) (result i32)))
+                              (memory 1)
+                              (data (i32.const 0) "current/log.txt")
+                              (export "memory" (memory 0))
+                              (func (export "open") (result i32)
+                                (call $path_open
+                                  (i32.const 3)   ;; fd
+                                  (i32.const 0)   ;; dirflags: none
+                                  (i32.const 0)   ;; path pointer: "current/log.txt"
+                                  (i32.const 15)  ;; path length
+                                  (i32.const 0)   ;; oflags: none
+                                  (i64.const 0)   ;; rights base: none
+                                  (i64.const 0)   ;; rights inheriting: none
+                                  (i32.const 0)   ;; fdflags: none
+                                  (i32.const 64)  ;; fd address
+                                )))
+                            """));
+
+            try (Context context = contextForPreopenedDirectory(preopenedDirectory)) {
+                Value exports = context.eval(Source.newBuilder(WasmLanguage.ID, binary, "main").build()).newInstance().getMember("exports");
+                assertEquals(Errno.Success.ordinal(), exports.getMember("open").execute().asInt());
+            }
+        } finally {
+            deleteTree(tempRoot);
+        }
+    }
+
     // Verifies that path_open rejects final symlinks by default and only follows them when asked.
     @Test
     public void testPathOpenHandlesFinalSymlinksAccordingToLookupFlags() throws IOException, InterruptedException {

--- a/wasm/src/org.graalvm.wasm.test/src/org/graalvm/wasm/test/regress/GR75058Test.java
+++ b/wasm/src/org.graalvm.wasm.test/src/org/graalvm/wasm/test/regress/GR75058Test.java
@@ -264,6 +264,81 @@ public class GR75058Test {
         }
     }
 
+    // Verifies that LOOKUP_SYMLINK_FOLLOW resolves final relative symlink targets from the real
+    // parent directory and that followed directory fds stay anchored to the resolved target.
+    @Test
+    public void testFollowedPathsUseRealParentAndResolvedDirectoryFd() throws IOException, InterruptedException {
+        Path tempRoot = Files.createTempDirectory("gr-75058-");
+        try {
+            assumeSymbolicLinksSupported(tempRoot);
+            Path preopenedDirectory = Files.createDirectory(tempRoot.resolve("preopen"));
+            Path releasesV1 = Files.createDirectories(preopenedDirectory.resolve("releases/v1"));
+            Path sharedDirectory = Files.createDirectories(preopenedDirectory.resolve("releases/shared"));
+            Files.writeString(sharedDirectory.resolve("inside.txt"), "inside", StandardCharsets.UTF_8);
+            Files.createSymbolicLink(preopenedDirectory.resolve("current"), Path.of("releases", "v1"));
+            Files.createSymbolicLink(releasesV1.resolve("final-link"), Path.of("..", "shared", "inside.txt"));
+
+            ByteSequence binary = ByteSequence.create(compileWat("main", """
+                            (module
+                              (import "wasi_snapshot_preview1" "path_open"
+                                (func $path_open (param i32 i32 i32 i32 i32 i64 i64 i32 i32) (result i32)))
+                              (import "wasi_snapshot_preview1" "path_filestat_get"
+                                (func $path_filestat_get (param i32 i32 i32 i32 i32) (result i32)))
+                              (memory 1)
+                              (data (i32.const 0) "current/final-link")
+                              (data (i32.const 32) "current")
+                              (data (i32.const 48) ".")
+                              (export "memory" (memory 0))
+                              (func (export "followRelativeFinalLink") (result i32)
+                                (call $path_open
+                                  (i32.const 3)   ;; fd
+                                  (i32.const 1)   ;; dirflags: LOOKUP_SYMLINK_FOLLOW
+                                  (i32.const 0)   ;; path pointer: "current/final-link"
+                                  (i32.const 18)  ;; path length
+                                  (i32.const 0)   ;; oflags: none
+                                  (i64.const 0)   ;; rights base: none
+                                  (i64.const 0)   ;; rights inheriting: none
+                                  (i32.const 0)   ;; fdflags: none
+                                  (i32.const 64)  ;; fd address
+                                ))
+                              (func (export "statSelfOfFollowedDirectoryFd") (result i32) (local $ret i32)
+                                (local.set $ret
+                                  (call $path_open
+                                    (i32.const 3)   ;; fd
+                                    (i32.const 1)   ;; dirflags: LOOKUP_SYMLINK_FOLLOW
+                                    (i32.const 32)  ;; path pointer: "current"
+                                    (i32.const 7)   ;; path length
+                                    (i32.const 2)   ;; oflags: DIRECTORY
+                                    (i64.const 262144) ;; rights base: PATH_FILESTAT_GET
+                                    (i64.const 0)   ;; rights inheriting: none
+                                    (i32.const 0)   ;; fdflags: none
+                                    (i32.const 64)  ;; fd address
+                                  ))
+                                (if (i32.ne (local.get $ret) (i32.const 0))
+                                  (then (return (local.get $ret))))
+                                (local.set $ret
+                                  (call $path_filestat_get
+                                    (i32.load (i32.const 64))  ;; fd loaded from memory
+                                    (i32.const 0)              ;; flags: none
+                                    (i32.const 48)             ;; path pointer: "."
+                                    (i32.const 1)              ;; path length
+                                    (i32.const 96)             ;; result address
+                                  ))
+                                (if (i32.ne (local.get $ret) (i32.const 0))
+                                  (then (return (local.get $ret))))
+                                (i32.load8_u (i32.const 112))))
+                            """));
+
+            try (Context context = contextForPreopenedDirectory(preopenedDirectory)) {
+                Value exports = context.eval(Source.newBuilder(WasmLanguage.ID, binary, "main").build()).newInstance().getMember("exports");
+                assertEquals(Errno.Success.ordinal(), exports.getMember("followRelativeFinalLink").execute().asInt());
+                assertEquals(Filetype.Directory.ordinal(), exports.getMember("statSelfOfFollowedDirectoryFd").execute().asInt());
+            }
+        } finally {
+            deleteTree(tempRoot);
+        }
+    }
+
     // Verifies that path_open rejects final symlinks by default and only follows them when asked,
     // including dangling and looping final links.
     @Test

--- a/wasm/src/org.graalvm.wasm.test/src/org/graalvm/wasm/test/regress/GR75058Test.java
+++ b/wasm/src/org.graalvm.wasm.test/src/org/graalvm/wasm/test/regress/GR75058Test.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.wasm.test.regress;
+
+import static org.graalvm.wasm.utils.WasmBinaryTools.compileWat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.stream.Stream;
+
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Source;
+import org.graalvm.polyglot.Value;
+import org.graalvm.polyglot.io.ByteSequence;
+import org.graalvm.polyglot.io.IOAccess;
+import org.graalvm.wasm.WasmLanguage;
+import org.graalvm.wasm.predefined.wasi.types.Errno;
+import org.junit.Test;
+
+public class GR75058Test {
+    @Test
+    public void testPathOpenCannotEscapePreopenedDirectoryThroughSymlink() throws IOException, InterruptedException {
+        Path tempRoot = Files.createTempDirectory("gr-75058-");
+        try {
+            Path preopenedDirectory = Files.createDirectory(tempRoot.resolve("preopen"));
+            Path outsideDirectory = Files.createDirectory(tempRoot.resolve("outside"));
+            Files.writeString(preopenedDirectory.resolve("inside.txt"), "inside", StandardCharsets.UTF_8);
+            Files.writeString(outsideDirectory.resolve("secret.txt"), "secret", StandardCharsets.UTF_8);
+            Files.createSymbolicLink(preopenedDirectory.resolve("escape"), outsideDirectory.toAbsolutePath());
+
+            ByteSequence binary = ByteSequence.create(compileWat("main", """
+                            (module
+                              (import "wasi_snapshot_preview1" "path_open"
+                                (func $path_open (param i32 i32 i32 i32 i32 i64 i64 i32 i32) (result i32)))
+                              (memory 1)
+                              (data (i32.const 0) "inside.txt")
+                              (data (i32.const 16) "escape/secret.txt")
+                              (export "memory" (memory 0))
+                              (func (export "direct") (result i32)
+                                (call $path_open
+                                  (i32.const 3)   ;; fd
+                                  (i32.const 0)   ;; dirflags
+                                  (i32.const 0)   ;; path pointer
+                                  (i32.const 10)  ;; path length
+                                  (i32.const 0)   ;; oflags
+                                  (i64.const 0)   ;; rights base
+                                  (i64.const 0)   ;; rights inheriting
+                                  (i32.const 0)   ;; fdflags
+                                  (i32.const 64)  ;; fd address
+                                ))
+                              (func (export "escaped") (result i32)
+                                (call $path_open
+                                  (i32.const 3)   ;; fd
+                                  (i32.const 0)   ;; dirflags
+                                  (i32.const 16)  ;; path pointer
+                                  (i32.const 17)  ;; path length
+                                  (i32.const 0)   ;; oflags
+                                  (i64.const 0)   ;; rights base
+                                  (i64.const 0)   ;; rights inheriting
+                                  (i32.const 0)   ;; fdflags
+                                  (i32.const 64)  ;; fd address
+                                )))
+                            """));
+
+            Source source = Source.newBuilder(WasmLanguage.ID, binary, "main").build();
+            try (Context context = Context.newBuilder(WasmLanguage.ID).allowExperimentalOptions(true).allowIO(IOAccess.ALL).option("wasm.Builtins", "wasi_snapshot_preview1").option("wasm.WasiMapDirs",
+                            "test::" + preopenedDirectory.toAbsolutePath()).build()) {
+                Value exports = context.eval(source).newInstance().getMember("exports");
+                assertEquals(Errno.Success.ordinal(), exports.getMember("direct").execute().asInt());
+                assertNotEquals(Errno.Success.ordinal(), exports.getMember("escaped").execute().asInt());
+            }
+        } finally {
+            deleteTree(tempRoot);
+        }
+    }
+
+    private static void deleteTree(Path root) throws IOException {
+        try (Stream<Path> paths = Files.walk(root)) {
+            for (Path path : paths.sorted(Comparator.reverseOrder()).toList()) {
+                Files.deleteIfExists(path);
+            }
+        }
+    }
+}

--- a/wasm/src/org.graalvm.wasm.test/src/org/graalvm/wasm/test/regress/GR75058Test.java
+++ b/wasm/src/org.graalvm.wasm.test/src/org/graalvm/wasm/test/regress/GR75058Test.java
@@ -166,6 +166,60 @@ public class GR75058Test {
         }
     }
 
+    // Verifies that paths which normalize to the preopened directory itself remain accessible.
+    @Test
+    public void testPathOpsCanAddressThePreopenedDirectoryItself() throws IOException, InterruptedException {
+        Path tempRoot = Files.createTempDirectory("gr-75058-");
+        try {
+            Path preopenedDirectory = Files.createDirectory(tempRoot.resolve("preopen"));
+            Files.createDirectory(preopenedDirectory.resolve("dir"));
+
+            ByteSequence binary = ByteSequence.create(compileWat("main", """
+                            (module
+                              (import "wasi_snapshot_preview1" "path_open"
+                                (func $path_open (param i32 i32 i32 i32 i32 i64 i64 i32 i32) (result i32)))
+                              (import "wasi_snapshot_preview1" "path_filestat_get"
+                                (func $path_filestat_get (param i32 i32 i32 i32 i32) (result i32)))
+                              (memory 1)
+                              (data (i32.const 0) ".")
+                              (data (i32.const 16) "dir/..")
+                              (export "memory" (memory 0))
+                              (func (export "openRoot") (result i32)
+                                (call $path_open
+                                  (i32.const 3)   ;; fd
+                                  (i32.const 0)   ;; dirflags: none
+                                  (i32.const 0)   ;; path pointer: "."
+                                  (i32.const 1)   ;; path length
+                                  (i32.const 2)   ;; oflags: DIRECTORY
+                                  (i64.const 0)   ;; rights base: none
+                                  (i64.const 0)   ;; rights inheriting: none
+                                  (i32.const 0)   ;; fdflags: none
+                                  (i32.const 64)  ;; fd address
+                                ))
+                              (func (export "statRootViaDotDot") (result i32) (local $ret i32)
+                                (local.set $ret
+                                  (call $path_filestat_get
+                                    (i32.const 3)   ;; fd
+                                    (i32.const 0)   ;; flags: none
+                                    (i32.const 16)  ;; path pointer: "dir/.."
+                                    (i32.const 6)   ;; path length
+                                    (i32.const 32)  ;; result address
+                                  ))
+                                (if (i32.ne (local.get $ret) (i32.const 0))
+                                  (then (return (local.get $ret))))
+                                (i32.load8_u (i32.const 48))))
+                            """));
+
+            try (Context context = contextForPreopenedDirectory(preopenedDirectory)) {
+                Value exports = context.eval(Source.newBuilder(WasmLanguage.ID, binary, "main").build()).newInstance().getMember("exports");
+                assertEquals(Errno.Success.ordinal(), exports.getMember("openRoot").execute().asInt());
+                assertEquals(Filetype.Directory.ordinal(), exports.getMember("statRootViaDotDot").execute().asInt());
+            }
+        } finally {
+            deleteTree(tempRoot);
+        }
+    }
+
     // Verifies that path_open rejects final symlinks by default and only follows them when asked.
     @Test
     public void testPathOpenHandlesFinalSymlinksAccordingToLookupFlags() throws IOException, InterruptedException {

--- a/wasm/src/org.graalvm.wasm.test/src/org/graalvm/wasm/test/regress/GR75058Test.java
+++ b/wasm/src/org.graalvm.wasm.test/src/org/graalvm/wasm/test/regress/GR75058Test.java
@@ -63,6 +63,7 @@ import org.graalvm.polyglot.io.IOAccess;
 import org.graalvm.wasm.WasmLanguage;
 import org.graalvm.wasm.predefined.wasi.types.Errno;
 import org.graalvm.wasm.predefined.wasi.types.Filetype;
+import org.junit.Assume;
 import org.junit.Test;
 
 public class GR75058Test {
@@ -71,6 +72,7 @@ public class GR75058Test {
     public void testPathOpenCannotEscapePreopenedDirectoryThroughSymlink() throws IOException, InterruptedException {
         Path tempRoot = Files.createTempDirectory("gr-75058-");
         try {
+            assumeSymbolicLinksSupported(tempRoot);
             Path preopenedDirectory = Files.createDirectory(tempRoot.resolve("preopen"));
             Path outsideDirectory = Files.createDirectory(tempRoot.resolve("outside"));
             Files.writeString(preopenedDirectory.resolve("inside.txt"), "inside", StandardCharsets.UTF_8);
@@ -128,6 +130,7 @@ public class GR75058Test {
     public void testPathOpenAllowsIntermediateSymlinkInsidePreopenedDirectory() throws IOException, InterruptedException {
         Path tempRoot = Files.createTempDirectory("gr-75058-");
         try {
+            assumeSymbolicLinksSupported(tempRoot);
             Path preopenedDirectory = Files.createDirectory(tempRoot.resolve("preopen"));
             Path releasesDirectory = Files.createDirectories(preopenedDirectory.resolve("releases/v1"));
             Files.writeString(releasesDirectory.resolve("log.txt"), "inside", StandardCharsets.UTF_8);
@@ -168,6 +171,7 @@ public class GR75058Test {
     public void testPathOpenHandlesFinalSymlinksAccordingToLookupFlags() throws IOException, InterruptedException {
         Path tempRoot = Files.createTempDirectory("gr-75058-");
         try {
+            assumeSymbolicLinksSupported(tempRoot);
             Path preopenedDirectory = Files.createDirectory(tempRoot.resolve("preopen"));
             Path outsideDirectory = Files.createDirectory(tempRoot.resolve("outside"));
             Path insideTarget = preopenedDirectory.resolve("inside.txt");
@@ -239,6 +243,7 @@ public class GR75058Test {
     public void testPathFilestatGetDoesNotFollowFinalSymlinkByDefault() throws IOException, InterruptedException {
         Path tempRoot = Files.createTempDirectory("gr-75058-");
         try {
+            assumeSymbolicLinksSupported(tempRoot);
             Path preopenedDirectory = Files.createDirectory(tempRoot.resolve("preopen"));
             Path outsideDirectory = Files.createDirectory(tempRoot.resolve("outside"));
             Path outsideTarget = outsideDirectory.resolve("secret.txt");
@@ -290,6 +295,7 @@ public class GR75058Test {
     public void testPathFilestatSetTimesDoesNotMutateSymlinkTargetByDefault() throws IOException, InterruptedException {
         Path tempRoot = Files.createTempDirectory("gr-75058-");
         try {
+            assumeSymbolicLinksSupported(tempRoot);
             Path preopenedDirectory = Files.createDirectory(tempRoot.resolve("preopen"));
             Path outsideDirectory = Files.createDirectory(tempRoot.resolve("outside"));
             Path outsideTarget = outsideDirectory.resolve("secret.txt");
@@ -334,6 +340,7 @@ public class GR75058Test {
     public void testPathUnlinkFileUnlinksFinalSymlinkWithoutTouchingTarget() throws IOException, InterruptedException {
         Path tempRoot = Files.createTempDirectory("gr-75058-");
         try {
+            assumeSymbolicLinksSupported(tempRoot);
             Path preopenedDirectory = Files.createDirectory(tempRoot.resolve("preopen"));
             Path outsideDirectory = Files.createDirectory(tempRoot.resolve("outside"));
             Path outsideTarget = outsideDirectory.resolve("secret.txt");
@@ -373,6 +380,7 @@ public class GR75058Test {
     public void testPathRemoveDirectoryRejectsFinalSymlinkToDirectory() throws IOException, InterruptedException {
         Path tempRoot = Files.createTempDirectory("gr-75058-");
         try {
+            assumeSymbolicLinksSupported(tempRoot);
             Path preopenedDirectory = Files.createDirectory(tempRoot.resolve("preopen"));
             Path outsideDirectory = Files.createDirectory(tempRoot.resolve("outside"));
             Path outsideTarget = Files.createDirectory(outsideDirectory.resolve("target-dir"));
@@ -413,6 +421,19 @@ public class GR75058Test {
         contextBuilder.option("wasm.Builtins", "wasi_snapshot_preview1");
         contextBuilder.option("wasm.WasiMapDirs", "test::" + preopenedDirectory.toAbsolutePath());
         return contextBuilder.build();
+    }
+
+    private static void assumeSymbolicLinksSupported(Path tempRoot) throws IOException {
+        Path target = Files.createFile(tempRoot.resolve("symlink-target"));
+        Path link = tempRoot.resolve("symlink-link");
+        try {
+            Files.createSymbolicLink(link, target.getFileName());
+        } catch (IOException | UnsupportedOperationException | SecurityException e) {
+            Assume.assumeTrue("symbolic links are not supported in this environment", false);
+        } finally {
+            Files.deleteIfExists(link);
+            Files.deleteIfExists(target);
+        }
     }
 
     private static void deleteTree(Path root) throws IOException {

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/DirectoryFd.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/DirectoryFd.java
@@ -178,8 +178,8 @@ class DirectoryFd extends Fd {
                 segments.add(name);
             }
         }
-        for (String segment : segments.reversed()) {
-            currentHostPath = currentHostPath.resolve(segment);
+        for (int i = segments.size() - 1; i >= 0; i--) {
+            currentHostPath = currentHostPath.resolve(segments.get(i));
             if (currentHostPath.isSymbolicLink()) {
                 return true;
             }

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/DirectoryFd.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/DirectoryFd.java
@@ -48,6 +48,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.NotLinkException;
 import java.nio.file.attribute.FileTime;
@@ -88,61 +89,133 @@ class DirectoryFd extends Fd {
         this.preopenedRoot = preopenedRoot;
     }
 
+    /**
+     * Reads a guest path string from memory, resolves it relative to this directory fd's virtual
+     * location, and rejects lexical escapes from the preopened virtual root.
+     */
     private TruffleFile resolveVirtualFile(Node node, WasmMemory memory, int pathAddress, int pathLength) {
         final String path = memory.readString(pathAddress, pathLength, node);
         return preopenedRoot.containedVirtualFile(virtualFile.resolve(path));
     }
 
-    private static TruffleFile resolveVirtualFile(Node node, WasmMemory memory, DirectoryFd fd, int pathAddress, int pathLength) {
-        final String path = memory.readString(pathAddress, pathLength, node);
-        return fd.preopenedRoot.containedVirtualFile(fd.virtualFile.resolve(path));
+    /**
+     * Maps a virtual child path to a host path for default no-follow semantics.
+     * <p>
+     * This keeps the result inside the preopened root and rejects paths whose intermediate
+     * components would traverse a symbolic link.
+     */
+    private TruffleFile resolveHostFile(TruffleFile virtualChildFile) throws SecurityException {
+        final TruffleFile hostChildFile = preopenedRoot.virtualFileToHostFile(virtualChildFile);
+        if (hostChildFile == null) {
+            return null;
+        }
+
+        // Default WASI path resolution is no-follow: reject paths that would traverse an
+        // intermediate symbolic link before reaching the final component.
+        if (usesSymlinkTraversal(virtualChildFile)) {
+            return null;
+        }
+        return hostChildFile;
     }
 
+    /**
+     * Maps a virtual child path to a host path for operations that explicitly request
+     * {@code LOOKUP_SYMLINK_FOLLOW}.
+     * <p>
+     * Existing targets are canonicalized directly. For paths whose final component does not yet
+     * exist, only the parent is canonicalized and the last segment is reattached under the verified
+     * in-sandbox parent.
+     */
+    private TruffleFile resolveHostFileByCanonicalizing(TruffleFile virtualChildFile) throws IOException, SecurityException {
+        final TruffleFile hostChildFile = preopenedRoot.virtualFileToHostFile(virtualChildFile);
+        if (hostChildFile == null) {
+            return null;
+        }
+
+        if (hostChildFile.exists()) {
+            // Existing target: canonicalize the whole path, then verify the resolved location is
+            // still inside the preopened root.
+            return preopenedRoot.containedHostFile(hostChildFile.getCanonicalFile());
+        }
+
+        final TruffleFile hostParent = hostChildFile.getParent();
+        if (hostParent == null) {
+            // No parent component to canonicalize. This is effectively just a containment check on
+            // the path itself.
+            return preopenedRoot.containedHostFile(hostChildFile);
+        }
+        final TruffleFile canonicalParent = preopenedRoot.containedHostFile(hostParent.getCanonicalFile());
+        if (canonicalParent == null) {
+            // The parent resolves outside the preopened root, so the requested path must be
+            // rejected as an escape.
+            return null;
+        }
+        // The final component does not exist yet, so canonicalize only the parent and reattach the
+        // last path segment under the verified in-sandbox parent.
+        return preopenedRoot.containedHostFile(canonicalParent.resolve(hostChildFile.getName()));
+    }
+
+    /**
+     * Returns {@code true} if reaching {@code virtualChildFile} from this directory fd would cross
+     * an intermediate symbolic link on the host filesystem.
+     * <p>
+     * The final path component is intentionally excluded here. Callers that care about the final
+     * component, such as {@code path_open}, perform that check separately.
+     */
+    private boolean usesSymlinkTraversal(TruffleFile virtualChildFile) throws SecurityException {
+        final TruffleFile currentHostDirectory = preopenedRoot.virtualFileToHostFile(virtualFile);
+        if (currentHostDirectory == null) {
+            return true;
+        }
+
+        final String relativePath = virtualFile.relativize(virtualChildFile).getPath();
+        if (relativePath.isEmpty()) {
+            return false;
+        }
+
+        TruffleFile currentHostPath = currentHostDirectory;
+        final String[] segments = relativePath.split("/");
+        for (int i = 0; i < segments.length - 1; i++) {
+            if (segments[i].isEmpty()) {
+                continue;
+            }
+            currentHostPath = currentHostPath.resolve(segments[i]);
+            if (currentHostPath.isSymbolicLink()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Convenience wrapper that reads a guest path from memory and resolves it using the default
+     * no-follow sandboxing policy.
+     */
     private TruffleFile resolveHostFile(Node node, WasmMemory memory, int pathAddress, int pathLength) {
         final TruffleFile virtualChildFile = resolveVirtualFile(node, memory, pathAddress, pathLength);
         if (virtualChildFile == null) {
             return null;
         }
 
-        return preopenedRoot.virtualFileToHostFile(virtualChildFile);
+        return resolveHostFile(virtualChildFile);
     }
 
-    private static TruffleFile resolveHostFile(Node node, WasmMemory memory, DirectoryFd fd, int pathAddress, int pathLength) {
-        final TruffleFile virtualChildFile = resolveVirtualFile(node, memory, fd, pathAddress, pathLength);
-        if (virtualChildFile == null) {
-            return null;
-        }
-        return fd.preopenedRoot.virtualFileToHostFile(virtualChildFile);
-    }
-
+    /**
+     * Reads a guest path from memory and resolves it according to the provided WASI lookup flags.
+     * <p>
+     * Without {@code LOOKUP_SYMLINK_FOLLOW}, this applies the default no-follow policy. With that
+     * flag set, the host path is canonicalized and then rechecked for containment in the preopened
+     * root.
+     */
     private TruffleFile resolveHostFile(Node node, WasmMemory memory, int pathAddress, int pathLength, int lookupFlags) throws IOException, SecurityException {
-        TruffleFile hostFile = resolveHostFile(node, memory, pathAddress, pathLength);
-        if (hostFile == null) {
-            return null;
-        }
-
-        if (isSet(lookupFlags, Lookupflags.SymlinkFollow) && hostFile.exists()) {
-            // Follow symbolic links, and make sure that the target is still contained in
-            // preopenedRoot.
-            hostFile = preopenedRoot.containedHostFile(hostFile.getCanonicalFile());
-        }
-        return hostFile;
-    }
-
-    private TruffleFile resolveHostFile(TruffleFile virtualChildFile, int lookupFlags) throws IOException, SecurityException {
+        final TruffleFile virtualChildFile = resolveVirtualFile(node, memory, pathAddress, pathLength);
         if (virtualChildFile == null) {
             return null;
         }
-        TruffleFile hostFile = preopenedRoot.virtualFileToHostFile(virtualChildFile);
-        if (hostFile == null) {
-            return null;
+        if (!isSet(lookupFlags, Lookupflags.SymlinkFollow)) {
+            return resolveHostFile(virtualChildFile);
         }
-        if (isSet(lookupFlags, Lookupflags.SymlinkFollow) && hostFile.exists()) {
-            // Follow symbolic links, and make sure that the target is still contained in
-            // preopenedRoot.
-            hostFile = preopenedRoot.containedHostFile(hostFile.getCanonicalFile());
-        }
-        return hostFile;
+        return resolveHostFileByCanonicalizing(virtualChildFile);
     }
 
     @Override
@@ -250,10 +323,10 @@ class DirectoryFd extends Fd {
             return Errno.Noent;
         }
 
-        if (!(newFd instanceof DirectoryFd)) {
+        if (!(newFd instanceof DirectoryFd newDirFd)) {
             return Errno.Notdir;
         }
-        final TruffleFile newHostChildFile = resolveHostFile(node, memory, (DirectoryFd) newFd, newPathAddress, newPathLength);
+        final TruffleFile newHostChildFile = newDirFd.resolveHostFile(node, memory, newPathAddress, newPathLength);
         if (newHostChildFile == null) {
             return Errno.Noent;
         }
@@ -285,8 +358,9 @@ class DirectoryFd extends Fd {
         }
 
         final TruffleFile hostChildFile;
+        final boolean followSymlinks = isSet(dirFlags, Lookupflags.SymlinkFollow);
         try {
-            hostChildFile = resolveHostFile(virtualChildFile, dirFlags);
+            hostChildFile = followSymlinks ? resolveHostFileByCanonicalizing(virtualChildFile) : resolveHostFile(virtualChildFile);
         } catch (IOException e) {
             return Errno.Io;
         } catch (SecurityException e) {
@@ -304,8 +378,21 @@ class DirectoryFd extends Fd {
             return Errno.Inval;
         }
 
+        if (!followSymlinks && hostChildFile.exists() && hostChildFile.isSymbolicLink()) {
+            return Errno.Loop;
+        }
+
         if (isSet(childOflags, Oflags.Directory)) {
-            if (hostChildFile.isDirectory()) {
+            final boolean isDirectory;
+            try {
+                isDirectory = hostChildFile.exists() &&
+                                hostChildFile.getAttribute(TruffleFile.IS_DIRECTORY, followSymlinks ? new LinkOption[0] : new LinkOption[]{LinkOption.NOFOLLOW_LINKS});
+            } catch (IOException e) {
+                return Errno.Io;
+            } catch (SecurityException e) {
+                return Errno.Acces;
+            }
+            if (isDirectory) {
                 final int fd = fdManager.put(new DirectoryFd(fdManager, virtualChildFile, preopenedRoot, childFsRightsBase, childFsRightsInheriting, childFdFlags));
                 WasmMemoryLibrary.getUncached().store_i32(memory, node, fdAddress, fd);
                 return Errno.Success;
@@ -314,7 +401,7 @@ class DirectoryFd extends Fd {
             }
         } else {
             try {
-                final int fd = fdManager.put(new FileFd(hostChildFile, childOflags, childFsRightsBase, childFsRightsInheriting, childFdFlags));
+                final int fd = fdManager.put(new FileFd(hostChildFile, childOflags, childFsRightsBase, childFsRightsInheriting, childFdFlags, followSymlinks));
                 WasmMemoryLibrary.getUncached().store_i32(memory, node, fdAddress, fd);
                 return Errno.Success;
             } catch (FileAlreadyExistsException e) {
@@ -451,11 +538,11 @@ class DirectoryFd extends Fd {
             return Errno.Noent;
         }
 
-        if (!(newFd instanceof DirectoryFd)) {
+        if (!(newFd instanceof DirectoryFd newDirFd)) {
             return Errno.Notdir;
         }
 
-        final TruffleFile newHostChildFile = resolveHostFile(node, memory, (DirectoryFd) newFd, newPathAddress, newPathLength);
+        final TruffleFile newHostChildFile = newDirFd.resolveHostFile(node, memory, newPathAddress, newPathLength);
         if (newHostChildFile == null) {
             return Errno.Noent;
         }

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/DirectoryFd.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/DirectoryFd.java
@@ -191,7 +191,7 @@ class DirectoryFd extends Fd {
      * Convenience wrapper that reads a guest path from memory and resolves it using the default
      * no-follow sandboxing policy.
      */
-    private TruffleFile resolveHostFile(Node node, WasmMemory memory, int pathAddress, int pathLength) {
+    private TruffleFile resolveHostFile(Node node, WasmMemory memory, int pathAddress, int pathLength) throws SecurityException {
         final TruffleFile virtualChildFile = resolveVirtualFile(node, memory, pathAddress, pathLength);
         if (virtualChildFile == null) {
             return null;
@@ -232,11 +232,11 @@ class DirectoryFd extends Fd {
             return Errno.Notcapable;
         }
 
-        final TruffleFile hostChildFile = resolveHostFile(node, memory, pathAddress, pathLength);
-        if (hostChildFile == null) {
-            return Errno.Noent;
-        }
         try {
+            final TruffleFile hostChildFile = resolveHostFile(node, memory, pathAddress, pathLength);
+            if (hostChildFile == null) {
+                return Errno.Noent;
+            }
             hostChildFile.createDirectory();
         } catch (FileAlreadyExistsException e) {
             return Errno.Exist;
@@ -273,18 +273,11 @@ class DirectoryFd extends Fd {
         if (!isSet(fsRightsBase, Rights.PathFilestatSetTimes)) {
             return Errno.Notcapable;
         }
-        final TruffleFile hostChildFile;
         try {
-            hostChildFile = resolveHostFile(node, memory, pathAddress, pathLength, flags);
-        } catch (IOException e) {
-            return Errno.Io;
-        } catch (SecurityException e) {
-            return Errno.Acces;
-        }
-        if (hostChildFile == null) {
-            return Errno.Noent;
-        }
-        try {
+            final TruffleFile hostChildFile = resolveHostFile(node, memory, pathAddress, pathLength, flags);
+            if (hostChildFile == null) {
+                return Errno.Noent;
+            }
             if (isSet(fstFlags, Fstflags.Atim)) {
                 hostChildFile.setLastAccessTime(FileTime.from(atim, TimeUnit.NANOSECONDS));
             }
@@ -310,27 +303,18 @@ class DirectoryFd extends Fd {
         if (!isSet(fsRightsBase, Rights.PathLinkSource) || !isSet(newFd.fsRightsBase, Rights.PathLinkTarget)) {
             return Errno.Notcapable;
         }
-
-        final TruffleFile oldHostChildFile;
         try {
-            oldHostChildFile = resolveHostFile(node, memory, oldPathAddress, oldPathLength, oldFlags);
-        } catch (IOException e) {
-            return Errno.Io;
-        } catch (SecurityException e) {
-            return Errno.Acces;
-        }
-        if (oldHostChildFile == null) {
-            return Errno.Noent;
-        }
-
-        if (!(newFd instanceof DirectoryFd newDirFd)) {
-            return Errno.Notdir;
-        }
-        final TruffleFile newHostChildFile = newDirFd.resolveHostFile(node, memory, newPathAddress, newPathLength);
-        if (newHostChildFile == null) {
-            return Errno.Noent;
-        }
-        try {
+            final TruffleFile oldHostChildFile = resolveHostFile(node, memory, oldPathAddress, oldPathLength, oldFlags);
+            if (oldHostChildFile == null) {
+                return Errno.Noent;
+            }
+            if (!(newFd instanceof DirectoryFd newDirFd)) {
+                return Errno.Notdir;
+            }
+            final TruffleFile newHostChildFile = newDirFd.resolveHostFile(node, memory, newPathAddress, newPathLength);
+            if (newHostChildFile == null) {
+                return Errno.Noent;
+            }
             newHostChildFile.createLink(oldHostChildFile);
         } catch (FileAlreadyExistsException e) {
             return Errno.Exist;
@@ -357,62 +341,47 @@ class DirectoryFd extends Fd {
             return Errno.Noent;
         }
 
-        final TruffleFile hostChildFile;
         final boolean followSymlinks = isSet(dirFlags, Lookupflags.SymlinkFollow);
         try {
-            hostChildFile = followSymlinks ? resolveHostFileByCanonicalizing(virtualChildFile) : resolveHostFile(virtualChildFile);
-        } catch (IOException e) {
-            return Errno.Io;
-        } catch (SecurityException e) {
-            return Errno.Acces;
-        }
-        if (hostChildFile == null) {
-            return Errno.Noent;
-        }
+            final TruffleFile hostChildFile = followSymlinks ? resolveHostFileByCanonicalizing(virtualChildFile) : resolveHostFile(virtualChildFile);
+            if (hostChildFile == null) {
+                return Errno.Noent;
+            }
+            // As they are non-null, virtualChildFile and hostChildFile are guaranteed to be
+            // contained in preopenedRoot.
 
-        // As they are non-null, virtualChildFile and hostChildFile are guaranteed to be
-        // contained in preopenedRoot.
+            if (isSet(childFdFlags, Fdflags.Rsync)) {
+                // Not supported.
+                return Errno.Inval;
+            }
 
-        if (isSet(childFdFlags, Fdflags.Rsync)) {
-            // Not supported.
-            return Errno.Inval;
-        }
+            if (!followSymlinks && hostChildFile.exists() && hostChildFile.isSymbolicLink()) {
+                return Errno.Loop;
+            }
 
-        if (!followSymlinks && hostChildFile.exists() && hostChildFile.isSymbolicLink()) {
-            return Errno.Loop;
-        }
-
-        if (isSet(childOflags, Oflags.Directory)) {
-            final boolean isDirectory;
-            try {
-                isDirectory = hostChildFile.exists() &&
+            if (isSet(childOflags, Oflags.Directory)) {
+                final boolean isDirectory = hostChildFile.exists() &&
                                 hostChildFile.getAttribute(TruffleFile.IS_DIRECTORY, followSymlinks ? new LinkOption[0] : new LinkOption[]{LinkOption.NOFOLLOW_LINKS});
-            } catch (IOException e) {
-                return Errno.Io;
-            } catch (SecurityException e) {
-                return Errno.Acces;
-            }
-            if (isDirectory) {
-                final int fd = fdManager.put(new DirectoryFd(fdManager, virtualChildFile, preopenedRoot, childFsRightsBase, childFsRightsInheriting, childFdFlags));
-                WasmMemoryLibrary.getUncached().store_i32(memory, node, fdAddress, fd);
-                return Errno.Success;
+                if (isDirectory) {
+                    final int fd = fdManager.put(new DirectoryFd(fdManager, virtualChildFile, preopenedRoot, childFsRightsBase, childFsRightsInheriting, childFdFlags));
+                    WasmMemoryLibrary.getUncached().store_i32(memory, node, fdAddress, fd);
+                    return Errno.Success;
+                } else {
+                    return Errno.Notdir;
+                }
             } else {
-                return Errno.Notdir;
-            }
-        } else {
-            try {
                 final int fd = fdManager.put(new FileFd(hostChildFile, childOflags, childFsRightsBase, childFsRightsInheriting, childFdFlags, followSymlinks));
                 WasmMemoryLibrary.getUncached().store_i32(memory, node, fdAddress, fd);
                 return Errno.Success;
-            } catch (FileAlreadyExistsException e) {
-                return Errno.Exist;
-            } catch (IOException | UnsupportedOperationException e) {
-                return Errno.Io;
-            } catch (IllegalArgumentException e) {
-                return Errno.Inval;
-            } catch (SecurityException e) {
-                return Errno.Acces;
             }
+        } catch (FileAlreadyExistsException e) {
+            return Errno.Exist;
+        } catch (IllegalArgumentException e) {
+            return Errno.Inval;
+        } catch (SecurityException e) {
+            return Errno.Acces;
+        } catch (IOException | UnsupportedOperationException e) {
+            return Errno.Io;
         }
     }
 
@@ -478,11 +447,11 @@ class DirectoryFd extends Fd {
         if (!isSet(fsRightsBase, Rights.PathReadlink)) {
             return Errno.Notcapable.ordinal();
         }
-        final TruffleFile hostChildFile = resolveHostFile(node, memory, pathAddress, pathLength);
-        if (hostChildFile == null) {
-            return Errno.Noent.ordinal();
-        }
         try {
+            final TruffleFile hostChildFile = resolveHostFile(node, memory, pathAddress, pathLength);
+            if (hostChildFile == null) {
+                return Errno.Noent.ordinal();
+            }
             final TruffleFile link = hostChildFile.readSymbolicLink();
             final TruffleFile virtualLink = preopenedRoot.hostFileToVirtualFile(link);
             if (virtualLink == null) {
@@ -506,14 +475,14 @@ class DirectoryFd extends Fd {
         if (!isSet(fsRightsBase, Rights.PathRemoveDirectory)) {
             return Errno.Notcapable;
         }
-        final TruffleFile hostChildFile = resolveHostFile(node, memory, pathAddress, pathLength);
-        if (hostChildFile == null) {
-            return Errno.Noent;
-        }
-        if (!hostChildFile.isDirectory()) {
-            return Errno.Notdir;
-        }
         try {
+            final TruffleFile hostChildFile = resolveHostFile(node, memory, pathAddress, pathLength);
+            if (hostChildFile == null) {
+                return Errno.Noent;
+            }
+            if (!hostChildFile.isDirectory()) {
+                return Errno.Notdir;
+            }
             hostChildFile.delete();
         } catch (DirectoryNotEmptyException e) {
             return Errno.Notempty;
@@ -533,21 +502,18 @@ class DirectoryFd extends Fd {
         if (!isSet(fsRightsBase, Rights.PathRenameSource) || !isSet(newFd.fsRightsBase, Rights.PathRenameTarget)) {
             return Errno.Notcapable;
         }
-        final TruffleFile oldHostChildFile = resolveHostFile(node, memory, oldPathAddress, oldPathLength);
-        if (oldHostChildFile == null) {
-            return Errno.Noent;
-        }
-
-        if (!(newFd instanceof DirectoryFd newDirFd)) {
-            return Errno.Notdir;
-        }
-
-        final TruffleFile newHostChildFile = newDirFd.resolveHostFile(node, memory, newPathAddress, newPathLength);
-        if (newHostChildFile == null) {
-            return Errno.Noent;
-        }
-
         try {
+            final TruffleFile oldHostChildFile = resolveHostFile(node, memory, oldPathAddress, oldPathLength);
+            if (oldHostChildFile == null) {
+                return Errno.Noent;
+            }
+            if (!(newFd instanceof DirectoryFd newDirFd)) {
+                return Errno.Notdir;
+            }
+            final TruffleFile newHostChildFile = newDirFd.resolveHostFile(node, memory, newPathAddress, newPathLength);
+            if (newHostChildFile == null) {
+                return Errno.Noent;
+            }
             oldHostChildFile.move(newHostChildFile);
         } catch (FileAlreadyExistsException e) {
             return Errno.Exist;
@@ -564,18 +530,15 @@ class DirectoryFd extends Fd {
         if (!isSet(fsRightsBase, Rights.PathSymlink)) {
             return Errno.Notcapable;
         }
-
-        final TruffleFile oldHostChildFile = resolveHostFile(node, memory, oldPathAddress, oldPathLength);
-        if (oldHostChildFile == null) {
-            return Errno.Noent;
-        }
-
-        final TruffleFile newHostChildFile = resolveHostFile(node, memory, newPathAddress, newPathLength);
-        if (newHostChildFile == null) {
-            return Errno.Noent;
-        }
-
         try {
+            final TruffleFile oldHostChildFile = resolveHostFile(node, memory, oldPathAddress, oldPathLength);
+            if (oldHostChildFile == null) {
+                return Errno.Noent;
+            }
+            final TruffleFile newHostChildFile = resolveHostFile(node, memory, newPathAddress, newPathLength);
+            if (newHostChildFile == null) {
+                return Errno.Noent;
+            }
             newHostChildFile.createSymbolicLink(oldHostChildFile);
         } catch (FileAlreadyExistsException e) {
             return Errno.Exist;
@@ -592,15 +555,14 @@ class DirectoryFd extends Fd {
         if (!isSet(fsRightsBase, Rights.PathUnlinkFile)) {
             return Errno.Notcapable;
         }
-
-        final TruffleFile hostChildFile = resolveHostFile(node, memory, pathAddress, pathLength);
-        if (hostChildFile == null) {
-            return Errno.Noent;
-        }
-        if (hostChildFile.isDirectory()) {
-            return Errno.Isdir;
-        }
         try {
+            final TruffleFile hostChildFile = resolveHostFile(node, memory, pathAddress, pathLength);
+            if (hostChildFile == null) {
+                return Errno.Noent;
+            }
+            if (hostChildFile.isDirectory()) {
+                return Errno.Isdir;
+            }
             hostChildFile.delete();
         } catch (NoSuchFileException e) {
             return Errno.Noent;

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/DirectoryFd.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/DirectoryFd.java
@@ -223,7 +223,7 @@ class DirectoryFd extends Fd {
         if (!isSet(fsRightsBase, Rights.FdFilestatGet)) {
             return Errno.Notcapable;
         }
-        return FdUtils.writeFilestat(node, memory, resultAddress, virtualFile);
+        return FdUtils.writeFilestat(node, memory, resultAddress, virtualFile, FdUtils.FOLLOW_LINKS);
     }
 
     @Override
@@ -254,6 +254,7 @@ class DirectoryFd extends Fd {
             return Errno.Notcapable;
         }
 
+        final boolean followSymlinks = isSet(flags, Lookupflags.SymlinkFollow);
         final TruffleFile hostChildFile;
         try {
             hostChildFile = resolveHostFile(node, memory, pathAddress, pathLength, flags);
@@ -265,7 +266,7 @@ class DirectoryFd extends Fd {
         if (hostChildFile == null) {
             return Errno.Noent;
         }
-        return FdUtils.writeFilestat(node, memory, resultAddress, hostChildFile);
+        return FdUtils.writeFilestat(node, memory, resultAddress, hostChildFile, FdUtils.linkOptions(followSymlinks));
     }
 
     @Override
@@ -273,22 +274,24 @@ class DirectoryFd extends Fd {
         if (!isSet(fsRightsBase, Rights.PathFilestatSetTimes)) {
             return Errno.Notcapable;
         }
+        final boolean followSymlinks = isSet(flags, Lookupflags.SymlinkFollow);
+        final LinkOption[] linkOptions = FdUtils.linkOptions(followSymlinks);
         try {
             final TruffleFile hostChildFile = resolveHostFile(node, memory, pathAddress, pathLength, flags);
             if (hostChildFile == null) {
                 return Errno.Noent;
             }
             if (isSet(fstFlags, Fstflags.Atim)) {
-                hostChildFile.setLastAccessTime(FileTime.from(atim, TimeUnit.NANOSECONDS));
+                hostChildFile.setLastAccessTime(FileTime.from(atim, TimeUnit.NANOSECONDS), linkOptions);
             }
             if (isSet(fstFlags, Fstflags.AtimNow)) {
-                hostChildFile.setLastAccessTime(FileTime.from(WasiClockTimeGetNode.realtimeNow(), TimeUnit.NANOSECONDS));
+                hostChildFile.setLastAccessTime(FileTime.from(WasiClockTimeGetNode.realtimeNow(), TimeUnit.NANOSECONDS), linkOptions);
             }
             if (isSet(fstFlags, Fstflags.Mtim)) {
-                hostChildFile.setLastModifiedTime(FileTime.from(mtim, TimeUnit.NANOSECONDS));
+                hostChildFile.setLastModifiedTime(FileTime.from(mtim, TimeUnit.NANOSECONDS), linkOptions);
             }
             if (isSet(fstFlags, Fstflags.MtimNow)) {
-                hostChildFile.setLastModifiedTime(FileTime.from(WasiClockTimeGetNode.realtimeNow(), TimeUnit.NANOSECONDS));
+                hostChildFile.setLastModifiedTime(FileTime.from(WasiClockTimeGetNode.realtimeNow(), TimeUnit.NANOSECONDS), linkOptions);
             }
         } catch (IOException e) {
             return Errno.Io;
@@ -361,7 +364,7 @@ class DirectoryFd extends Fd {
 
             if (isSet(childOflags, Oflags.Directory)) {
                 final boolean isDirectory = hostChildFile.exists() &&
-                                hostChildFile.getAttribute(TruffleFile.IS_DIRECTORY, followSymlinks ? new LinkOption[0] : new LinkOption[]{LinkOption.NOFOLLOW_LINKS});
+                                hostChildFile.getAttribute(TruffleFile.IS_DIRECTORY, FdUtils.linkOptions(followSymlinks));
                 if (isDirectory) {
                     final int fd = fdManager.put(new DirectoryFd(fdManager, virtualChildFile, preopenedRoot, childFsRightsBase, childFsRightsInheriting, childFdFlags));
                     WasmMemoryLibrary.getUncached().store_i32(memory, node, fdAddress, fd);
@@ -396,6 +399,7 @@ class DirectoryFd extends Fd {
             entries.add(virtualFile.resolve("."));
             entries.add(virtualFile.resolve(".."));
             entries.addAll(children);
+            final LinkOption[] linkOptions = FdUtils.NOFOLLOW_LINKS;
 
             int bufPointer = bufAddress;
             int bufEnd = bufAddress + bufLength;
@@ -407,12 +411,18 @@ class DirectoryFd extends Fd {
                 // Only write entries whose index is past the received "cookie"
                 if (currentEntry >= cookie) {
                     byte[] name = file.getName().getBytes(StandardCharsets.UTF_8);
+                    final boolean syntheticDirectoryEntry = ".".equals(file.getName()) || "..".equals(file.getName());
+                    final TruffleFile metadataFile = syntheticDirectoryEntry ? null : preopenedRoot.virtualFileToHostFile(file);
 
                     if (bufEnd - bufPointer >= Dirent.BYTES) {
-                        bufPointer += FdUtils.writeDirent(node, memory, bufPointer, file, name.length, currentEntry + 1);
+                        bufPointer += syntheticDirectoryEntry
+                                        ? FdUtils.writeSyntheticDirent(node, memory, bufPointer, name.length, currentEntry + 1, Filetype.Directory)
+                                        : FdUtils.writeDirent(node, memory, bufPointer, metadataFile, name.length, currentEntry + 1, linkOptions);
                     } else {
                         // Write dirent to temp buffer and truncate
-                        byte[] dirent = FdUtils.writeDirentToByteArray(file, name.length, currentEntry + 1);
+                        byte[] dirent = syntheticDirectoryEntry
+                                        ? FdUtils.writeSyntheticDirentToByteArray(name.length, currentEntry + 1, Filetype.Directory)
+                                        : FdUtils.writeDirentToByteArray(metadataFile, name.length, currentEntry + 1, linkOptions);
                         for (int i = 0; bufPointer < bufEnd; i++, bufPointer++) {
                             assert i < dirent.length;
                             memories.store_i32_8(memory, node, bufPointer, dirent[i]);
@@ -480,7 +490,7 @@ class DirectoryFd extends Fd {
             if (hostChildFile == null) {
                 return Errno.Noent;
             }
-            if (!hostChildFile.isDirectory()) {
+            if (!hostChildFile.getAttribute(TruffleFile.IS_DIRECTORY, FdUtils.NOFOLLOW_LINKS)) {
                 return Errno.Notdir;
             }
             hostChildFile.delete();
@@ -560,7 +570,7 @@ class DirectoryFd extends Fd {
             if (hostChildFile == null) {
                 return Errno.Noent;
             }
-            if (hostChildFile.isDirectory()) {
+            if (hostChildFile.getAttribute(TruffleFile.IS_DIRECTORY, FdUtils.NOFOLLOW_LINKS)) {
                 return Errno.Isdir;
             }
             hostChildFile.delete();

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/DirectoryFd.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/DirectoryFd.java
@@ -48,13 +48,16 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileSystemLoopException;
 import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.NotLinkException;
 import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.graalvm.wasm.memory.WasmMemory;
@@ -78,6 +81,12 @@ import com.oracle.truffle.api.nodes.Node;
  */
 class DirectoryFd extends Fd {
 
+    private enum FinalSymlinkPolicy {
+        NoFollow,
+        Follow,
+        FollowAllowMissingTarget
+    }
+
     private final FdManager fdManager;
     private final PreopenedDirectory preopenedRoot;
     private final TruffleFile virtualFile;
@@ -99,63 +108,87 @@ class DirectoryFd extends Fd {
     }
 
     /**
-     * Maps a virtual child path to a host path for default no-follow semantics.
+     * Maps a virtual child path to a host path according to the requested final-symlink policy.
      * <p>
-     * Intermediate components are resolved on the host and must stay inside the preopened root, but
-     * the final component is kept unresolved so callers can apply the default no-follow policy to
-     * it.
+     * Intermediate components are resolved on the host and must stay inside the preopened root. The
+     * final component is either kept unresolved, followed, or followed with a missing target
+     * allowed for {@code path_open(O_CREAT)}.
      */
-    private TruffleFile resolveHostFile(TruffleFile virtualChildFile) throws IOException, SecurityException {
-        final TruffleFile hostChildFile = preopenedRoot.virtualFileToHostFile(virtualChildFile);
+    private TruffleFile resolveHostFile(TruffleFile virtualChildFile, FinalSymlinkPolicy finalSymlinkPolicy) throws IOException, SecurityException {
+        final TruffleFile lexicalHostChildFile = preopenedRoot.virtualFileToHostFile(virtualChildFile);
+        if (lexicalHostChildFile == null) {
+            return null;
+        }
+        final TruffleFile hostChildFile = resolveWithCanonicalParent(lexicalHostChildFile);
         if (hostChildFile == null) {
             return null;
         }
-        return resolveHostFileWithCanonicalParent(hostChildFile);
+
+        if (finalSymlinkPolicy == FinalSymlinkPolicy.NoFollow) {
+            return hostChildFile;
+        }
+        if (isSymbolicLink(hostChildFile)) {
+            // Canonicalize the parent chain first, then resolve the final symlink from that real
+            // parent so relative targets and escape checks both match the host filesystem.
+            final boolean allowMissingTargetOfFinalSymlink = finalSymlinkPolicy == FinalSymlinkPolicy.FollowAllowMissingTarget;
+            return resolveFollowedFinalSymlink(hostChildFile, allowMissingTargetOfFinalSymlink);
+        }
+        if (hostChildFile.exists()) {
+            return preopenedRoot.containedHostFile(hostChildFile.getCanonicalFile());
+        }
+        return hostChildFile;
     }
 
     /**
-     * Canonicalizes the parent chain of a host path while leaving the final component unresolved.
-     * Paths that already denote the preopened root itself are returned unchanged.
+     * Resolves a final symlink explicitly, following chains of final symlinks while preserving the
+     * distinction between missing targets, actual symlink loops, and other host failures.
      */
-    private TruffleFile resolveHostFileWithCanonicalParent(TruffleFile hostChildFile) throws IOException, SecurityException {
+    private TruffleFile resolveFollowedFinalSymlink(TruffleFile hostSymlinkFile, boolean allowMissingTarget) throws IOException, SecurityException {
+        final Set<String> visitedPaths = new HashSet<>();
+        TruffleFile currentFile = hostSymlinkFile;
+        while (true) {
+            final String currentPath = currentFile.normalize().getPath();
+            if (!visitedPaths.add(currentPath)) {
+                throw new FileSystemLoopException(hostSymlinkFile.getPath());
+            }
+            final TruffleFile linkTarget;
+            try {
+                linkTarget = currentFile.readSymbolicLink();
+            } catch (NoSuchFileException e) {
+                if (!allowMissingTarget) {
+                    throw new NoSuchFileException(hostSymlinkFile.getPath());
+                }
+                return currentFile;
+            } catch (NotLinkException | UnsupportedOperationException e) {
+                if (currentFile.exists()) {
+                    return preopenedRoot.containedHostFile(currentFile.getCanonicalFile());
+                }
+                if (!allowMissingTarget) {
+                    throw new NoSuchFileException(hostSymlinkFile.getPath());
+                }
+                return currentFile;
+            }
+            final TruffleFile currentParent = currentFile.getParent();
+            currentFile = linkTarget.isAbsolute() || currentParent == null ? linkTarget : currentParent.resolve(linkTarget.getPath());
+            currentFile = resolveWithCanonicalParent(currentFile.normalize());
+            if (currentFile == null) {
+                return null;
+            }
+        }
+    }
+
+    /**
+     * Canonicalizes the parent chain of a host path, verifies that parent stays inside the
+     * preopened root, and then reattaches the final path segment without resolving it. Paths that
+     * already denote the preopened root itself are returned unchanged.
+     */
+    private TruffleFile resolveWithCanonicalParent(TruffleFile hostChildFile) throws IOException, SecurityException {
         if (preopenedRoot.isHostRoot(hostChildFile)) {
             // Paths like "." or "dir/.." may normalize to the preopened root itself. Treat that
             // as an in-sandbox result instead of canonicalizing the parent one level above it.
             return hostChildFile;
         }
-        // Canonicalize the parent chain, then reattach the unresolved final component so callers
-        // can decide whether the last path element may be followed.
-        return resolveHostFileUnderCanonicalParent(hostChildFile);
-    }
 
-    /**
-     * Maps a virtual child path to a host path for operations that explicitly request
-     * {@code LOOKUP_SYMLINK_FOLLOW}.
-     * <p>
-     * Existing targets are canonicalized directly. For paths whose final component does not yet
-     * exist, only the parent is canonicalized and the last segment is reattached under the verified
-     * in-sandbox parent.
-     */
-    private TruffleFile resolveHostFileByCanonicalizing(TruffleFile virtualChildFile) throws IOException, SecurityException {
-        final TruffleFile hostChildFile = preopenedRoot.virtualFileToHostFile(virtualChildFile);
-        if (hostChildFile == null) {
-            return null;
-        }
-
-        if (hostChildFile.exists()) {
-            // Existing target: canonicalize the whole path, then verify the resolved location is
-            // still inside the preopened root.
-            return preopenedRoot.containedHostFile(hostChildFile.getCanonicalFile());
-        }
-
-        return resolveHostFileUnderCanonicalParent(hostChildFile);
-    }
-
-    /**
-     * Canonicalizes the parent chain of a host path, verifies that parent stays inside the
-     * preopened root, and then reattaches the final path segment without resolving it.
-     */
-    private TruffleFile resolveHostFileUnderCanonicalParent(TruffleFile hostChildFile) throws IOException, SecurityException {
         final TruffleFile hostParent = hostChildFile.getParent();
         if (hostParent == null) {
             // No parent component to canonicalize. This is effectively just a containment check on
@@ -181,7 +214,7 @@ class DirectoryFd extends Fd {
             return null;
         }
 
-        return resolveHostFile(virtualChildFile);
+        return resolveHostFile(virtualChildFile, FinalSymlinkPolicy.NoFollow);
     }
 
     /**
@@ -197,9 +230,9 @@ class DirectoryFd extends Fd {
             return null;
         }
         if (!isSet(lookupFlags, Lookupflags.SymlinkFollow)) {
-            return resolveHostFile(virtualChildFile);
+            return resolveHostFile(virtualChildFile, FinalSymlinkPolicy.NoFollow);
         }
-        return resolveHostFileByCanonicalizing(virtualChildFile);
+        return resolveHostFile(virtualChildFile, FinalSymlinkPolicy.Follow);
     }
 
     private static Errno errnoForIoException(IOException e) {
@@ -349,11 +382,30 @@ class DirectoryFd extends Fd {
 
         final boolean followSymlinks = isSet(dirFlags, Lookupflags.SymlinkFollow);
         try {
-            final TruffleFile hostChildFile = followSymlinks ? resolveHostFileByCanonicalizing(virtualChildFile) : resolveHostFile(virtualChildFile);
-            if (hostChildFile == null) {
+            final boolean createRequested = isSet(childOflags, Oflags.Creat);
+            final boolean exclusiveRequested = isSet(childOflags, Oflags.Excl);
+            final FinalSymlinkPolicy finalSymlinkPolicy;
+            if (followSymlinks && createRequested) {
+                finalSymlinkPolicy = FinalSymlinkPolicy.FollowAllowMissingTarget;
+            } else if (followSymlinks) {
+                finalSymlinkPolicy = FinalSymlinkPolicy.Follow;
+            } else {
+                finalSymlinkPolicy = FinalSymlinkPolicy.NoFollow;
+            }
+            final TruffleFile resolvedHostChildFile = resolveHostFile(virtualChildFile, finalSymlinkPolicy);
+            if (resolvedHostChildFile == null) {
                 return Errno.Noent;
             }
-            // As they are non-null, virtualChildFile and hostChildFile are guaranteed to be
+            if (followSymlinks && exclusiveRequested) {
+                final TruffleFile lexicalHostChildFile = resolveHostFile(virtualChildFile, FinalSymlinkPolicy.NoFollow);
+                if (lexicalHostChildFile == null) {
+                    return Errno.Noent;
+                }
+                if (isSymbolicLink(lexicalHostChildFile)) {
+                    return Errno.Exist;
+                }
+            }
+            // As they are non-null, virtualChildFile and resolvedHostChildFile are guaranteed to be
             // contained in preopenedRoot.
 
             if (isSet(childFdFlags, Fdflags.Rsync)) {
@@ -361,13 +413,13 @@ class DirectoryFd extends Fd {
                 return Errno.Inval;
             }
 
-            if (!followSymlinks && hostChildFile.exists() && hostChildFile.isSymbolicLink()) {
+            if (!followSymlinks && isSymbolicLink(resolvedHostChildFile)) {
                 return Errno.Loop;
             }
 
             if (isSet(childOflags, Oflags.Directory)) {
-                final boolean isDirectory = hostChildFile.exists() &&
-                                hostChildFile.getAttribute(TruffleFile.IS_DIRECTORY, FdUtils.linkOptions(followSymlinks));
+                final boolean isDirectory = resolvedHostChildFile.exists() &&
+                                resolvedHostChildFile.getAttribute(TruffleFile.IS_DIRECTORY, FdUtils.linkOptions(followSymlinks));
                 if (isDirectory) {
                     final int fd = fdManager.put(new DirectoryFd(fdManager, virtualChildFile, preopenedRoot, childFsRightsBase, childFsRightsInheriting, childFdFlags));
                     WasmMemoryLibrary.getUncached().store_i32(memory, node, fdAddress, fd);
@@ -376,7 +428,7 @@ class DirectoryFd extends Fd {
                     return Errno.Notdir;
                 }
             } else {
-                final int fd = fdManager.put(new FileFd(hostChildFile, childOflags, childFsRightsBase, childFsRightsInheriting, childFdFlags, followSymlinks));
+                final int fd = fdManager.put(new FileFd(resolvedHostChildFile, childOflags, childFsRightsBase, childFsRightsInheriting, childFdFlags, followSymlinks));
                 WasmMemoryLibrary.getUncached().store_i32(memory, node, fdAddress, fd);
                 return Errno.Success;
             }
@@ -388,6 +440,20 @@ class DirectoryFd extends Fd {
             return errnoForIoException(e);
         } catch (UnsupportedOperationException e) {
             return Errno.Io;
+        }
+    }
+
+    /**
+     * Best-effort symlink probe used for errno shaping in path operations. It relies on readlink
+     * instead of basic:isSymbolicLink metadata so plain opens keep working on custom file systems
+     * that do not expose that attribute.
+     */
+    private static boolean isSymbolicLink(TruffleFile file) throws IOException, SecurityException {
+        try {
+            file.readSymbolicLink();
+            return true;
+        } catch (NotLinkException | NoSuchFileException | UnsupportedOperationException e) {
+            return false;
         }
     }
 

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/DirectoryFd.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/DirectoryFd.java
@@ -486,15 +486,16 @@ class DirectoryFd extends Fd {
                     byte[] name = file.getName().getBytes(StandardCharsets.UTF_8);
                     final boolean syntheticDirectoryEntry = ".".equals(file.getName()) || "..".equals(file.getName());
                     final TruffleFile metadataFile = syntheticDirectoryEntry ? null : preopenedRoot.virtualFileToHostFile(file);
+                    final long syntheticInode = syntheticDirectoryEntry ? inodeOrZero(preopenedRoot.virtualFileToHostFile(file)) : 0;
 
                     if (bufEnd - bufPointer >= Dirent.BYTES) {
                         bufPointer += syntheticDirectoryEntry
-                                        ? FdUtils.writeSyntheticDirent(node, memory, bufPointer, name.length, currentEntry + 1, Filetype.Directory)
+                                        ? FdUtils.writeSyntheticDirent(node, memory, bufPointer, name.length, currentEntry + 1, syntheticInode, Filetype.Directory)
                                         : FdUtils.writeDirent(node, memory, bufPointer, metadataFile, name.length, currentEntry + 1, linkOptions);
                     } else {
                         // Write dirent to temp buffer and truncate
                         byte[] dirent = syntheticDirectoryEntry
-                                        ? FdUtils.writeSyntheticDirentToByteArray(name.length, currentEntry + 1, Filetype.Directory)
+                                        ? FdUtils.writeSyntheticDirentToByteArray(name.length, currentEntry + 1, syntheticInode, Filetype.Directory)
                                         : FdUtils.writeDirentToByteArray(metadataFile, name.length, currentEntry + 1, linkOptions);
                         for (int i = 0; bufPointer < bufEnd; i++, bufPointer++) {
                             assert i < dirent.length;
@@ -523,6 +524,17 @@ class DirectoryFd extends Fd {
             return Errno.Io;
         }
         return Errno.Success;
+    }
+
+    private static long inodeOrZero(TruffleFile file) throws IOException {
+        if (file == null) {
+            return 0;
+        }
+        try {
+            return file.getAttribute(TruffleFile.UNIX_INODE, FdUtils.NOFOLLOW_LINKS);
+        } catch (UnsupportedOperationException e) {
+            return 0;
+        }
     }
 
     @Override

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/DirectoryFd.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/DirectoryFd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -168,18 +168,18 @@ class DirectoryFd extends Fd {
             return true;
         }
 
-        final String relativePath = virtualFile.relativize(virtualChildFile).getPath();
-        if (relativePath.isEmpty()) {
-            return false;
-        }
+        final TruffleFile relativePath = virtualFile.relativize(virtualChildFile);
 
         TruffleFile currentHostPath = currentHostDirectory;
-        final String[] segments = relativePath.split("/");
-        for (int i = 0; i < segments.length - 1; i++) {
-            if (segments[i].isEmpty()) {
-                continue;
+        final List<String> segments = new ArrayList<>();
+        for (TruffleFile path = relativePath.getParent(); path != null; path = path.getParent()) {
+            final String name = path.getName();
+            if (name != null && !name.isEmpty()) {
+                segments.add(name);
             }
-            currentHostPath = currentHostPath.resolve(segments[i]);
+        }
+        for (String segment : segments.reversed()) {
+            currentHostPath = currentHostPath.resolve(segment);
             if (currentHostPath.isSymbolicLink()) {
                 return true;
             }

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/DirectoryFd.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/DirectoryFd.java
@@ -196,6 +196,25 @@ class DirectoryFd extends Fd {
         return resolveHostFileByCanonicalizing(virtualChildFile);
     }
 
+    private static Errno errnoForIoException(IOException e) {
+        if (e instanceof NoSuchFileException) {
+            return Errno.Noent;
+        }
+        if (e instanceof FileSystemLoopException) {
+            return Errno.Loop;
+        }
+        if (e instanceof FileAlreadyExistsException) {
+            return Errno.Exist;
+        }
+        if (e instanceof NotLinkException) {
+            return Errno.Nolink;
+        }
+        if (e instanceof DirectoryNotEmptyException) {
+            return Errno.Notempty;
+        }
+        return Errno.Io;
+    }
+
     @Override
     public Errno filestatGet(Node node, WasmMemory memory, int resultAddress) {
         if (!isSet(fsRightsBase, Rights.FdFilestatGet)) {
@@ -216,9 +235,9 @@ class DirectoryFd extends Fd {
                 return Errno.Noent;
             }
             hostChildFile.createDirectory();
-        } catch (FileAlreadyExistsException e) {
-            return Errno.Exist;
-        } catch (IOException | UnsupportedOperationException e) {
+        } catch (IOException e) {
+            return errnoForIoException(e);
+        } catch (UnsupportedOperationException e) {
             return Errno.Io;
         } catch (SecurityException e) {
             return Errno.Acces;
@@ -237,7 +256,7 @@ class DirectoryFd extends Fd {
         try {
             hostChildFile = resolveHostFile(node, memory, pathAddress, pathLength, flags);
         } catch (IOException e) {
-            return Errno.Io;
+            return errnoForIoException(e);
         } catch (SecurityException e) {
             return Errno.Acces;
         }
@@ -272,7 +291,7 @@ class DirectoryFd extends Fd {
                 hostChildFile.setLastModifiedTime(FileTime.from(WasiClockTimeGetNode.realtimeNow(), TimeUnit.NANOSECONDS), linkOptions);
             }
         } catch (IOException e) {
-            return Errno.Io;
+            return errnoForIoException(e);
         } catch (SecurityException e) {
             return Errno.Acces;
         }
@@ -297,9 +316,9 @@ class DirectoryFd extends Fd {
                 return Errno.Noent;
             }
             newHostChildFile.createLink(oldHostChildFile);
-        } catch (FileAlreadyExistsException e) {
-            return Errno.Exist;
-        } catch (IOException | UnsupportedOperationException e) {
+        } catch (IOException e) {
+            return errnoForIoException(e);
+        } catch (UnsupportedOperationException e) {
             return Errno.Io;
         } catch (SecurityException e) {
             return Errno.Acces;
@@ -355,13 +374,13 @@ class DirectoryFd extends Fd {
                 WasmMemoryLibrary.getUncached().store_i32(memory, node, fdAddress, fd);
                 return Errno.Success;
             }
-        } catch (FileAlreadyExistsException e) {
-            return Errno.Exist;
         } catch (IllegalArgumentException e) {
             return Errno.Inval;
         } catch (SecurityException e) {
             return Errno.Acces;
-        } catch (IOException | UnsupportedOperationException e) {
+        } catch (IOException e) {
+            return errnoForIoException(e);
+        } catch (UnsupportedOperationException e) {
             return Errno.Io;
         }
     }
@@ -449,9 +468,9 @@ class DirectoryFd extends Fd {
             int bytesWritten = memory.writeString(node, content, buf, bufLen);
             WasmMemoryLibrary.getUncached().store_i32(memory, node, sizeAddress, bytesWritten);
             return Errno.Success.ordinal();
-        } catch (NotLinkException e) {
-            return Errno.Nolink.ordinal();
-        } catch (IOException | UnsupportedOperationException e) {
+        } catch (IOException e) {
+            return errnoForIoException(e).ordinal();
+        } catch (UnsupportedOperationException e) {
             return Errno.Io.ordinal();
         } catch (SecurityException e) {
             return Errno.Acces.ordinal();
@@ -472,12 +491,8 @@ class DirectoryFd extends Fd {
                 return Errno.Notdir;
             }
             hostChildFile.delete();
-        } catch (DirectoryNotEmptyException e) {
-            return Errno.Notempty;
-        } catch (NoSuchFileException e) {
-            return Errno.Noent;
         } catch (IOException e) {
-            return Errno.Io;
+            return errnoForIoException(e);
         } catch (SecurityException e) {
             return Errno.Acces;
         }
@@ -503,9 +518,9 @@ class DirectoryFd extends Fd {
                 return Errno.Noent;
             }
             oldHostChildFile.move(newHostChildFile);
-        } catch (FileAlreadyExistsException e) {
-            return Errno.Exist;
-        } catch (IOException | UnsupportedOperationException e) {
+        } catch (IOException e) {
+            return errnoForIoException(e);
+        } catch (UnsupportedOperationException e) {
             return Errno.Io;
         } catch (SecurityException e) {
             return Errno.Acces;
@@ -528,9 +543,9 @@ class DirectoryFd extends Fd {
                 return Errno.Noent;
             }
             newHostChildFile.createSymbolicLink(oldHostChildFile);
-        } catch (FileAlreadyExistsException e) {
-            return Errno.Exist;
-        } catch (IOException | UnsupportedOperationException e) {
+        } catch (IOException e) {
+            return errnoForIoException(e);
+        } catch (UnsupportedOperationException e) {
             return Errno.Io;
         } catch (SecurityException e) {
             return Errno.Acces;
@@ -552,10 +567,8 @@ class DirectoryFd extends Fd {
                 return Errno.Isdir;
             }
             hostChildFile.delete();
-        } catch (NoSuchFileException e) {
-            return Errno.Noent;
         } catch (IOException e) {
-            return Errno.Io;
+            return errnoForIoException(e);
         } catch (SecurityException e) {
             return Errno.Acces;
         }

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/DirectoryFd.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/DirectoryFd.java
@@ -421,7 +421,11 @@ class DirectoryFd extends Fd {
                 final boolean isDirectory = resolvedHostChildFile.exists() &&
                                 resolvedHostChildFile.getAttribute(TruffleFile.IS_DIRECTORY, FdUtils.linkOptions(followSymlinks));
                 if (isDirectory) {
-                    final int fd = fdManager.put(new DirectoryFd(fdManager, virtualChildFile, preopenedRoot, childFsRightsBase, childFsRightsInheriting, childFdFlags));
+                    final TruffleFile directoryVirtualFile = followSymlinks ? preopenedRoot.hostFileToVirtualFile(resolvedHostChildFile) : virtualChildFile;
+                    if (directoryVirtualFile == null) {
+                        return Errno.Noent;
+                    }
+                    final int fd = fdManager.put(new DirectoryFd(fdManager, directoryVirtualFile, preopenedRoot, childFsRightsBase, childFsRightsInheriting, childFdFlags));
                     WasmMemoryLibrary.getUncached().store_i32(memory, node, fdAddress, fd);
                     return Errno.Success;
                 } else {

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/DirectoryFd.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/DirectoryFd.java
@@ -101,21 +101,31 @@ class DirectoryFd extends Fd {
     /**
      * Maps a virtual child path to a host path for default no-follow semantics.
      * <p>
-     * This keeps the result inside the preopened root and rejects paths whose intermediate
-     * components would traverse a symbolic link.
+     * Intermediate components are resolved on the host and must stay inside the preopened root, but
+     * the final component is kept unresolved so callers can apply the default no-follow policy to
+     * it.
      */
-    private TruffleFile resolveHostFile(TruffleFile virtualChildFile) throws SecurityException {
+    private TruffleFile resolveHostFile(TruffleFile virtualChildFile) throws IOException, SecurityException {
         final TruffleFile hostChildFile = preopenedRoot.virtualFileToHostFile(virtualChildFile);
         if (hostChildFile == null) {
             return null;
         }
 
-        // Default WASI path resolution is no-follow: reject paths that would traverse an
-        // intermediate symbolic link before reaching the final component.
-        if (usesSymlinkTraversal(virtualChildFile)) {
+        final TruffleFile hostParent = hostChildFile.getParent();
+        if (hostParent == null) {
+            // No parent component to canonicalize. This is effectively just a containment check on
+            // the path itself while still leaving the final component unresolved.
+            return preopenedRoot.containedHostFile(hostChildFile);
+        }
+        final TruffleFile canonicalParent = preopenedRoot.containedHostFile(hostParent.getCanonicalFile());
+        if (canonicalParent == null) {
+            // The parent resolves outside the preopened root, so the requested path must be
+            // rejected as an escape.
             return null;
         }
-        return hostChildFile;
+        // Canonicalize the parent chain, then reattach the unresolved final component so callers
+        // can decide whether the last path element may be followed.
+        return preopenedRoot.containedHostFile(canonicalParent.resolve(hostChildFile.getName()));
     }
 
     /**
@@ -156,42 +166,10 @@ class DirectoryFd extends Fd {
     }
 
     /**
-     * Returns {@code true} if reaching {@code virtualChildFile} from this directory fd would cross
-     * an intermediate symbolic link on the host filesystem.
-     * <p>
-     * The final path component is intentionally excluded here. Callers that care about the final
-     * component, such as {@code path_open}, perform that check separately.
-     */
-    private boolean usesSymlinkTraversal(TruffleFile virtualChildFile) throws SecurityException {
-        final TruffleFile currentHostDirectory = preopenedRoot.virtualFileToHostFile(virtualFile);
-        if (currentHostDirectory == null) {
-            return true;
-        }
-
-        final TruffleFile relativePath = virtualFile.relativize(virtualChildFile);
-
-        TruffleFile currentHostPath = currentHostDirectory;
-        final List<String> segments = new ArrayList<>();
-        for (TruffleFile path = relativePath.getParent(); path != null; path = path.getParent()) {
-            final String name = path.getName();
-            if (name != null && !name.isEmpty()) {
-                segments.add(name);
-            }
-        }
-        for (int i = segments.size() - 1; i >= 0; i--) {
-            currentHostPath = currentHostPath.resolve(segments.get(i));
-            if (currentHostPath.isSymbolicLink()) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
      * Convenience wrapper that reads a guest path from memory and resolves it using the default
      * no-follow sandboxing policy.
      */
-    private TruffleFile resolveHostFile(Node node, WasmMemory memory, int pathAddress, int pathLength) throws SecurityException {
+    private TruffleFile resolveHostFile(Node node, WasmMemory memory, int pathAddress, int pathLength) throws IOException, SecurityException {
         final TruffleFile virtualChildFile = resolveVirtualFile(node, memory, pathAddress, pathLength);
         if (virtualChildFile == null) {
             return null;

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/DirectoryFd.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/DirectoryFd.java
@@ -110,22 +110,22 @@ class DirectoryFd extends Fd {
         if (hostChildFile == null) {
             return null;
         }
+        return resolveHostFileWithCanonicalParent(hostChildFile);
+    }
 
-        final TruffleFile hostParent = hostChildFile.getParent();
-        if (hostParent == null) {
-            // No parent component to canonicalize. This is effectively just a containment check on
-            // the path itself while still leaving the final component unresolved.
-            return preopenedRoot.containedHostFile(hostChildFile);
-        }
-        final TruffleFile canonicalParent = preopenedRoot.containedHostFile(hostParent.getCanonicalFile());
-        if (canonicalParent == null) {
-            // The parent resolves outside the preopened root, so the requested path must be
-            // rejected as an escape.
-            return null;
+    /**
+     * Canonicalizes the parent chain of a host path while leaving the final component unresolved.
+     * Paths that already denote the preopened root itself are returned unchanged.
+     */
+    private TruffleFile resolveHostFileWithCanonicalParent(TruffleFile hostChildFile) throws IOException, SecurityException {
+        if (preopenedRoot.isHostRoot(hostChildFile)) {
+            // Paths like "." or "dir/.." may normalize to the preopened root itself. Treat that
+            // as an in-sandbox result instead of canonicalizing the parent one level above it.
+            return hostChildFile;
         }
         // Canonicalize the parent chain, then reattach the unresolved final component so callers
         // can decide whether the last path element may be followed.
-        return preopenedRoot.containedHostFile(canonicalParent.resolve(hostChildFile.getName()));
+        return resolveHostFileUnderCanonicalParent(hostChildFile);
     }
 
     /**
@@ -148,6 +148,14 @@ class DirectoryFd extends Fd {
             return preopenedRoot.containedHostFile(hostChildFile.getCanonicalFile());
         }
 
+        return resolveHostFileUnderCanonicalParent(hostChildFile);
+    }
+
+    /**
+     * Canonicalizes the parent chain of a host path, verifies that parent stays inside the
+     * preopened root, and then reattaches the final path segment without resolving it.
+     */
+    private TruffleFile resolveHostFileUnderCanonicalParent(TruffleFile hostChildFile) throws IOException, SecurityException {
         final TruffleFile hostParent = hostChildFile.getParent();
         if (hostParent == null) {
             // No parent component to canonicalize. This is effectively just a containment check on
@@ -160,8 +168,6 @@ class DirectoryFd extends Fd {
             // rejected as an escape.
             return null;
         }
-        // The final component does not exist yet, so canonicalize only the parent and reattach the
-        // last path segment under the verified in-sandbox parent.
         return preopenedRoot.containedHostFile(canonicalParent.resolve(hostChildFile.getName()));
     }
 

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/FdUtils.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/FdUtils.java
@@ -207,10 +207,10 @@ final class FdUtils {
         return Dirent.BYTES;
     }
 
-    static int writeSyntheticDirent(Node node, WasmMemory memory, int address, int nameLength, long offset, Filetype type) {
+    static int writeSyntheticDirent(Node node, WasmMemory memory, int address, int nameLength, long offset, long inode, Filetype type) {
         WasmMemoryLibrary memoryLib = WasmMemoryLibrary.getUncached();
         Dirent.writeDNext(node, memoryLib, memory, address, offset);
-        Dirent.writeDIno(node, memoryLib, memory, address, 0);
+        Dirent.writeDIno(node, memoryLib, memory, address, inode);
         Dirent.writeDNamlen(node, memoryLib, memory, address, nameLength);
         Dirent.writeDType(node, memoryLib, memory, address, type);
         return Dirent.BYTES;
@@ -229,10 +229,10 @@ final class FdUtils {
         return buffer;
     }
 
-    static byte[] writeSyntheticDirentToByteArray(int nameLength, long offset, Filetype type) {
+    static byte[] writeSyntheticDirentToByteArray(int nameLength, long offset, long inode, Filetype type) {
         byte[] buffer = new byte[Dirent.BYTES];
         Dirent.writeDNextToByteArray(buffer, 0, offset);
-        Dirent.writeDInoToByteArray(buffer, 0, 0);
+        Dirent.writeDInoToByteArray(buffer, 0, inode);
         Dirent.writeDNamlen(buffer, 0, nameLength);
         Dirent.writeDType(buffer, 0, type);
         return buffer;

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/FdUtils.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/FdUtils.java
@@ -56,12 +56,20 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.channels.SeekableByteChannel;
+import java.nio.file.LinkOption;
 import java.util.concurrent.TimeUnit;
 
 final class FdUtils {
 
+    static final LinkOption[] FOLLOW_LINKS = new LinkOption[0];
+    static final LinkOption[] NOFOLLOW_LINKS = new LinkOption[]{LinkOption.NOFOLLOW_LINKS};
+
     private FdUtils() {
 
+    }
+
+    static LinkOption[] linkOptions(boolean followSymlinks) {
+        return followSymlinks ? FOLLOW_LINKS : NOFOLLOW_LINKS;
     }
 
     static Errno writeToStream(Node node, WasmMemory memory, OutputStream stream, int iovecArrayAddress, int iovecCount, int sizeAddress) {
@@ -160,21 +168,21 @@ final class FdUtils {
      * "https://github.com/WebAssembly/WASI/blob/a206794fea66118945a520f6e0af3754cc51860b/phases/snapshot/docs.md#-filestat-struct"><code>filestat</code></a>
      * structure to memory.
      */
-    static Errno writeFilestat(Node node, WasmMemory memory, int address, TruffleFile file) {
+    static Errno writeFilestat(Node node, WasmMemory memory, int address, TruffleFile file, LinkOption[] linkOptions) {
         // Write filestat structure
         // https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md#-filestat-struct
         WasmMemoryLibrary memoryLib = WasmMemoryLibrary.getUncached();
         try {
-            Filestat.writeFiletype(node, memoryLib, memory, address, getType(file));
-            Filestat.writeSize(node, memoryLib, memory, address, file.getAttribute(TruffleFile.SIZE));
-            Filestat.writeAtim(node, memoryLib, memory, address, file.getAttribute(TruffleFile.LAST_ACCESS_TIME).to(TimeUnit.NANOSECONDS));
-            Filestat.writeMtim(node, memoryLib, memory, address, file.getAttribute(TruffleFile.LAST_MODIFIED_TIME).to(TimeUnit.NANOSECONDS));
+            Filestat.writeFiletype(node, memoryLib, memory, address, getType(file, linkOptions));
+            Filestat.writeSize(node, memoryLib, memory, address, file.getAttribute(TruffleFile.SIZE, linkOptions));
+            Filestat.writeAtim(node, memoryLib, memory, address, file.getAttribute(TruffleFile.LAST_ACCESS_TIME, linkOptions).to(TimeUnit.NANOSECONDS));
+            Filestat.writeMtim(node, memoryLib, memory, address, file.getAttribute(TruffleFile.LAST_MODIFIED_TIME, linkOptions).to(TimeUnit.NANOSECONDS));
 
             try {
-                Filestat.writeDev(node, memoryLib, memory, address, file.getAttribute(TruffleFile.UNIX_DEV));
-                Filestat.writeIno(node, memoryLib, memory, address, file.getAttribute(TruffleFile.UNIX_INODE));
-                Filestat.writeNlink(node, memoryLib, memory, address, file.getAttribute(TruffleFile.UNIX_NLINK));
-                Filestat.writeCtim(node, memoryLib, memory, address, file.getAttribute(TruffleFile.UNIX_CTIME).to(TimeUnit.NANOSECONDS));
+                Filestat.writeDev(node, memoryLib, memory, address, file.getAttribute(TruffleFile.UNIX_DEV, linkOptions));
+                Filestat.writeIno(node, memoryLib, memory, address, file.getAttribute(TruffleFile.UNIX_INODE, linkOptions));
+                Filestat.writeNlink(node, memoryLib, memory, address, file.getAttribute(TruffleFile.UNIX_NLINK, linkOptions));
+                Filestat.writeCtim(node, memoryLib, memory, address, file.getAttribute(TruffleFile.UNIX_CTIME, linkOptions).to(TimeUnit.NANOSECONDS));
             } catch (UnsupportedOperationException e) {
                 // GR-29297: these attributes are currently not supported on non-Unix platforms.
             }
@@ -186,7 +194,7 @@ final class FdUtils {
         return Errno.Success;
     }
 
-    static int writeDirent(Node node, WasmMemory memory, int address, TruffleFile file, int nameLength, long offset) throws IOException {
+    static int writeDirent(Node node, WasmMemory memory, int address, TruffleFile file, int nameLength, long offset, LinkOption[] linkOptions) throws IOException {
         WasmMemoryLibrary memoryLib = WasmMemoryLibrary.getUncached();
         Dirent.writeDNext(node, memoryLib, memory, address, offset);
         try {
@@ -195,11 +203,20 @@ final class FdUtils {
             // GR-29297: these attributes are currently not supported on non-Unix platforms.
         }
         Dirent.writeDNamlen(node, memoryLib, memory, address, nameLength);
-        Dirent.writeDType(node, memoryLib, memory, address, FdUtils.getType(file));
+        Dirent.writeDType(node, memoryLib, memory, address, FdUtils.getType(file, linkOptions));
         return Dirent.BYTES;
     }
 
-    static byte[] writeDirentToByteArray(TruffleFile file, int nameLength, long offset) throws IOException {
+    static int writeSyntheticDirent(Node node, WasmMemory memory, int address, int nameLength, long offset, Filetype type) {
+        WasmMemoryLibrary memoryLib = WasmMemoryLibrary.getUncached();
+        Dirent.writeDNext(node, memoryLib, memory, address, offset);
+        Dirent.writeDIno(node, memoryLib, memory, address, 0);
+        Dirent.writeDNamlen(node, memoryLib, memory, address, nameLength);
+        Dirent.writeDType(node, memoryLib, memory, address, type);
+        return Dirent.BYTES;
+    }
+
+    static byte[] writeDirentToByteArray(TruffleFile file, int nameLength, long offset, LinkOption[] linkOptions) throws IOException {
         byte[] buffer = new byte[Dirent.BYTES];
         Dirent.writeDNextToByteArray(buffer, 0, offset);
         try {
@@ -208,16 +225,29 @@ final class FdUtils {
             // GR-29297: these attributes are currently not supported on non-Unix platforms.
         }
         Dirent.writeDNamlen(buffer, 0, nameLength);
-        Dirent.writeDType(buffer, 0, FdUtils.getType(file));
+        Dirent.writeDType(buffer, 0, FdUtils.getType(file, linkOptions));
+        return buffer;
+    }
+
+    static byte[] writeSyntheticDirentToByteArray(int nameLength, long offset, Filetype type) {
+        byte[] buffer = new byte[Dirent.BYTES];
+        Dirent.writeDNextToByteArray(buffer, 0, offset);
+        Dirent.writeDInoToByteArray(buffer, 0, 0);
+        Dirent.writeDNamlen(buffer, 0, nameLength);
+        Dirent.writeDType(buffer, 0, type);
         return buffer;
     }
 
     static Filetype getType(TruffleFile file) throws IOException {
-        if (file.getAttribute(TruffleFile.IS_DIRECTORY)) {
+        return getType(file, FOLLOW_LINKS);
+    }
+
+    static Filetype getType(TruffleFile file, LinkOption[] linkOptions) throws IOException {
+        if (file.getAttribute(TruffleFile.IS_DIRECTORY, linkOptions)) {
             return Filetype.Directory;
-        } else if (file.getAttribute(TruffleFile.IS_REGULAR_FILE)) {
+        } else if (file.getAttribute(TruffleFile.IS_REGULAR_FILE, linkOptions)) {
             return Filetype.RegularFile;
-        } else if (file.getAttribute(TruffleFile.IS_SYMBOLIC_LINK)) {
+        } else if (file.getAttribute(TruffleFile.IS_SYMBOLIC_LINK, linkOptions)) {
             return Filetype.SymbolicLink;
         } else {
             return Filetype.Unknown;

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/FdUtils.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/FdUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -198,7 +198,7 @@ final class FdUtils {
         WasmMemoryLibrary memoryLib = WasmMemoryLibrary.getUncached();
         Dirent.writeDNext(node, memoryLib, memory, address, offset);
         try {
-            Dirent.writeDIno(node, memoryLib, memory, address, file.getAttribute(TruffleFile.UNIX_INODE));
+            Dirent.writeDIno(node, memoryLib, memory, address, file.getAttribute(TruffleFile.UNIX_INODE, linkOptions));
         } catch (UnsupportedOperationException e) {
             // GR-29297: these attributes are currently not supported on non-Unix platforms.
         }
@@ -220,7 +220,7 @@ final class FdUtils {
         byte[] buffer = new byte[Dirent.BYTES];
         Dirent.writeDNextToByteArray(buffer, 0, offset);
         try {
-            Dirent.writeDInoToByteArray(buffer, 0, file.getAttribute(TruffleFile.UNIX_INODE));
+            Dirent.writeDInoToByteArray(buffer, 0, file.getAttribute(TruffleFile.UNIX_INODE, linkOptions));
         } catch (UnsupportedOperationException e) {
             // GR-29297: these attributes are currently not supported on non-Unix platforms.
         }

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/FileFd.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/FileFd.java
@@ -55,6 +55,7 @@ import org.graalvm.wasm.predefined.wasi.types.Rights;
 
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.LinkOption;
 import java.nio.file.OpenOption;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.FileAttribute;
@@ -78,6 +79,7 @@ class FileFd extends SeekableByteChannelFd {
 
     private final TruffleFile file;
     private final short oflags;
+    private final boolean followSymlinks;
 
     /**
      * @throws FileAlreadyExistsException if {@link StandardOpenOption#CREATE_NEW} option is set and
@@ -89,13 +91,14 @@ class FileFd extends SeekableByteChannelFd {
      * @throws SecurityException if the {@link FileSystem} denied the operation
      * @see TruffleFile#newByteChannel(Set, FileAttribute[])
      */
-    FileFd(TruffleFile file, short oflags, long fsRightsBase, long fsRightsInheriting, short fdFlags) throws IOException {
-        super(file.newByteChannel(parseOptions(oflags, fdFlags)), Filetype.RegularFile, fsRightsBase, fsRightsInheriting, fdFlags);
+    FileFd(TruffleFile file, short oflags, long fsRightsBase, long fsRightsInheriting, short fdFlags, boolean followSymlinks) throws IOException {
+        super(file.newByteChannel(parseOptions(oflags, fdFlags, followSymlinks)), Filetype.RegularFile, fsRightsBase, fsRightsInheriting, fdFlags);
         this.file = file;
         this.oflags = oflags;
+        this.followSymlinks = followSymlinks;
     }
 
-    private static Set<? extends OpenOption> parseOptions(short oflags, short fdFlags) {
+    private static Set<? extends OpenOption> parseOptions(short oflags, short fdFlags, boolean followSymlinks) {
         final Set<OpenOption> openOptions = new LinkedHashSet<>();
 
         // In WASI, the file access mode (read vs. write) is not specified when opening a file.
@@ -103,6 +106,9 @@ class FileFd extends SeekableByteChannelFd {
         // reading and writing.
         openOptions.add(StandardOpenOption.READ);
         openOptions.add(StandardOpenOption.WRITE);
+        if (!followSymlinks) {
+            openOptions.add(LinkOption.NOFOLLOW_LINKS);
+        }
         if (isSet(oflags, Oflags.Creat)) {
             openOptions.add(StandardOpenOption.CREATE);
         }
@@ -166,7 +172,7 @@ class FileFd extends SeekableByteChannelFd {
         try {
             close();
             fdFlags = newFsflags;
-            setChannel(file.newByteChannel(parseOptions(oflags, newFsflags)));
+            setChannel(file.newByteChannel(parseOptions(oflags, newFsflags, followSymlinks)));
             return Errno.Success;
         } catch (IOException e) {
             return Errno.Io;

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/FileFd.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/FileFd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -81,6 +81,10 @@ class FileFd extends SeekableByteChannelFd {
     private final short oflags;
     private final boolean followSymlinks;
 
+    private LinkOption[] linkOptions() {
+        return FdUtils.linkOptions(followSymlinks);
+    }
+
     /**
      * @throws FileAlreadyExistsException if {@link StandardOpenOption#CREATE_NEW} option is set and
      *             a file already exists on given path
@@ -161,7 +165,7 @@ class FileFd extends SeekableByteChannelFd {
         if (!isSet(fsRightsBase, Rights.FdFilestatGet)) {
             return Errno.Notcapable;
         }
-        return FdUtils.writeFilestat(node, memory, resultAddress, file);
+        return FdUtils.writeFilestat(node, memory, resultAddress, file, linkOptions());
     }
 
     @Override
@@ -232,16 +236,16 @@ class FileFd extends SeekableByteChannelFd {
         }
         try {
             if (isSet(fstFlags, Fstflags.Atim)) {
-                file.setLastAccessTime(FileTime.from(atim, TimeUnit.NANOSECONDS));
+                file.setLastAccessTime(FileTime.from(atim, TimeUnit.NANOSECONDS), linkOptions());
             }
             if (isSet(fstFlags, Fstflags.AtimNow)) {
-                file.setLastAccessTime(FileTime.from(WasiClockTimeGetNode.realtimeNow(), TimeUnit.NANOSECONDS));
+                file.setLastAccessTime(FileTime.from(WasiClockTimeGetNode.realtimeNow(), TimeUnit.NANOSECONDS), linkOptions());
             }
             if (isSet(fstFlags, Fstflags.Mtim)) {
-                file.setLastModifiedTime(FileTime.from(mtim, TimeUnit.NANOSECONDS));
+                file.setLastModifiedTime(FileTime.from(mtim, TimeUnit.NANOSECONDS), linkOptions());
             }
             if (isSet(fstFlags, Fstflags.MtimNow)) {
-                file.setLastModifiedTime(FileTime.from(WasiClockTimeGetNode.realtimeNow(), TimeUnit.NANOSECONDS));
+                file.setLastModifiedTime(FileTime.from(WasiClockTimeGetNode.realtimeNow(), TimeUnit.NANOSECONDS), linkOptions());
             }
         } catch (IOException e) {
             return Errno.Io;

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/PreopenedDirectory.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/PreopenedDirectory.java
@@ -136,6 +136,14 @@ final class PreopenedDirectory {
     }
 
     /**
+     * Returns whether the given host file denotes the pre-opened directory itself.
+     */
+    boolean isHostRoot(TruffleFile hostFile) {
+        Objects.requireNonNull(hostFile);
+        return hostPath.equals(hostFile.normalize());
+    }
+
+    /**
      * Returns the normalized host file for the given virtual file if it is contained in this
      * pre-opened directory, or {@code null} otherwise.
      */


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/13419

**Conflicts:**

- no conflicts
 
<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk25u/issues/118