### PR TITLE
[Backport] [Oracle GraalVM] [GR-75978] [GR-75981] [GR-75956] [GR-75960] [GR-75963] [GR-75966] [GR-75969] [GR-75972] [GR-75975] [GR-75984] [GR-75987] Backport to 25.0: CompactingOldGen improvements and Adaptive2 policy.

### DIFF
--- a/sdk/mx.sdk/mx_sdk_benchmark.py
+++ b/sdk/mx.sdk/mx_sdk_benchmark.py
@@ -387,8 +387,8 @@ class NativeImageBenchmarkConfig:
             base_image_build_args += ['-H:+UseStringInlining']
         if vm.use_open_type_world:
             base_image_build_args += ['-H:-ClosedTypeWorld']
-        if vm.use_compacting_gc:
-            base_image_build_args += ['-H:+CompactingOldGen']
+        if vm.copyingoldgen_oldpolicy: # for later removal: GR-73132
+            base_image_build_args += ['-H:-CompactingOldGen','-H:InitialCollectionPolicy=Adaptive']
         if vm.is_llvm:
             base_image_build_args += ['--features=org.graalvm.home.HomeFinderFeature'] + ['-H:CompilerBackend=llvm',
                                                                                           '-H:DeadlockWatchdogInterval=0']
@@ -728,7 +728,7 @@ class NativeImageVM(GraalVm):
         self.future_defaults_all = False
         self.use_upx = False
         self.use_open_type_world = False
-        self.use_compacting_gc = False
+        self.copyingoldgen_oldpolicy = False # for later removal: GR-73132
         self.graalvm_edition = None
         self.config: Optional[NativeImageBenchmarkConfig] = None
         self.stages_info: Optional[StagesInfo] = None
@@ -768,8 +768,8 @@ class NativeImageVM(GraalVm):
             config += ["string-inlining"]
         if self.use_open_type_world is True:
             config += ["otw"]
-        if self.use_compacting_gc is True:
-            config += ["compacting-gc"]
+        if self.copyingoldgen_oldpolicy is True: # for later removal: GR-73132
+            config += ["copyingoldgen-oldpolicy"]
         if self.preserve_all is True:
             config += ["preserve-all"]
         if self.preserve_classpath is True:
@@ -846,7 +846,7 @@ class NativeImageVM(GraalVm):
 
         # This defines the allowed config names for NativeImageVM. The ones registered will be available via --jvm-config
         # Note: the order of entries here must match the order of statements in NativeImageVM.config_name()
-        rule = r'^(?P<native_architecture>native-architecture-)?(?P<string_inlining>string-inlining-)?(?P<otw>otw-)?(?P<compacting_gc>compacting-gc-)?(?P<preserve_all>preserve-all-)?(?P<preserve_classpath>preserve-classpath-)?' \
+        rule = r'^(?P<native_architecture>native-architecture-)?(?P<string_inlining>string-inlining-)?(?P<otw>otw-)?(?P<copyingoldgen_oldpolicy>copyingoldgen-oldpolicy-)?(?P<preserve_all>preserve-all-)?(?P<preserve_classpath>preserve-classpath-)?' \
                r'(?P<future_defaults_all>future-defaults-all-)?(?P<gate>gate-)?(?P<upx>upx-)?(?P<quickbuild>quickbuild-)?(?P<layered>layered-)?(?P<graalos>graalos-)?(?P<gc>g1gc-)?' \
                r'(?P<llvm>llvm-)?(?P<pgo>pgo-|pgo-sampler-)?(?P<inliner>inline-)?' \
                r'(?P<analysis_context_sensitivity>insens-|allocsens-|1obj-|2obj1h-|3obj2h-|4obj3h-)?(?P<jdk_profiles>jdk-profiles-collect-|adopted-jdk-pgo-)?' \
@@ -890,9 +890,9 @@ class NativeImageVM(GraalVm):
             mx.logv(f"'otw' is enabled for {config_name}")
             self.use_open_type_world = True
 
-        if matching.group("compacting_gc") is not None:
-            mx.logv(f"'compacting-gc' is enabled for {config_name}")
-            self.use_compacting_gc = True
+        if matching.group("copyingoldgen_oldpolicy") is not None: # for later removal (including above): GR-73132
+            mx.logv(f"'copyingoldgen_oldpolicy' is enabled for {config_name}")
+            self.copyingoldgen_oldpolicy = True
 
         if matching.group("quickbuild") is not None:
             mx.logv(f"'quickbuild' is enabled for {config_name}")

--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/StackValue.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/StackValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -72,7 +72,7 @@ public final class StackValue {
      * <pre>
      * ComplexValue numberOnStack = StackValue.get(ComplexValue.class);
      * numberOnStack.realPart(3.0);
-     * numberOnStack.imagineryPart(4.0);
+     * numberOnStack.imaginaryPart(4.0);
      * double absoluteValue = absoluteValue(numberOnStack);
      * assert 5.0 == absoluteValue;
      * </pre>

--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/c/struct/CStruct.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/c/struct/CStruct.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -67,10 +67,10 @@ import org.graalvm.word.PointerBase;
  *     void realPart(double re);
  *
  *     &#64;CField("im")
- *     double imagineryPart();
+ *     double imaginaryPart();
  *
  *     &#64;CField("im")
- *     void imagineryPart(double im);
+ *     void imaginaryPart(double im);
  * }
  * </pre>
  *

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AbstractCollectionPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AbstractCollectionPolicy.java
@@ -294,10 +294,7 @@ abstract class AbstractCollectionPolicy implements CollectionPolicy {
     @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25+21/src/hotspot/share/gc/parallel/psYoungGen.cpp#L104-L116")
     @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25+21/src/hotspot/share/gc/parallel/psYoungGen.cpp#L146-L168")
     private void computeSizeParameters(RawSizeParameters newParamsOnStack) {
-        UnsignedWord minYoungSpaces = minSpaceSize(); // eden
-        if (HeapParameters.getMaxSurvivorSpaces() > 0) {
-            minYoungSpaces = minYoungSpaces.add(minSpaceSize().multiply(2)); // survivor from and to
-        }
+        UnsignedWord minYoungSpaces = getMinYoungSpacesSize();
         UnsignedWord minAllSpaces = minYoungSpaces.add(minSpaceSize()); // old
         UnsignedWord heapSizeLimit = UnsignedUtils.max(alignDown(getHeapSizeLimit()), minAllSpaces);
 
@@ -405,6 +402,14 @@ abstract class AbstractCollectionPolicy implements CollectionPolicy {
                         promoSize,
                         initialYoung, youngSize, maxYoung,
                         minHeap, initialHeap, heapSize, maxHeap);
+    }
+
+    protected static UnsignedWord getMinYoungSpacesSize() {
+        UnsignedWord minYoung = minSpaceSize(); // eden
+        if (HeapParameters.getMaxSurvivorSpaces() > 0) {
+            minYoung = minYoung.add(minSpaceSize().multiply(2)); // survivor from and to
+        }
+        return minYoung;
     }
 
     /** The initial sizes only change when a relevant GC-specific option value is modified. */

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AbstractCollectionPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AbstractCollectionPolicy.java
@@ -272,7 +272,7 @@ abstract class AbstractCollectionPolicy implements CollectionPolicy {
     }
 
     @Override
-    public void onCollectionBegin(boolean completeCollection, long requestingNanoTime) {
+    public void onCollectionBegin(boolean completeCollection, long beginNanoTime) {
         sizes.freeUnusedSizeParameters();
 
         // Capture the fraction of bytes in aligned chunks at the start to include all allocated

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AdaptiveCollectionPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AdaptiveCollectionPolicy.java
@@ -163,10 +163,13 @@ class AdaptiveCollectionPolicy extends AbstractCollectionPolicy {
     }
 
     @Override
-    public boolean shouldCollectCompletely(boolean followingIncrementalCollection) { // should_attempt_scavenge
+    public boolean shouldCollectCompletely(boolean followingIncrementalCollection, boolean forcedCompleteCollection) { // should_attempt_scavenge
         guaranteeSizeParametersInitialized();
 
         boolean collectYoungSeparately = shouldCollectYoungGenSeparately(!SerialGCOptions.useCompactingOldGen());
+        if (forcedCompleteCollection && !collectYoungSeparately) {
+            return true;
+        }
         if (!followingIncrementalCollection && collectYoungSeparately) {
             /*
              * With a copying collector, default to always doing an incremental collection first

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AdaptiveCollectionPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AdaptiveCollectionPolicy.java
@@ -28,6 +28,7 @@ import static com.oracle.svm.core.genscavenge.CollectionPolicy.shouldCollectYoun
 
 import org.graalvm.word.UnsignedWord;
 
+import com.oracle.svm.core.Isolates;
 import com.oracle.svm.core.heap.GCCause;
 import com.oracle.svm.core.thread.VMOperation;
 import com.oracle.svm.core.util.BasedOnJDKFile;
@@ -360,6 +361,10 @@ class AdaptiveCollectionPolicy extends AbstractCollectionPolicy {
         double decayedMajorGcCost = majorGcCost();
         double avgMajorInterval = avgMajorIntervalSeconds.getAverage();
         if (USE_ADAPTIVE_SIZE_DECAY_MAJOR_GC_COST && ADAPTIVE_SIZE_MAJOR_GC_DECAY_TIME_SCALE > 0 && avgMajorInterval > 0) {
+            /*
+             * This seems pointless or flawed for major GCs because this method is called at the end
+             * when majorTimer has only just been restarted.
+             */
             double secondsSinceMajor = secondsSinceMajorGc();
             if (secondsSinceMajor > 0 && secondsSinceMajor > ADAPTIVE_SIZE_MAJOR_GC_DECAY_TIME_SCALE * avgMajorInterval) {
                 double decayed = decayedMajorGcCost * (ADAPTIVE_SIZE_MAJOR_GC_DECAY_TIME_SCALE * avgMajorInterval) / secondsSinceMajor;
@@ -397,24 +402,31 @@ class AdaptiveCollectionPolicy extends AbstractCollectionPolicy {
         return curSize.unsignedDivide(100).multiply(percentChange);
     }
 
+    /**
+     * Should not be called during a major collection itself because then, {@link #majorTimer} is
+     * repurposed to measure collection time (rather than time between collections).
+     */
     private double secondsSinceMajorGc() { // time_since_major_gc
-        return TimeUtils.nanosToSecondsDouble(System.nanoTime() - majorTimer.startedNanos());
+        return TimeUtils.nanosToSecondsDouble(System.nanoTime() - majorTimer.lastStartedNanoTime());
     }
 
     @Override
-    public void onCollectionBegin(boolean completeCollection, long requestingNanoTime) { // {major,minor}_collection_begin
+    public void onCollectionBegin(boolean completeCollection, long beginNanoTime) { // {major,minor}_collection_begin
         Timer timer = completeCollection ? majorTimer : minorTimer;
-        timer.stopAt(requestingNanoTime);
+        if (!timer.wasStartedAtLeastOnce()) {
+            long origin = Isolates.isStartTimeAssigned() ? Isolates.getStartTimeNanos() : beginNanoTime;
+            timer.startAt(origin);
+        }
+        timer.stopAt(beginNanoTime);
         if (completeCollection) {
-            latestMajorMutatorIntervalNanos = timer.totalNanos();
+            latestMajorMutatorIntervalNanos = timer.lastIntervalNanos();
         } else {
-            latestMinorMutatorIntervalNanos = timer.totalNanos();
+            latestMinorMutatorIntervalNanos = timer.lastIntervalNanos();
         }
 
-        timer.reset();
         timer.start(); // measure collection pause
 
-        super.onCollectionBegin(completeCollection, requestingNanoTime);
+        super.onCollectionBegin(completeCollection, beginNanoTime);
     }
 
     @Override
@@ -424,13 +436,13 @@ class AdaptiveCollectionPolicy extends AbstractCollectionPolicy {
 
         if (completeCollection) {
             updateCollectionEndAverages(avgMajorGcCost, avgMajorPause, majorCostEstimator, avgMajorIntervalSeconds,
-                            cause, latestMajorMutatorIntervalNanos, timer.totalNanos(), sizes.getPromoSize());
+                            cause, latestMajorMutatorIntervalNanos, timer.lastIntervalNanos(), sizes.getPromoSize());
             majorCount++;
             minorCountSinceMajorCollection = 0;
 
         } else {
             updateCollectionEndAverages(avgMinorGcCost, avgMinorPause, minorCostEstimator, null,
-                            cause, latestMinorMutatorIntervalNanos, timer.totalNanos(), sizes.getEdenSize());
+                            cause, latestMinorMutatorIntervalNanos, timer.lastIntervalNanos(), sizes.getEdenSize());
             minorCount++;
             minorCountSinceMajorCollection++;
 

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AdaptiveCollectionPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AdaptiveCollectionPolicy.java
@@ -133,7 +133,7 @@ class AdaptiveCollectionPolicy extends AbstractCollectionPolicy {
     private final AdaptivePaddedAverage avgMinorPause = new AdaptivePaddedAverage(ADAPTIVE_TIME_WEIGHT, PAUSE_PADDING);
     private final AdaptivePaddedAverage avgSurvived = new AdaptivePaddedAverage(ADAPTIVE_SIZE_POLICY_WEIGHT, SURVIVOR_PADDING);
     private final AdaptivePaddedAverage avgPromoted = new AdaptivePaddedAverage(ADAPTIVE_SIZE_POLICY_WEIGHT, PROMOTED_PADDING, true);
-    private final ReciprocalLeastSquareFit minorCostEstimator = new ReciprocalLeastSquareFit(ADAPTIVE_SIZE_COST_ESTIMATORS_HISTORY_LENGTH);
+    private final ReciprocalLeastSquareFit minorCostEstimator = ReciprocalLeastSquareFit.createWithEffectiveHistoryLength(ADAPTIVE_SIZE_COST_ESTIMATORS_HISTORY_LENGTH);
     private long minorCount;
     private long latestMinorMutatorIntervalNanos;
     private boolean youngGenPolicyIsReady;
@@ -146,7 +146,7 @@ class AdaptiveCollectionPolicy extends AbstractCollectionPolicy {
     private final AdaptivePaddedAverage avgMajorPause = new AdaptivePaddedAverage(ADAPTIVE_TIME_WEIGHT, PAUSE_PADDING);
     private final AdaptiveWeightedAverage avgMajorIntervalSeconds = new AdaptiveWeightedAverage(ADAPTIVE_TIME_WEIGHT);
     private final AdaptiveWeightedAverage avgOldLive = new AdaptiveWeightedAverage(ADAPTIVE_SIZE_POLICY_WEIGHT);
-    private final ReciprocalLeastSquareFit majorCostEstimator = new ReciprocalLeastSquareFit(ADAPTIVE_SIZE_COST_ESTIMATORS_HISTORY_LENGTH);
+    private final ReciprocalLeastSquareFit majorCostEstimator = ReciprocalLeastSquareFit.createWithEffectiveHistoryLength(ADAPTIVE_SIZE_COST_ESTIMATORS_HISTORY_LENGTH);
     private long majorCount;
     private UnsignedWord oldGenSizeIncrementSupplement = Word.unsigned(TENURED_GENERATION_SIZE_SUPPLEMENT);
     private long latestMajorMutatorIntervalNanos;
@@ -181,10 +181,14 @@ class AdaptiveCollectionPolicy extends AbstractCollectionPolicy {
         }
         if (followingIncrementalCollection && oldSizeExceededInPreviousCollection) {
             /*
-             * In the preceding incremental collection, we promoted objects to the old generation
-             * beyond its current capacity to avoid a promotion failure, but due to the chunked
-             * nature of our heap, we should still be within the maximum heap size. Follow up with a
-             * full collection during which we reclaim enough space or expand the old generation.
+             * In the preceding incremental collection, to avoid a promotion failure, we promoted
+             * objects to the old generation beyond its current capacity. We might have temporarily
+             * exceeded the maximum heap size, but due to the chunked nature of our heap, should
+             * currently be within limits.
+             *
+             * Follow up with a full collection during which we reclaim enough space or expand the
+             * old generation. However, when tenuring all objects, we might exceed the old
+             * generation's maximum size and potentially later maximum heap size (GR-72932).
              */
             return true;
         }
@@ -258,9 +262,10 @@ class AdaptiveCollectionPolicy extends AbstractCollectionPolicy {
         sizes.setSurvivorSize(targetSize);
 
         if (decrTenuringThreshold) {
-            tenuringThreshold = Math.max(tenuringThreshold - 1, 1);
+            // Note: we allow 0 to promote from eden to the old gen, but the original code uses >=1.
+            tenuringThreshold = Math.max(tenuringThreshold - 1, 0);
         } else if (incrTenuringThreshold) {
-            tenuringThreshold = Math.min(tenuringThreshold + 1, HeapParameters.getMaxSurvivorSpaces() + 1);
+            tenuringThreshold = Math.min(tenuringThreshold + 1, HeapParameters.getMaxSurvivorSpaces());
         }
     }
 
@@ -319,6 +324,13 @@ class AdaptiveCollectionPolicy extends AbstractCollectionPolicy {
         if (deltax == 0 || totalSize == 0) { // division by zero below
             return true; // general assumption for space expansion
         }
+
+        /*
+         * Note: prior to using the estimator, we should check whether its current model is
+         * plausible (e.g., increasing size results in strictly decreasing predicted cost, and
+         * predicted costs are non-negative), and fall back to a conservative behavior if not.
+         */
+
         double y0 = estimator.estimate(x0) + otherCost;
         double y1 = y0 * (1 - deltax / totalSize * ADAPTIVE_SIZE_ESTIMATOR_MIN_TOTAL_SIZE_COST_TRADEOFF);
         double minSlope = (y1 - y0) / deltax;
@@ -432,8 +444,10 @@ class AdaptiveCollectionPolicy extends AbstractCollectionPolicy {
         super.onCollectionBegin(completeCollection, beginNanoTime);
     }
 
+    // PSParallelCompact::invoke_no_policy + major_collection_end
+    // or PSScavenge::invoke + minor_collection_end
     @Override
-    public void onCollectionEnd(boolean completeCollection, GCCause cause) { // {major,minor}_collection_end
+    public void onCollectionEnd(boolean completeCollection, GCCause cause) {
         Timer timer = completeCollection ? majorTimer : minorTimer;
         timer.stop();
 
@@ -601,6 +615,7 @@ class AdaptiveCollectionPolicy extends AbstractCollectionPolicy {
                     intervalSeconds.sample(intervalInSeconds);
                 }
             }
+            // Note: we should probably discard the sample if an interval is 0 or negative above.
             costEstimator.sample(UnsignedUtils.toDouble(sizeBytes), cost);
         }
     }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AdaptiveCollectionPolicy2.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AdaptiveCollectionPolicy2.java
@@ -1,0 +1,809 @@
+/*
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.genscavenge;
+
+import static com.oracle.svm.core.genscavenge.AdaptiveCollectionPolicy2Tunables.NUM_OF_GC_SAMPLE;
+
+import org.graalvm.word.UnsignedWord;
+import org.graalvm.word.impl.Word;
+
+import com.oracle.svm.core.Isolates;
+import com.oracle.svm.core.heap.GCCause;
+import com.oracle.svm.core.util.BasedOnJDKFile;
+import com.oracle.svm.core.util.TimeUtils;
+import com.oracle.svm.core.util.Timer;
+import com.oracle.svm.core.util.UnsignedUtils;
+
+/** Constants for policy tunables. */
+interface AdaptiveCollectionPolicy2Tunables {
+
+    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/shared/gc_globals.hpp#L489-L493") //
+    int INITIAL_NEW_RATIO = 2; // HotSpot: NewRatio
+
+    /*
+     *
+     * The following are -XX options in HotSpot, refer to their descriptions for details. The values
+     * are HotSpot defaults unless labeled otherwise.
+     *
+     * Don't change these values individually without carefully going over their occurrences in
+     * HotSpot source code, there are dependencies between them that are not handled in our code.
+     *
+     */
+
+    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/shared/gc_globals.hpp#L308-L353") //
+    int ADAPTIVE_SIZE_POLICY_READY_THRESHOLD = 5;
+    int ADAPTIVE_SIZE_POLICY_WEIGHT = 10;
+    int PROMOTED_PADDING = 3;
+    int THRESHOLD_TOLERANCE = 10;
+    int YOUNG_GENERATION_SIZE_INCREMENT = 20;
+    int YOUNG_GENERATION_SIZE_SUPPLEMENT = 80;
+    int YOUNG_GENERATION_SIZE_SUPPLEMENT_DECAY = 8;
+    double MAX_GC_PAUSE_MILLIS = UnsignedUtils.toDouble(UnsignedUtils.MAX_VALUE.subtract(1));
+    int GC_TIME_RATIO = 99;
+    int ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR = 4;
+    /**
+     * The tenuring threshold at startup (HotSpot default: 7). The policy intentionally never
+     * reduces the tenuring threshold, so this is also its minimum value.
+     */
+    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/shared/gc_globals.hpp#L512-L517") //
+    int INITIAL_TENURING_THRESHOLD = 7;
+
+    /*
+     * We don't want to limit our freedom to adjust the heap. (Unless set explicitly, these options
+     * are set to these values in ParallelArguments::initialize on HotSpot)
+     */
+    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/parallel/parallelArguments.cpp#L57-L68") //
+    int MIN_HEAP_FREE_RATIO = 0; // %
+    int MAX_HEAP_FREE_RATIO = 100; // %
+    /** On HotSpot, this is the behavior if {@link #MIN_HEAP_FREE_RATIO} is not set explicitly. */
+    boolean SHRINK_OLD_CAUTIOUSLY = true;
+
+    /*
+     *
+     * Constants in class AdaptiveSizePolicy.
+     *
+     */
+
+    /** [0, 1]; closer to 1 means assigning more weight to most recent samples. */
+    double SEQ_DEFAULT_ALPHA_VALUE = 0.75;
+
+    /**
+     * Minimal distance between two consecutive GC pauses; shorter distance (more frequent gc) can
+     * hinder app throughput. Additionally, too frequent gc means objs haven't got time to die yet,
+     * so the number of promoted objs will be high. Default: 100ms.
+     */
+    double MIN_GC_DISTANCE_SECOND = 0.100;
+
+    int NUM_OF_GC_SAMPLE = 32;
+}
+
+/**
+ * A garbage collection policy that balances throughput and memory footprint (and optionally pause
+ * times, which we currently don't consider).
+ * <p>
+ * Most importantly, it tries to ensure a minimum throughput ({@link #GC_TIME_RATIO}) and a minimum
+ * time between collections ({@link #MIN_GC_DISTANCE_SECOND}) by expanding or shrinking eden in
+ * {@link #computeDesiredEdenSize}.
+ * <p>
+ * The policy triggers complete collections when an incremental collection promotes objects beyond
+ * the old generation's capacity, or the next incremental collection is predicted to exceed the
+ * maximum old generation size, see {@link #shouldCollectCompletely}.
+ * <p>
+ * The policy increases the tenuring threshold (incremental collections before promoting an object
+ * to the old generation) to favor incremental collections when spending most time on complete
+ * collections, see {@link #computeTenuringThreshold}. It never decreases the tenuring threshold.
+ * <p>
+ * Most of this code is based on HotSpot's ParallelGC adaptive size policy. Unless otherwise stated,
+ * code in this class has been adapted from HotSpot class {@code PSAdaptiveSizePolicy}. Names have
+ * been kept mostly the same for comparability.
+ */
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.hpp")
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp")
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/parallel/psScavenge.cpp#L311-L508")
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/parallel/psParallelCompact.cpp#L934-L1055")
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/parallel/psYoungGen.cpp#L325-L423")
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp#L824-L916")
+class AdaptiveCollectionPolicy2 extends AdaptiveCollectionPolicy2Base {
+
+    private final AdaptivePaddedAverage avgPromoted = new AdaptivePaddedAverage(ADAPTIVE_SIZE_POLICY_WEIGHT, PROMOTED_PADDING, true);
+
+    private boolean oldSizeExceededInPreviousCollection = false;
+
+    /**
+     * To facilitate faster growth at start up, supplement the normal growth percentage for the
+     * young gen eden and the old gen space for promotion with this value, which decays with
+     * increasing collections.
+     */
+    private int youngGenSizeIncrementSupplement = YOUNG_GENERATION_SIZE_SUPPLEMENT;
+
+    private long majorCount = 0;
+
+    AdaptiveCollectionPolicy2() {
+        super(MAX_GC_PAUSE_MILLIS / 1000.0);
+    }
+
+    @Override
+    public String getName() {
+        return "adaptive2";
+    }
+
+    @Override
+    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp#L372-L421")
+    public boolean shouldCollectCompletely(boolean followingIncrementalCollection, boolean forcedCompleteCollection) { // ParallelScavengeHeap::should_attempt_young_gc
+        guaranteeSizeParametersInitialized();
+
+        boolean collectYoungSeparately = CollectionPolicy.shouldCollectYoungGenSeparately(!SerialGCOptions.useCompactingOldGen());
+        if (forcedCompleteCollection && !collectYoungSeparately) {
+            return true;
+        }
+        if (!followingIncrementalCollection && collectYoungSeparately) {
+            /*
+             * With a copying collector, default to always doing an incremental collection first
+             * because we expect most of the objects in the young generation to be garbage, and we
+             * can reuse their leftover chunks for copying the live objects in the old generation
+             * with fewer allocations.
+             *
+             * With a compacting collector, complete collections are more expensive, but first doing
+             * an incremental collection if the young generation makes up a significant part of the
+             * heap wasn't found to be beneficial.
+             */
+            return false;
+        }
+        if (followingIncrementalCollection && oldSizeExceededInPreviousCollection) {
+            /*
+             * In the preceding incremental collection, to avoid a promotion failure, we promoted
+             * objects to the old generation beyond its current capacity. We might have temporarily
+             * exceeded the maximum heap size, but due to the chunked nature of our heap, should
+             * currently be within limits.
+             *
+             * Follow up with a full collection during which we reclaim enough space or expand the
+             * old generation. However, when tenuring all objects, we might exceed the old
+             * generation's maximum size and potentially later maximum heap size (GR-72932).
+             */
+            return true;
+        }
+
+        if (!collectYoungSeparately && followingIncrementalCollection) {
+            // Don't override the earlier decision to not do a full GC below (and prolong the pause)
+            return false;
+        }
+
+        UnsignedWord youngUsed = HeapImpl.getHeapImpl().getYoungGeneration().getChunkBytes();
+        UnsignedWord oldUsed = HeapImpl.getHeapImpl().getOldGeneration().getChunkBytes();
+
+        /*
+         * If the remaining free space in the old generation is less than what is expected to be
+         * needed by the next collection, do a full collection now.
+         */
+        UnsignedWord averagePromoted = UnsignedUtils.fromDouble(avgPromoted.getPaddedAverage());
+        UnsignedWord promotionEstimate = UnsignedUtils.min(averagePromoted, youngUsed);
+        UnsignedWord freeInOldGenWithExpansion = sizes.getMaxOldSize().subtract(oldUsed);
+        /*
+         * Note that ParallelScavengeHeap also considers if the OS has enough free memory ready to
+         * commit and expand old gen for promotions, and if not, does a full GC. This is to avoid
+         * inflating minor GC pause times, and as a result, inaccurately resizing the young gen.
+         */
+        return promotionEstimate.aboveOrEqual(freeInOldGenWithExpansion);
+    }
+
+    /** First part of PSScavenge::invoke and PSParallelCompact::invoke. */
+    @Override
+    public void onCollectionBegin(boolean completeCollection, long beginNanoTime) {
+        incrementTotalCollections(completeCollection);
+        if (completeCollection) {
+            majorCollectionBegin(beginNanoTime);
+        } else {
+            minorCollectionBegin(beginNanoTime);
+        }
+
+        super.onCollectionBegin(completeCollection, beginNanoTime);
+    }
+
+    void incrementTotalCollections(boolean full) { // CollectedHeap::increment_total_collections
+        if (full) {
+            majorCount++;
+        } else {
+            minorCount++;
+        }
+    }
+
+    /** Second part of PSScavenge::invoke and PSParallelCompact::invoke. */
+    @Override
+    public void onCollectionEnd(boolean completeCollection, GCCause cause) {
+        GCAccounting acc = GCImpl.getAccounting();
+        UnsignedWord oldLive = acc.getOldGenerationAfterChunkBytes();
+        if (completeCollection) {
+            majorCollectionEnd();
+            UnsignedWord oldUsed = UnsignedUtils.max(acc.getOldGenerationBeforeChunkBytes(), acc.getOldGenerationAfterChunkBytes());
+            sampleOldGenUsedBytes(oldUsed);
+            resizeAfterFullGC(oldLive);
+        } else {
+            minorCollectionEnd(sizes.getEdenSize());
+
+            /*
+             * We technically don't have promotion failures in which case the HotSpot policy doesn't
+             * do some of what is below. We can exceed the current capacity of the old generation
+             * during a young collection however, and trigger a full collection straight after.
+             */
+            oldSizeExceededInPreviousCollection = oldLive.aboveThan(sizes.getOldSize());
+
+            boolean survivorOverflow = acc.hasLastIncrementalCollectionOverflowedSurvivors();
+            UnsignedWord survived = HeapImpl.getHeapImpl().getYoungGeneration().getSurvivorChunkBytes();
+            UnsignedWord promoted = acc.getLastIncrementalCollectionPromotedChunkBytes();
+            updateAverages(survivorOverflow, UnsignedUtils.toDouble(survived), UnsignedUtils.toDouble(promoted));
+            sampleOldGenUsedBytes(acc.getOldGenerationAfterChunkBytes());
+
+            tenuringThreshold = computeTenuringThreshold(survivorOverflow, tenuringThreshold);
+
+            resizeAfterYoungGC(survivorOverflow, oldLive, survived);
+
+            decaySupplementalGrowth(minorCount);
+        }
+
+        recordGcPauseEndInstant();
+    }
+
+    private void resizeAfterFullGC(UnsignedWord oldLive) { // ParallelScavengeHeap::resize_after_full_gc
+        resizeOldGenAfterFullGC(oldLive);
+        /*
+         * We don't resize young-gen after full-gc because eden-size directly affects young-gc
+         * frequency (GC_TIME_RATIO), and we don't have enough info to determine its desired size.
+         */
+    }
+
+    private UnsignedWord calculateDesiredOldGenCapacity(UnsignedWord oldGenLiveSize) { // ParallelScavengeHeap::calculate_desired_old_gen_capacity
+        // If min free percent is 100%, the old-gen should always be at its max capacity.
+        int minHeapFreeRatio = MIN_HEAP_FREE_RATIO; // (avoids ecj warnings)
+        if (minHeapFreeRatio == 100) {
+            return sizes.getMaxOldSize();
+        }
+
+        // Using recorded data to calculate the new capacity of old-gen to avoid
+        // excessive expansion but also keep footprint low
+
+        UnsignedWord promotedEstimate = paddedAveragePromotedInBytes();
+
+        // Should have at least this free room for the next young-gc promotion.
+        UnsignedWord freeSize = promotedEstimate;
+
+        UnsignedWord largestLiveSize = UnsignedUtils.max(oldGenLiveSize, UnsignedUtils.fromDouble(peakOldGenUsedEstimate()));
+        freeSize = freeSize.add(largestLiveSize.subtract(oldGenLiveSize));
+
+        // Respect free percent
+        if (minHeapFreeRatio != 0) {
+            UnsignedWord minFree = calculateFreeFromFreeRatioFlag(oldGenLiveSize, minHeapFreeRatio);
+            freeSize = UnsignedUtils.max(freeSize, minFree);
+        }
+
+        int maxHeapFreeRatio = MAX_HEAP_FREE_RATIO; // (avoids ecj warnings)
+        if (maxHeapFreeRatio != 100) {
+            UnsignedWord maxFree = calculateFreeFromFreeRatioFlag(oldGenLiveSize, maxHeapFreeRatio);
+            freeSize = UnsignedUtils.min(maxFree, freeSize);
+        }
+
+        return oldGenLiveSize.add(freeSize);
+    }
+
+    private static UnsignedWord calculateFreeFromFreeRatioFlag(UnsignedWord live, int freePercent) { // ParallelScavengeHeap::calculate_free_from_free_ratio_flag
+        assert freePercent != 100;
+        // We want to calculate how much free memory there can be based on the
+        // live size.
+        // percent * (free + live) = free
+        // =>
+        // free = (live * percent) / (1 - percent)
+        double percent = freePercent / 100.0;
+        return UnsignedUtils.fromDouble(UnsignedUtils.toDouble(live) * percent / (1.0 - percent));
+    }
+
+    private void resizeOldGenAfterFullGC(UnsignedWord oldLive) { // ParallelScavengeHeap::resize_old_gen_after_full_gc
+        UnsignedWord currentCapacity = sizes.getOldSize();
+        UnsignedWord desiredCapacity = calculateDesiredOldGenCapacity(oldLive);
+
+        if (SHRINK_OLD_CAUTIOUSLY) {
+            if (desiredCapacity.belowThan(currentCapacity)) {
+                // Shrinking
+                if (majorCount < ADAPTIVE_SIZE_POLICY_READY_THRESHOLD) {
+                    // Not enough data for shrinking
+                    return;
+                }
+            }
+        }
+
+        // from PSOldGen::resize
+        UnsignedWord newOldSize = UnsignedUtils.clamp(alignUp(desiredCapacity), minSpaceSize(), sizes.getMaxOldSize());
+        sizes.setOldSize(newOldSize);
+    }
+
+    private void resizeAfterYoungGC(boolean isSurvivorOverflowing, UnsignedWord oldLive, UnsignedWord survived) { // ParallelScavengeHeap::resize_after_young_gc
+        doResizeAfterYoungGC(isSurvivorOverflowing, survived);
+
+        // Consider if should shrink old-gen
+        if (!isSurvivorOverflowing) {
+            // Upper bound for a single step shrink
+            UnsignedWord maxShrinkBytes = minSpaceSize();
+            UnsignedWord oldCapacity = sizes.getOldSize();
+            UnsignedWord oldGenFreeInBytes = oldCapacity.subtract(oldLive);
+            UnsignedWord shrinkBytes = computeOldGenShrinkBytes(oldGenFreeInBytes, maxShrinkBytes);
+            if (shrinkBytes.notEqual(0)) {
+                int minHeapFreeRatio = MIN_HEAP_FREE_RATIO; // (avoids ecj warnings)
+                if (minHeapFreeRatio != 0) {
+                    UnsignedWord newCapacity = oldCapacity.subtract(shrinkBytes);
+                    UnsignedWord newFreeSize = oldGenFreeInBytes.subtract(shrinkBytes);
+                    if (UnsignedUtils.toDouble(newFreeSize) / UnsignedUtils.toDouble(newCapacity) * 100 < minHeapFreeRatio) {
+                        // Would violate MinHeapFreeRatio
+                        return;
+                    }
+                }
+
+                // from PSOldGen::shrink
+                UnsignedWord newOldSize = minSpaceSize(alignDown(oldCapacity.subtract(shrinkBytes)));
+                sizes.setOldSize(newOldSize);
+            }
+        }
+    }
+
+    private void doResizeAfterYoungGC(boolean isSurvivorOverflowing, UnsignedWord survived) { // PSYoungGen::resize_after_young_gc
+        computeYoungDesiredSizesAndResize(isSurvivorOverflowing, survived);
+    }
+
+    private void computeYoungDesiredSizesAndResize(boolean isSurvivorOverflowing, UnsignedWord survived) { // PSYoungGen::compute_desired_sizes
+        UnsignedWord currentEdenSize = sizes.getEdenSize();
+        UnsignedWord currentSurvivorSize = sizes.getSurvivorSize();
+
+        UnsignedWord edenSize = computeDesiredEdenSize(isSurvivorOverflowing, currentEdenSize);
+        edenSize = minSpaceSize(alignUp(edenSize));
+
+        UnsignedWord survivorSize = computeDesiredSurvivorSize(currentSurvivorSize);
+        survivorSize = minSpaceSize(alignUp(UnsignedUtils.max(survivorSize, survived)));
+        // If we don't have survivor spaces, max survivor size is 0:
+        survivorSize = UnsignedUtils.min(survivorSize, sizes.getMaxSurvivorSize());
+
+        UnsignedWord newGenSize = edenSize.add(survivorSize.multiply(2));
+        final UnsignedWord minGenSize = getMinYoungSpacesSize();
+        final UnsignedWord maxGenSize = sizes.getMaxYoungSize();
+        if (newGenSize.belowThan(minGenSize)) {
+            // Keep survivor and adjust eden to meet min-gen-size
+            edenSize = minGenSize.subtract(survivorSize.multiply(2));
+        } else if (maxGenSize.belowThan(newGenSize)) {
+            // New capacity would exceed max; need to revise these desired sizes.
+            // Favor survivor over eden in order to reduce promotion (overflow).
+            if (survivorSize.multiply(2).aboveOrEqual(maxGenSize)) {
+                // If requested survivor size is too large
+                survivorSize = alignDown(maxGenSize.subtract(minSpaceSize()).unsignedDivide(2));
+                edenSize = maxGenSize.subtract(survivorSize.multiply(2));
+            } else {
+                // Respect survivor size and reduce eden
+                edenSize = maxGenSize.subtract(survivorSize.multiply(2));
+            }
+        }
+
+        // PSYoungGen::resize_inner
+        sizes.setEdenSize(edenSize);
+        sizes.setSurvivorSize(survivorSize);
+    }
+
+    private UnsignedWord paddedAveragePromotedInBytes() {
+        return UnsignedUtils.fromDouble(avgPromoted.getPaddedAverage());
+    }
+
+    /** Should be called at the start of a major collection. */
+    private void majorCollectionBegin(long beginNanoTime) {
+        majorTimer.reset();
+        majorTimer.startAt(beginNanoTime);
+        recordGcPauseStartInstant(beginNanoTime);
+    }
+
+    /** Should be called at the end of a major collection. */
+    private void majorCollectionEnd() {
+        majorTimer.stop();
+        double majorPauseInSeconds = TimeUtils.nanosToSecondsDouble(majorTimer.totalNanos());
+        recordGcDuration(majorPauseInSeconds);
+        trimmedMajorGcTimeSeconds.add(majorPauseInSeconds);
+    }
+
+    /**
+     * The throughput goal is implemented as _throughput_goal = 1 - (1 / (1 + gc_cost_ratio)).
+     *
+     * gc_cost_ratio is the ratio application cost / gc cost.
+     *
+     * For example a gc_cost_ratio of 4 translates into a throughput goal of 0.80.
+     */
+    private static double calculateThroughputGoal(double gcCostRatio) {
+        return 1.0 - (1.0 / (1.0 + gcCostRatio));
+    }
+
+    private UnsignedWord computeDesiredEdenSize(boolean isSurvivorOverflowing, UnsignedWord curEden) {
+        // Guard against divide-by-zero; 0.001ms
+        double gcDistance = Math.max(gcDistanceSecondsSeq.last(), 0.000001);
+        double minGcDistance = MIN_GC_DISTANCE_SECOND;
+
+        double throughputGoal = calculateThroughputGoal(GC_TIME_RATIO);
+
+        if (mutatorTimePercent() < throughputGoal) {
+            UnsignedWord newEden;
+            double expectedGcDistance = trimmedMinorGcTimeSeconds.last() * GC_TIME_RATIO;
+            if (gcDistance >= expectedGcDistance) {
+                // The latest sample already satisfies throughput goal; keep the current size
+                newEden = curEden;
+            } else {
+                // Using the latest sample to limit the growth in order to avoid overshoot
+                newEden = UnsignedUtils.min(
+                                UnsignedUtils.fromDouble((expectedGcDistance / gcDistance) * UnsignedUtils.toDouble(curEden)),
+                                increaseEden(curEden));
+            }
+            return newEden;
+        }
+
+        if (minorGcTimeEstimate() > gcPauseGoalSec) {
+            return decreaseEdenForMinorPauseTime(curEden);
+        }
+
+        if (gcDistance < minGcDistance) {
+            UnsignedWord newEden = UnsignedUtils.min(
+                            UnsignedUtils.fromDouble((minGcDistance / gcDistance) * UnsignedUtils.toDouble(curEden)),
+                            increaseEden(curEden));
+            return newEden;
+        }
+
+        // If no overflowing and promotion is small
+        if (!isSurvivorOverflowing && promotedBytesEstimate() < 1024) {
+            UnsignedWord delta = UnsignedUtils.min(
+                            edenIncrement(curEden).unsignedDivide(ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR),
+                            curEden.unsignedDivide(2));
+            double deltaFactor = UnsignedUtils.toDouble(delta) / UnsignedUtils.toDouble(curEden);
+
+            double gcTimeLowerEstimate = trimmedMinorGcTimeSeconds.davg() - trimmedMinorGcTimeSeconds.dsd();
+            // Limit GC frequency so that promoted rate is < 1MB/s
+            // promotedBytesEstimate() / (gcDistance + gcTimeLowerEstimate) < 1M/s
+            // ==> promotedBytesEstimate() / 1M - gcTimeLowerEstimate < gcDistance
+            double gcDistanceTarget = Math.max(Math.max(
+                            minorGcTimeConservativeEstimate() * GC_TIME_RATIO,
+                            promotedBytesEstimate() / (1024 * 1024) - gcTimeLowerEstimate),
+                            minGcDistance);
+            double predictedGcDistance = gcDistance * (1 - deltaFactor) - gcDistanceSecondsSeq.dsd();
+
+            if (predictedGcDistance > gcDistanceTarget) {
+                return curEden.subtract(delta);
+            }
+        }
+
+        return curEden;
+    }
+
+    private UnsignedWord computeDesiredSurvivorSize(UnsignedWord currentSurvivorSize) {
+        UnsignedWord desiredSurvivorSize = UnsignedUtils.fromDouble(survivedBytesEstimate());
+        if (desiredSurvivorSize.aboveOrEqual(currentSurvivorSize)) {
+            // Increasing survivor
+            return UnsignedUtils.min(desiredSurvivorSize, sizes.getMaxSurvivorSize());
+        }
+        UnsignedWord delta = currentSurvivorSize.subtract(desiredSurvivorSize);
+        return currentSurvivorSize.subtract(delta.unsignedDivide(ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR));
+    }
+
+    private UnsignedWord computeOldGenShrinkBytes(UnsignedWord oldGenFreeBytes, UnsignedWord maxShrinkBytes) {
+        final double lookaheadSec = 10 * 60; // 10min
+
+        double freeBytes = UnsignedUtils.toDouble(oldGenFreeBytes);
+        double promotionRate = promotionRateBytesPerSecEstimate();
+
+        double minFreeBytes = Math.max(
+                        UnsignedUtils.toDouble(paddedAveragePromotedInBytes()),
+                        promotionRate * lookaheadSec);
+
+        UnsignedWord shrinkBytes = Word.zero();
+        if (freeBytes > minFreeBytes) {
+            shrinkBytes = UnsignedUtils.fromDouble((freeBytes - minFreeBytes) / 2);
+            shrinkBytes = UnsignedUtils.min(shrinkBytes, maxShrinkBytes);
+        }
+        return shrinkBytes;
+    }
+
+    /** Decays the supplemental growth additive. Called on collection count increments. */
+    private void decaySupplementalGrowth(long numMinorGcs) {
+        if (numMinorGcs >= ADAPTIVE_SIZE_POLICY_READY_THRESHOLD && numMinorGcs % YOUNG_GENERATION_SIZE_SUPPLEMENT_DECAY == 0) {
+            youngGenSizeIncrementSupplement >>= 1;
+        }
+    }
+
+    private UnsignedWord decreaseEdenForMinorPauseTime(UnsignedWord currentEdenSize) {
+        UnsignedWord desiredEdenSize = minorPauseYoungEstimator.decrementWillDecrease()
+                        ? currentEdenSize.subtract(edenDecrementAlignedDown(currentEdenSize))
+                        : currentEdenSize;
+        assert desiredEdenSize.belowOrEqual(currentEdenSize);
+        return desiredEdenSize;
+    }
+
+    private UnsignedWord increaseEden(UnsignedWord currentEdenSize) {
+        UnsignedWord delta = edenIncrementWithSupplementAlignedUp(currentEdenSize);
+        UnsignedWord desiredEdenSize = currentEdenSize.add(delta);
+        assert desiredEdenSize.aboveOrEqual(currentEdenSize);
+        return desiredEdenSize;
+    }
+
+    private UnsignedWord edenIncrementWithSupplementAlignedUp(UnsignedWord curEden) {
+        UnsignedWord result = edenIncrement(curEden, YOUNG_GENERATION_SIZE_INCREMENT + youngGenSizeIncrementSupplement);
+        return alignUp(result);
+    }
+
+    private UnsignedWord edenDecrementAlignedDown(UnsignedWord curEden) {
+        UnsignedWord edenHeapDelta = edenIncrement(curEden).unsignedDivide(ADAPTIVE_SIZE_DECREMENT_SCALE_FACTOR);
+        return alignDown(edenHeapDelta);
+    }
+
+    private int computeTenuringThreshold(boolean isSurvivorOverflowing, int currentThreshold) {
+        if (!youngGenPolicyIsReady) {
+            return currentThreshold;
+        }
+        if (isSurvivorOverflowing) {
+            return currentThreshold;
+        }
+        boolean incrTenuringThreshold = false;
+        double majorCost = majorGcTimeSum();
+        double minorCost = minorGcTimeSum();
+        if (minorCost > majorCost * thresholdTolerancePercent) {
+            // nothing; we prefer young-gc over full-gc
+        } else if (majorCost > minorCost * thresholdTolerancePercent) {
+            // Major times are too long, so we want less promotion.
+            incrTenuringThreshold = true;
+        }
+        int newThreshold = currentThreshold;
+        if (incrTenuringThreshold && newThreshold < HeapParameters.getMaxSurvivorSpaces()) {
+            newThreshold++;
+        }
+        return newThreshold;
+    }
+
+    /** Updates averages that are always used (even if adaptive sizing is turned off). */
+    private void updateAverages(boolean isSurvivorOverflow, double survived, double promoted) {
+        if (!isSurvivorOverflow) {
+            survivedBytes.add(survived);
+        } else {
+            // survived is an underestimate
+            survivedBytes.add(survived + promoted);
+        }
+        avgPromoted.sample(promoted);
+        promotedBytes.add(promoted);
+
+        double promotionRate = promoted / (gcDistanceSecondsSeq.last() + trimmedMinorGcTimeSeconds.last());
+        promotionRateBytesPerSec.add(promotionRate);
+    }
+}
+
+/*
+ * Code in this class has been adapted from HotSpot class {@code AdaptiveSizePolicy}. Names have
+ * been kept mostly the same for comparability.
+ */
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/shared/adaptiveSizePolicy.hpp")
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/shared/adaptiveSizePolicy.cpp")
+abstract class AdaptiveCollectionPolicy2Base extends AbstractCollectionPolicy implements AdaptiveCollectionPolicy2Tunables {
+
+    // pause and interval times for collections
+    final Timer minorTimer = new Timer("minor/between minor");
+    final Timer majorTimer = new Timer("major/between major");
+
+    // To measure wall-clock time between two GCs, i.e. mutator running time, and record them.
+    final Timer gcDistanceTimer = new Timer("mutator running time");
+    final NumberSeq gcDistanceSecondsSeq = new NumberSeq(SEQ_DEFAULT_ALPHA_VALUE);
+
+    // Recording the last NUM_OF_GC_SAMPLE number of minor/major gc durations
+    final TruncatedSeq trimmedMinorGcTimeSeconds = new TruncatedSeq(NUM_OF_GC_SAMPLE, SEQ_DEFAULT_ALPHA_VALUE);
+    final TruncatedSeq trimmedMajorGcTimeSeconds = new TruncatedSeq(NUM_OF_GC_SAMPLE, SEQ_DEFAULT_ALPHA_VALUE);
+
+    final GCSampleRingBuffer gcSamples = new GCSampleRingBuffer();
+
+    /** The number of bytes promoted to old-gen after a young-gc. */
+    final NumberSeq promotedBytes = new NumberSeq(SEQ_DEFAULT_ALPHA_VALUE);
+
+    /** The number of bytes in to-space after a young-gc. */
+    final NumberSeq survivedBytes = new NumberSeq(SEQ_DEFAULT_ALPHA_VALUE);
+
+    /** The rate of promotion to old-gen. */
+    final NumberSeq promotionRateBytesPerSec = new NumberSeq(SEQ_DEFAULT_ALPHA_VALUE);
+
+    /** The peak of used bytes in old-gen before/after young/full-gc. */
+    final NumberSeq peakOldUsedBytesSeq = new NumberSeq(SEQ_DEFAULT_ALPHA_VALUE);
+
+    /**
+     * Variable for estimating the major and minor pause times. These variables represent linear
+     * least-squares fits of the data: minor pause time vs. young gen size
+     */
+    final LinearLeastSquareFit minorPauseYoungEstimator = new LinearLeastSquareFit(ADAPTIVE_SIZE_POLICY_WEIGHT);
+
+    /** Allowed difference between major and minor GC times, used to compute tenuring threshold. */
+    final double thresholdTolerancePercent = 1.0 + THRESHOLD_TOLERANCE / 100.0;
+
+    /** Goal for maximum GC pause. */
+    final double gcPauseGoalSec;
+
+    /** Flag indicating that the adaptive policy is ready to use. */
+    boolean youngGenPolicyIsReady = false;
+
+    long minorCount = 0;
+
+    AdaptiveCollectionPolicy2Base(double gcPauseGoalSec) {
+        super(INITIAL_NEW_RATIO, INITIAL_TENURING_THRESHOLD);
+        this.gcPauseGoalSec = gcPauseGoalSec;
+    }
+
+    double minorGcTimeSum() {
+        return trimmedMinorGcTimeSeconds.getSum();
+    }
+
+    double majorGcTimeSum() {
+        return trimmedMajorGcTimeSeconds.getSum();
+    }
+
+    void recordGcDuration(double gcDuration) {
+        gcSamples.recordSample(gcDuration);
+    }
+
+    /** Percent of GC wall-clock time. */
+    double gcTimePercent() {
+        double totalTime = gcSamples.trimmedWindowDuration();
+        double gcTime = gcSamples.durationSum();
+        double gcPercent = gcTime / totalTime;
+        assert gcPercent <= 1.0;
+        assert gcPercent >= 0;
+        return gcPercent;
+    }
+
+    UnsignedWord edenIncrement(UnsignedWord curEden, int percentChange) {
+        return curEden.multiply(percentChange).unsignedDivide(100);
+    }
+
+    UnsignedWord edenIncrement(UnsignedWord curEden) {
+        return edenIncrement(curEden, YOUNG_GENERATION_SIZE_INCREMENT);
+    }
+
+    void recordGcPauseEndInstant() {
+        gcDistanceTimer.reset();
+        gcDistanceTimer.start();
+    }
+
+    void recordGcPauseStartInstant(long beginNanoTime) {
+        if (!gcDistanceTimer.wasStartedAtLeastOnce()) {
+            long origin = Isolates.isStartTimeAssigned() ? Isolates.getStartTimeNanos() : beginNanoTime;
+            gcDistanceTimer.startAt(origin);
+        }
+        gcDistanceTimer.stopAt(beginNanoTime);
+        gcDistanceSecondsSeq.add(TimeUtils.nanosToSecondsDouble(gcDistanceTimer.totalNanos()));
+    }
+
+    double minorGcTimeEstimate() {
+        return trimmedMinorGcTimeSeconds.davg() + trimmedMinorGcTimeSeconds.dsd();
+    }
+
+    double minorGcTimeConservativeEstimate() {
+        double davgPlusDsd = trimmedMinorGcTimeSeconds.davg() + trimmedMinorGcTimeSeconds.dsd();
+        double avgPlusSd = trimmedMinorGcTimeSeconds.avg() + trimmedMinorGcTimeSeconds.sd();
+        return Math.max(davgPlusDsd, avgPlusSd);
+    }
+
+    void sampleOldGenUsedBytes(UnsignedWord usedBytes) {
+        peakOldUsedBytesSeq.add(UnsignedUtils.toDouble(usedBytes));
+    }
+
+    double peakOldGenUsedEstimate() {
+        return peakOldUsedBytesSeq.davg() + peakOldUsedBytesSeq.dsd();
+    }
+
+    double promotedBytesEstimate() {
+        return promotedBytes.davg() + promotedBytes.dsd();
+    }
+
+    double promotionRateBytesPerSecEstimate() {
+        return promotionRateBytesPerSec.davg() + promotionRateBytesPerSec.dsd();
+    }
+
+    /** Conservative estimate to minimize promotion to old-gen. */
+    double survivedBytesEstimate() {
+        double avgPlusSd = survivedBytes.avg() + survivedBytes.sd();
+        double davgPlusDsd = survivedBytes.davg() + survivedBytes.dsd();
+        return Math.max(avgPlusSd, davgPlusDsd);
+    }
+
+    /** Percent of mutator wall-clock time. */
+    double mutatorTimePercent() {
+        return 1.0 - gcTimePercent();
+    }
+
+    void minorCollectionBegin(long beginNanoTime) {
+        minorTimer.reset();
+        minorTimer.startAt(beginNanoTime);
+        recordGcPauseStartInstant(beginNanoTime);
+    }
+
+    void minorCollectionEnd(UnsignedWord edenCapacityBytes) {
+        minorTimer.stop();
+
+        double minorPauseInSeconds = TimeUtils.nanosToSecondsDouble(minorTimer.totalNanos());
+        double minorPauseInMs = minorPauseInSeconds * 1000;
+
+        recordGcDuration(minorPauseInSeconds);
+        trimmedMinorGcTimeSeconds.add(minorPauseInSeconds);
+
+        if (!youngGenPolicyIsReady) {
+            /*
+             * NOTE that the original code uses GCId::current(), which is incremented for both major
+             * and minor collections, contrary to what the following comment says.
+             */
+            // The policy does not have enough data until at least some
+            // young collections have been done.
+            youngGenPolicyIsReady = (minorCount >= ADAPTIVE_SIZE_POLICY_READY_THRESHOLD);
+        }
+
+        double edenSizeInMbytes = UnsignedUtils.toDouble(edenCapacityBytes) / (1024 * 1024);
+        minorPauseYoungEstimator.update(edenSizeInMbytes, minorPauseInMs);
+    }
+}
+
+/**
+ * A ring buffer with fixed size to record the most recent samples of GC duration (minor and major)
+ * so that we can calculate mutator-wall-clock-time percentage for the given window.
+ */
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/shared/adaptiveSizePolicy.hpp")
+final class GCSampleRingBuffer {
+    private final double[] startInstants = new double[NUM_OF_GC_SAMPLE];
+    private final double[] durations = new double[NUM_OF_GC_SAMPLE];
+    private double durationSum = 0.0;
+    private int sampleIndex = 0;
+    private int numOfSamples = 0;
+
+    double durationSum() {
+        return durationSum;
+    }
+
+    /** Records a GC duration into the ring buffer. */
+    void recordSample(double gcDuration) {
+        if (numOfSamples < NUM_OF_GC_SAMPLE) {
+            numOfSamples++;
+        } else {
+            assert numOfSamples == NUM_OF_GC_SAMPLE;
+            durationSum -= durations[sampleIndex];
+        }
+        double gcStartInstant = elapsedTime() - gcDuration;
+        startInstants[sampleIndex] = gcStartInstant;
+        durations[sampleIndex] = gcDuration;
+        durationSum += gcDuration;
+
+        sampleIndex = (sampleIndex + 1) % NUM_OF_GC_SAMPLE;
+    }
+
+    /** Returns window length, i.e. time from oldest to now. */
+    double trimmedWindowDuration() {
+        double currentTime = elapsedTime();
+        double oldestGcStartInstant;
+        if (numOfSamples < NUM_OF_GC_SAMPLE) {
+            oldestGcStartInstant = startInstants[0];
+        } else {
+            oldestGcStartInstant = startInstants[sampleIndex];
+        }
+        return currentTime - oldestGcStartInstant;
+    }
+
+    private static double elapsedTime() {
+        return TimeUtils.nanosToSecondsDouble(System.nanoTime());
+    }
+}

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AdaptiveCollectionPolicy2.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AdaptiveCollectionPolicy2.java
@@ -40,6 +40,18 @@ import com.oracle.svm.core.util.UnsignedUtils;
 interface AdaptiveCollectionPolicy2Tunables {
 
     /**
+     * The minimum estimated decrease in eden survival rate (survived eden bytes after collection
+     * vs. eden usage before collection) in percent to decide in favor of expanding eden by 1%.
+     */
+    double EDEN_GROWTH_MIN_SURVIVAL_RATE_TRADEOFF = 0.5;
+
+    /**
+     * When throughput is below this percentage, sizes are increased unconditionally to avoid
+     * starving the mutator.
+     */
+    double ALWAYS_GROW_BELOW_THROUGHPUT_THRESHOLD = 0.5;
+
+    /**
      * Start out with the same sizes for young and old generation. This leads to less frequent minor
      * collections and tenuring at startup especially with {@link #YOUNG_GENERATION_SIZE_SUPPLEMENT}
      * disabled. (The HotSpot NewRatio default is 2, so 1:2 for young:old)
@@ -156,6 +168,8 @@ interface AdaptiveCollectionPolicy2Tunables {
 @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/parallel/psYoungGen.cpp#L325-L423")
 @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp#L824-L916")
 class AdaptiveCollectionPolicy2 extends AdaptiveCollectionPolicy2Base {
+
+    private final ReciprocalLeastSquareFit edenOccupiedToSurvivedRate = new ReciprocalLeastSquareFit(ADAPTIVE_SIZE_POLICY_WEIGHT);
 
     private final AdaptivePaddedAverage avgPromoted = new AdaptivePaddedAverage(ADAPTIVE_SIZE_POLICY_WEIGHT, PROMOTED_PADDING, true);
 
@@ -279,10 +293,21 @@ class AdaptiveCollectionPolicy2 extends AdaptiveCollectionPolicy2Base {
              */
             oldSizeExceededInPreviousCollection = oldLive.aboveThan(sizes.getOldSize());
 
+            YoungGeneration youngGen = HeapImpl.getHeapImpl().getYoungGeneration();
             boolean survivorOverflow = acc.hasLastIncrementalCollectionOverflowedSurvivors();
-            UnsignedWord survived = HeapImpl.getHeapImpl().getYoungGeneration().getSurvivorChunkBytes();
+            UnsignedWord survived = youngGen.getSurvivorChunkBytes();
             UnsignedWord promoted = acc.getLastIncrementalCollectionPromotedChunkBytes();
             updateAverages(survivorOverflow, UnsignedUtils.toDouble(survived), UnsignedUtils.toDouble(promoted));
+
+            UnsignedWord edenOccupiedBefore = acc.getEdenChunkBytesBefore();
+            UnsignedWord edenSurvived;
+            if (youngGen.getMaxSurvivorSpaces() > 0) {
+                edenSurvived = youngGen.getSurvivorChunkBytes(0); // age 1, only from eden
+            } else {
+                edenSurvived = promoted;
+            }
+            sampleEdenSurvived(edenOccupiedBefore, edenSurvived);
+
             sampleOldGenUsedBytes(acc.getOldGenerationAfterChunkBytes());
 
             tenuringThreshold = computeTenuringThreshold(survivorOverflow, tenuringThreshold);
@@ -293,6 +318,39 @@ class AdaptiveCollectionPolicy2 extends AdaptiveCollectionPolicy2Base {
         }
 
         recordGcPauseEndInstant();
+    }
+
+    /**
+     * Build a model of how eden sizing impacts the survival rate out of eden.
+     *
+     * @see #growingEdenSufficientlyReducesSurvivalRate
+     */
+    private void sampleEdenSurvived(UnsignedWord edenOccupiedBefore, UnsignedWord edenSurvived) {
+        assert edenSurvived.belowOrEqual(edenOccupiedBefore);
+        double edenBefore = UnsignedUtils.toDouble(edenOccupiedBefore);
+        edenBefore = Math.max(edenBefore, 1); // 1 byte, to avoid division by zero
+        double edenSurvivalRate = UnsignedUtils.toDouble(edenSurvived) / edenBefore;
+        edenOccupiedToSurvivedRate.sample(edenBefore, edenSurvivalRate);
+    }
+
+    /**
+     * We might find it hard to meet our throughput goal, especially when trying to keep up with
+     * multithreaded allocations. While growing eden can help throughput, we avoid growing past the
+     * point where it doesn't reduce the survival rate of objects significantly but inflates our
+     * footprint.
+     * <p>
+     * This and {@link #sampleEdenSurvived} is not part of the original code.
+     */
+    private boolean growingEdenSufficientlyReducesSurvivalRate(UnsignedWord curEden) {
+        double size = UnsignedUtils.toDouble(curEden);
+        if (!youngGenPolicyIsReady || size == 0.0) {
+            return true; // general assumption for space expansion
+        }
+        double y = edenOccupiedToSurvivedRate.estimate(size);
+        double minSlope = -(y * EDEN_GROWTH_MIN_SURVIVAL_RATE_TRADEOFF / size);
+
+        double estimatedSlope = edenOccupiedToSurvivedRate.getSlope(size);
+        return estimatedSlope <= minSlope;
     }
 
     private void resizeAfterFullGC(UnsignedWord oldLive) { // ParallelScavengeHeap::resize_after_full_gc
@@ -471,23 +529,28 @@ class AdaptiveCollectionPolicy2 extends AdaptiveCollectionPolicy2Base {
 
         double throughputGoal = calculateThroughputGoal(GC_TIME_RATIO);
 
-        if (mutatorTimePercent() < throughputGoal) {
-            UnsignedWord newEden;
+        double throughput = mutatorTimePercent();
+        boolean meetingThroughputGoal = (throughput >= throughputGoal);
+        if (meetingThroughputGoal) {
+            if (minorGcTimeEstimate() > gcPauseGoalSec) {
+                return decreaseEdenForMinorPauseTime(curEden);
+            }
+        } else {
             double expectedGcDistance = trimmedMinorGcTimeSeconds.last() * GC_TIME_RATIO;
             if (gcDistance >= expectedGcDistance) {
                 // The latest sample already satisfies throughput goal; keep the current size
-                newEden = curEden;
-            } else {
-                // Using the latest sample to limit the growth in order to avoid overshoot
-                newEden = UnsignedUtils.min(
+                return curEden;
+            }
+
+            boolean growEden = (throughput < ALWAYS_GROW_BELOW_THROUGHPUT_THRESHOLD) || growingEdenSufficientlyReducesSurvivalRate(curEden);
+            if (growEden) {
+                // Using the latest sample to limit the growth to avoid overshoot
+                return UnsignedUtils.min(
                                 UnsignedUtils.fromDouble((expectedGcDistance / gcDistance) * UnsignedUtils.toDouble(curEden)),
                                 increaseEden(curEden));
             }
-            return newEden;
-        }
 
-        if (minorGcTimeEstimate() > gcPauseGoalSec) {
-            return decreaseEdenForMinorPauseTime(curEden);
+            /* We think growing eden won't help throughput. Look at min GC distance first. */
         }
 
         if (gcDistance < minGcDistance) {
@@ -495,6 +558,14 @@ class AdaptiveCollectionPolicy2 extends AdaptiveCollectionPolicy2Base {
                             UnsignedUtils.fromDouble((minGcDistance / gcDistance) * UnsignedUtils.toDouble(curEden)),
                             increaseEden(curEden));
             return newEden;
+        }
+
+        if (!meetingThroughputGoal) {
+            /*
+             * We decided above that growing won't help throughput. Shrink instead so we don't get
+             * stuck and so we keep collecting new data points for the underlying estimator.
+             */
+            return decreaseEden(curEden);
         }
 
         // If no overflowing and promotion is small
@@ -558,9 +629,13 @@ class AdaptiveCollectionPolicy2 extends AdaptiveCollectionPolicy2Base {
     }
 
     private UnsignedWord decreaseEdenForMinorPauseTime(UnsignedWord currentEdenSize) {
-        UnsignedWord desiredEdenSize = minorPauseYoungEstimator.decrementWillDecrease()
-                        ? currentEdenSize.subtract(edenDecrementAlignedDown(currentEdenSize))
+        return minorPauseYoungEstimator.decrementWillDecrease()
+                        ? decreaseEden(currentEdenSize)
                         : currentEdenSize;
+    }
+
+    private UnsignedWord decreaseEden(UnsignedWord currentEdenSize) {
+        UnsignedWord desiredEdenSize = currentEdenSize.subtract(edenDecrementAlignedDown(currentEdenSize));
         assert desiredEdenSize.belowOrEqual(currentEdenSize);
         return desiredEdenSize;
     }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AdaptiveCollectionPolicy2.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AdaptiveCollectionPolicy2.java
@@ -27,7 +27,6 @@ package com.oracle.svm.core.genscavenge;
 import static com.oracle.svm.core.genscavenge.AdaptiveCollectionPolicy2Tunables.NUM_OF_GC_SAMPLE;
 
 import org.graalvm.word.UnsignedWord;
-import org.graalvm.word.impl.Word;
 
 import com.oracle.svm.core.Isolates;
 import com.oracle.svm.core.heap.GCCause;
@@ -35,6 +34,8 @@ import com.oracle.svm.core.util.BasedOnJDKFile;
 import com.oracle.svm.core.util.TimeUtils;
 import com.oracle.svm.core.util.Timer;
 import com.oracle.svm.core.util.UnsignedUtils;
+
+import jdk.graal.compiler.word.Word;
 
 /** Constants for policy tunables. */
 interface AdaptiveCollectionPolicy2Tunables {
@@ -44,7 +45,7 @@ interface AdaptiveCollectionPolicy2Tunables {
      * collections and tenuring at startup especially with {@link #YOUNG_GENERATION_SIZE_SUPPLEMENT}
      * disabled. (The HotSpot NewRatio default is 2, so 1:2 for young:old)
      */
-    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/shared/gc_globals.hpp#L489-L493") //
+    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25-ga/src/hotspot/share/gc/shared/gc_globals.hpp#L553-L557") //
     int INITIAL_NEW_RATIO = 1;
 
     /*
@@ -57,7 +58,7 @@ interface AdaptiveCollectionPolicy2Tunables {
      *
      */
 
-    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/shared/gc_globals.hpp#L308-L353") //
+    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25-ga/src/hotspot/share/gc/shared/gc_globals.hpp#L325-L401") // actually:jdk-26+25#L308-L353
     int ADAPTIVE_SIZE_POLICY_READY_THRESHOLD = 5;
     int ADAPTIVE_SIZE_POLICY_WEIGHT = 10;
     int PROMOTED_PADDING = 3;
@@ -89,14 +90,14 @@ interface AdaptiveCollectionPolicy2Tunables {
      * The tenuring threshold at startup (HotSpot default: 7). The policy intentionally never
      * reduces the tenuring threshold, so this is also its minimum value.
      */
-    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/shared/gc_globals.hpp#L512-L517") //
+    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25-ga/src/hotspot/share/gc/shared/gc_globals.hpp#L576-L581") //
     int INITIAL_TENURING_THRESHOLD = 7;
 
     /*
      * We don't want to limit our freedom to adjust the heap. (Unless set explicitly, these options
      * are set to these values in ParallelArguments::initialize on HotSpot)
      */
-    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/parallel/parallelArguments.cpp#L57-L68") //
+    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25-ga/src/hotspot/share/gc/parallel/parallelArguments.cpp#L57-L68") //
     int MIN_HEAP_FREE_RATIO = 0; // %
     int MAX_HEAP_FREE_RATIO = 100; // %
     /** On HotSpot, this is the behavior if {@link #MIN_HEAP_FREE_RATIO} is not set explicitly. */
@@ -149,12 +150,12 @@ interface AdaptiveCollectionPolicy2Tunables {
  * been kept mostly the same for comparability. Initial tweaking focused on {@link #GC_TIME_RATIO}
  * and {@link #MIN_GC_DISTANCE_SECOND}, further ideas are tracked in GR-73130.
  */
-@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.hpp")
-@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp")
-@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/parallel/psScavenge.cpp#L311-L508")
-@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/parallel/psParallelCompact.cpp#L934-L1055")
-@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/parallel/psYoungGen.cpp#L325-L423")
-@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp#L824-L916")
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25-ga/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.hpp") // actually:jdk-26+25
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25-ga/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp") // actually:jdk-26+25
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25-ga/src/hotspot/share/gc/parallel/psScavenge.cpp") // actually:jdk-26+25#L311-L508
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25-ga/src/hotspot/share/gc/parallel/psParallelCompact.cpp") // actually:jdk-26+25#L934-L1055
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25-ga/src/hotspot/share/gc/parallel/psYoungGen.cpp") // actually:jdk-26+25#L325-L423
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25-ga/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp") // actually:jdk-26+25#L824-L916
 class AdaptiveCollectionPolicy2 extends AdaptiveCollectionPolicy2Base {
 
     private final AdaptivePaddedAverage avgPromoted = new AdaptivePaddedAverage(ADAPTIVE_SIZE_POLICY_WEIGHT, PROMOTED_PADDING, true);
@@ -180,7 +181,7 @@ class AdaptiveCollectionPolicy2 extends AdaptiveCollectionPolicy2Base {
     }
 
     @Override
-    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp#L372-L421")
+    @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25-ga/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp") // actually:jdk-26+25#L372-L421
     public boolean shouldCollectCompletely(boolean followingIncrementalCollection, boolean forcedCompleteCollection) { // ParallelScavengeHeap::should_attempt_young_gc
         guaranteeSizeParametersInitialized();
 
@@ -625,8 +626,8 @@ class AdaptiveCollectionPolicy2 extends AdaptiveCollectionPolicy2Base {
  * Code in this class has been adapted from HotSpot class {@code AdaptiveSizePolicy}. Names have
  * been kept mostly the same for comparability.
  */
-@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/shared/adaptiveSizePolicy.hpp")
-@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/shared/adaptiveSizePolicy.cpp")
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25-ga/src/hotspot/share/gc/shared/adaptiveSizePolicy.hpp") // actually:jdk-26+25
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25-ga/src/hotspot/share/gc/shared/adaptiveSizePolicy.cpp") // actually:jdk-26+25
 abstract class AdaptiveCollectionPolicy2Base extends AbstractCollectionPolicy implements AdaptiveCollectionPolicy2Tunables {
 
     // pause and interval times for collections
@@ -793,7 +794,7 @@ abstract class AdaptiveCollectionPolicy2Base extends AbstractCollectionPolicy im
  * A ring buffer with fixed size to record the most recent samples of GC duration (minor and major)
  * so that we can calculate mutator-wall-clock-time percentage for the given window.
  */
-@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/shared/adaptiveSizePolicy.hpp")
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25-ga/src/hotspot/share/gc/shared/adaptiveSizePolicy.hpp") // actually:jdk-26+25
 final class GCSampleRingBuffer {
     private final double[] startInstants = new double[NUM_OF_GC_SAMPLE];
     private final double[] durations = new double[NUM_OF_GC_SAMPLE];

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AdaptiveWeightedAverage.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AdaptiveWeightedAverage.java
@@ -29,6 +29,7 @@ import static com.oracle.svm.core.Uninterruptible.CALLED_FROM_UNINTERRUPTIBLE_CO
 import org.graalvm.word.UnsignedWord;
 
 import com.oracle.svm.core.Uninterruptible;
+import com.oracle.svm.core.util.BasedOnJDKFile;
 import com.oracle.svm.core.util.UnsignedUtils;
 
 /**
@@ -39,23 +40,10 @@ import com.oracle.svm.core.util.UnsignedUtils;
  *
  * This serves as our best estimate of a future unknown.
  */
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/shared/gcUtil.hpp")
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/shared/gcUtil.cpp")
 class AdaptiveWeightedAverage {
     static final int OLD_THRESHOLD = 100;
-
-    /** @see #computeEffectiveHistoryLengthForWeight */
-    static double computeWeightForEffectiveHistoryLength(double length) {
-        assert length > 0;
-        return 100.0 * (1.0 - Math.pow(Math.E, -1.0 / length));
-    }
-
-    /**
-     * Computes the effective history length for the given weight, which is the number of data
-     * points after which the former history is discounted to 1/e, i.e., its time constant.
-     */
-    static double computeEffectiveHistoryLengthForWeight(double weight) {
-        assert weight > 0 && weight <= 100;
-        return -1.0 / Math.log(1.0 - weight / 100.0);
-    }
 
     private final double weight;
 
@@ -76,6 +64,10 @@ class AdaptiveWeightedAverage {
 
     public double getAverage() {
         return average;
+    }
+
+    public long getCount() {
+        return sampleCount;
     }
 
     public void sample(double value) {
@@ -151,9 +143,5 @@ class AdaptivePaddedAverage extends AdaptiveWeightedAverage {
 
     public double getPaddedAverage() {
         return paddedAverage;
-    }
-
-    public double getDeviation() {
-        return deviation;
     }
 }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AdaptiveWeightedAverage.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AdaptiveWeightedAverage.java
@@ -40,8 +40,8 @@ import com.oracle.svm.core.util.UnsignedUtils;
  *
  * This serves as our best estimate of a future unknown.
  */
-@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/shared/gcUtil.hpp")
-@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/shared/gcUtil.cpp")
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25-ga/src/hotspot/share/gc/shared/gcUtil.hpp")
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25-ga/src/hotspot/share/gc/shared/gcUtil.cpp")
 class AdaptiveWeightedAverage {
     static final int OLD_THRESHOLD = 100;
 

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AlignedHeapChunk.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AlignedHeapChunk.java
@@ -24,6 +24,8 @@
  */
 package com.oracle.svm.core.genscavenge;
 
+import static com.oracle.svm.core.Uninterruptible.CALLED_FROM_UNINTERRUPTIBLE_CODE;
+
 import org.graalvm.nativeimage.c.struct.RawField;
 import org.graalvm.nativeimage.c.struct.RawStructure;
 import org.graalvm.word.Pointer;
@@ -33,7 +35,6 @@ import com.oracle.svm.core.AlwaysInline;
 import com.oracle.svm.core.Uninterruptible;
 import com.oracle.svm.core.genscavenge.remset.RememberedSet;
 import com.oracle.svm.core.heap.ObjectVisitor;
-import com.oracle.svm.core.heap.RestrictHeapAccess;
 import com.oracle.svm.core.util.PointerUtils;
 
 import jdk.graal.compiler.api.directives.GraalDirectives;
@@ -102,10 +103,12 @@ public final class AlignedHeapChunk {
         return HeapChunk.asPointer(that).add(getObjectsStartOffset());
     }
 
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     public static Pointer getObjectsEnd(AlignedHeader that) {
         return HeapChunk.getEndPointer(that);
     }
 
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     public static boolean isEmpty(AlignedHeader that) {
         return HeapChunk.getTopOffset(that).equal(getObjectsStartOffset());
     }
@@ -165,13 +168,7 @@ public final class AlignedHeapChunk {
     }
 
     public interface Visitor {
-        /**
-         * Visit an {@link AlignedHeapChunk}.
-         *
-         * @param chunk The {@link AlignedHeapChunk} to be visited.
-         * @return {@code true} if visiting should continue, {@code false} if visiting should stop.
-         */
-        @RestrictHeapAccess(access = RestrictHeapAccess.Access.NO_ALLOCATION, reason = "Must not allocate while visiting the heap.")
-        boolean visitChunk(AlignedHeapChunk.AlignedHeader chunk);
+        @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+        void visitChunk(AlignedHeader chunk);
     }
 }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/BasicCollectionPolicies.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/BasicCollectionPolicies.java
@@ -207,7 +207,7 @@ final class BasicCollectionPolicies {
     public static final class OnlyIncrementally extends BasicPolicy {
 
         @Override
-        public boolean shouldCollectCompletely(boolean followingIncrementalCollection) {
+        public boolean shouldCollectCompletely(boolean followingIncrementalCollection, boolean forcedCompleteCollection) {
             return false;
         }
 
@@ -220,7 +220,7 @@ final class BasicCollectionPolicies {
     public static final class OnlyCompletely extends BasicPolicy {
 
         @Override
-        public boolean shouldCollectCompletely(boolean followingIncrementalCollection) {
+        public boolean shouldCollectCompletely(boolean followingIncrementalCollection, boolean forcedCompleteCollection) {
             return followingIncrementalCollection || !shouldCollectYoungGenSeparately(false);
         }
 
@@ -238,7 +238,7 @@ final class BasicCollectionPolicies {
         }
 
         @Override
-        public boolean shouldCollectCompletely(boolean followingIncrementalCollection) {
+        public boolean shouldCollectCompletely(boolean followingIncrementalCollection, boolean forcedCompleteCollection) {
             throw VMError.shouldNotReachHere("Collection must not be initiated in the first place");
         }
 
@@ -255,8 +255,12 @@ final class BasicCollectionPolicies {
     public static final class BySpaceAndTime extends BasicPolicy {
 
         @Override
-        public boolean shouldCollectCompletely(boolean followingIncrementalCollection) {
-            if (!followingIncrementalCollection && shouldCollectYoungGenSeparately(false)) {
+        public boolean shouldCollectCompletely(boolean followingIncrementalCollection, boolean forcedCompleteCollection) {
+            boolean collectYoungSeparately = shouldCollectYoungGenSeparately(false);
+            if (forcedCompleteCollection && !collectYoungSeparately) {
+                return true;
+            }
+            if (!followingIncrementalCollection && collectYoungSeparately) {
                 return false;
             }
             return estimateUsedHeapAtNextIncrementalCollection().aboveThan(getMaximumHeapSize()) ||

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/BasicCollectionPolicies.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/BasicCollectionPolicies.java
@@ -196,7 +196,7 @@ final class BasicCollectionPolicies {
         }
 
         @Override
-        public void onCollectionBegin(boolean completeCollection, long requestingNanoTime) {
+        public void onCollectionBegin(boolean completeCollection, long beginNanoTime) {
         }
 
         @Override

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CollectionPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CollectionPolicy.java
@@ -209,7 +209,7 @@ public interface CollectionPolicy {
     int getTenuringAge();
 
     /** Called at the beginning of a collection, in the safepoint operation. */
-    void onCollectionBegin(boolean completeCollection, long requestingNanoTime);
+    void onCollectionBegin(boolean completeCollection, long beginNanoTime);
 
     /** Called before the end of a collection, in the safepoint operation. */
     void onCollectionEnd(boolean completeCollection, GCCause cause);

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CollectionPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CollectionPolicy.java
@@ -138,8 +138,10 @@ public interface CollectionPolicy {
      * @param followingIncrementalCollection whether an incremental collection has just finished in
      *            the same safepoint. Implementations would typically decide whether to follow up
      *            with a full collection based on whether enough memory was reclaimed.
+     * @param forcedCompleteCollection whether a complete collection will eventually be forced. The
+     *            policy can still return {@code false} to do an incremental collection first.
      */
-    boolean shouldCollectCompletely(boolean followingIncrementalCollection);
+    boolean shouldCollectCompletely(boolean followingIncrementalCollection, boolean forcedCompleteCollection);
 
     /**
      * The current limit for the size of the entire heap, which is less than or equal to

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CollectionPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CollectionPolicy.java
@@ -147,8 +147,7 @@ public interface CollectionPolicy {
      * The current limit for the size of the entire heap, which is less than or equal to
      * {@link #getMaximumHeapSize}.
      *
-     * NOTE: this can currently be exceeded during a collection while copying objects in the old
-     * generation.
+     * NOTE: this can currently be exceeded during a collection with {@link CopyingOldGeneration}.
      */
     UnsignedWord getCurrentHeapCapacity();
 
@@ -161,8 +160,7 @@ public interface CollectionPolicy {
      * The hard limit for the size of the entire heap. Exceeding this limit triggers an
      * {@link OutOfMemoryError}.
      *
-     * NOTE: this can currently be exceeded during a collection while copying objects in the old
-     * generation.
+     * NOTE: this can currently be exceeded during a collection with {@link CopyingOldGeneration}.
      */
     UnsignedWord getMaximumHeapSize();
 
@@ -218,6 +216,10 @@ public interface CollectionPolicy {
 
     /** Can be overridden to recover from OOM. */
     default boolean isOutOfMemory(UnsignedWord usedBytes) {
+        /*
+         * GR-72932: collections can tenure objects beyond the old generation's current or maximum
+         * size, and the following allocations can exceed the current or maximum heap size.
+         */
         return usedBytes.aboveThan(getMaximumHeapSize());
     }
 

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CollectionPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CollectionPolicy.java
@@ -67,6 +67,8 @@ public interface CollectionPolicy {
     @Platforms(Platform.HOSTED_ONLY.class)
     static Class<? extends CollectionPolicy> getPolicyClass(String name) {
         switch (name) {
+            case "Adaptive2":
+                return AdaptiveCollectionPolicy2.class;
             case "Adaptive":
                 return AdaptiveCollectionPolicy.class;
             case "LibGraal":

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CompactingOldGeneration.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CompactingOldGeneration.java
@@ -292,6 +292,7 @@ final class CompactingOldGeneration extends OldGeneration {
     }
 
     @Override
+    @Uninterruptible(reason = "Avoid unnecessary safepoint checks in GC for performance.")
     void sweepAndCompact(Timers timers, ChunkReleaser chunkReleaser) {
         /*
          * Update or clear reference object referent fields now because planning below overwrites
@@ -322,12 +323,13 @@ final class CompactingOldGeneration extends OldGeneration {
         }
     }
 
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     private void planCompaction() {
         planningVisitor.init(space);
         space.walkAlignedHeapChunks(planningVisitor);
     }
 
-    @Uninterruptible(reason = "Avoid unnecessary safepoint checks in GC for performance.")
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     private void fixupReferencesBeforeCompaction(ChunkReleaser chunkReleaser, Timers timers) {
         Timer oldFixupAlignedChunksTimer = timers.oldFixupAlignedChunks.start();
         try {
@@ -392,7 +394,7 @@ final class CompactingOldGeneration extends OldGeneration {
         }
     }
 
-    @Uninterruptible(reason = "Avoid unnecessary safepoint checks in GC for performance.")
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     private void fixupImageHeapRoots(ImageHeapInfo info) {
         if (HeapImpl.usesImageHeapCardMarking()) {
             // Note that cards have already been cleaned and roots re-marked during the initial scan
@@ -402,7 +404,7 @@ final class CompactingOldGeneration extends OldGeneration {
         }
     }
 
-    @Uninterruptible(reason = "Avoid unnecessary safepoint checks in GC for performance.")
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     private void fixupUnalignedChunkReferences(ChunkReleaser chunkReleaser) {
         UnalignedHeapChunk.UnalignedHeader uChunk = space.getFirstUnalignedHeapChunk();
         while (uChunk.isNonNull()) {
@@ -430,6 +432,7 @@ final class CompactingOldGeneration extends OldGeneration {
         GCImpl.walkStackRoots(refFixupVisitor, sp, false);
     }
 
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     private void compact(Timers timers) {
         AlignedHeapChunk.AlignedHeader chunk = space.getFirstAlignedHeapChunk();
         while (chunk.isNonNull()) {

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CompactingOldGeneration.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CompactingOldGeneration.java
@@ -24,6 +24,7 @@
  */
 package com.oracle.svm.core.genscavenge;
 
+import static com.oracle.svm.core.Uninterruptible.CALLED_FROM_UNINTERRUPTIBLE_CODE;
 import static com.oracle.svm.core.snippets.KnownIntrinsics.readCallerStackPointer;
 
 import org.graalvm.nativeimage.IsolateThread;
@@ -51,11 +52,15 @@ import com.oracle.svm.core.graal.RuntimeCompilation;
 import com.oracle.svm.core.heap.Heap;
 import com.oracle.svm.core.heap.ObjectHeader;
 import com.oracle.svm.core.heap.ObjectVisitor;
+import com.oracle.svm.core.hub.DynamicHub;
+import com.oracle.svm.core.hub.HubType;
 import com.oracle.svm.core.log.Log;
+import com.oracle.svm.core.snippets.KnownIntrinsics;
 import com.oracle.svm.core.thread.VMThreads;
 import com.oracle.svm.core.threadlocal.VMThreadLocalSupport;
 import com.oracle.svm.core.util.Timer;
 
+import jdk.graal.compiler.nodes.java.ArrayLengthNode;
 import jdk.graal.compiler.word.Word;
 
 /**
@@ -109,6 +114,7 @@ final class CompactingOldGeneration extends OldGeneration {
 
     private final Space space = new Space("Old", "O", false, HeapParameters.getMaxSurvivorSpaces() + 1);
     private final MarkStack markStack = new MarkStack();
+    private final MarkStack arrayMarkStack = new MarkStack();
 
     private final GreyObjectsWalker toGreyObjectsWalker = new GreyObjectsWalker();
     private final PlanningVisitor planningVisitor = new PlanningVisitor();
@@ -161,15 +167,54 @@ final class CompactingOldGeneration extends OldGeneration {
             }
             toGreyObjectsWalker.walkGreyObjects();
         } else {
-            if (markStack.isEmpty()) {
+            if (markStack.isEmpty() && arrayMarkStack.isEmpty()) {
                 return false;
             }
             GreyToBlackObjectVisitor visitor = GCImpl.getGCImpl().getGreyToBlackObjectVisitor();
             do {
-                visitor.visitObject(markStack.pop());
-            } while (!markStack.isEmpty());
+                while (!markStack.isEmpty()) {
+                    visitor.visitObject(markStack.popObject());
+                }
+
+                // Process array ranges one at a time to avoid bloating the marking stack
+                if (!arrayMarkStack.isEmpty()) {
+                    scanArrayRange(visitor);
+                }
+            } while (!markStack.isEmpty() || !arrayMarkStack.isEmpty());
         }
         return true;
+    }
+
+    @AlwaysInline("GC performance")
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+    private void pushOntoMarkStack(Object obj) {
+        DynamicHub objHub = KnownIntrinsics.readHub(obj);
+        if (objHub.getHubType() == HubType.OBJECT_ARRAY) {
+            if (ArrayLengthNode.arrayLength(obj) != 0) {
+                arrayMarkStack.pushObject(obj);
+                arrayMarkStack.pushInt(0);
+            }
+        } else {
+            markStack.pushObject(obj);
+        }
+    }
+
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+    private void scanArrayRange(GreyToBlackObjectVisitor visitor) {
+        int index = arrayMarkStack.popInt();
+        Object array = arrayMarkStack.popObject();
+
+        int length = ArrayLengthNode.arrayLength(array);
+        final int stride = 2048;
+        int endIndex = index + stride;
+        if (endIndex < length) {
+            arrayMarkStack.pushObject(array);
+            arrayMarkStack.pushInt(endIndex);
+        } else {
+            endIndex = length;
+        }
+
+        visitor.visitObjectArrayRange(array, index, endIndex - index);
     }
 
     @AlwaysInline("GC performance")
@@ -199,7 +244,7 @@ final class CompactingOldGeneration extends OldGeneration {
             assert !ObjectHeaderImpl.hasIdentityHashFromAddressInline(oh.readHeaderFromObject(result));
         }
         ObjectHeaderImpl.setMarked(result);
-        markStack.push(result);
+        pushOntoMarkStack(result);
         return result;
     }
 
@@ -215,7 +260,7 @@ final class CompactingOldGeneration extends OldGeneration {
         assert originalSpace == space;
         if (!ObjectHeaderImpl.isMarked(original)) {
             ObjectHeaderImpl.setMarked(original);
-            markStack.push(original);
+            pushOntoMarkStack(original);
         }
         return original;
     }
@@ -241,7 +286,7 @@ final class CompactingOldGeneration extends OldGeneration {
             ((AlignedHeapChunk.AlignedHeader) originalChunk).setShouldSweepInsteadOfCompact(true);
         }
         ObjectHeaderImpl.setMarked(obj);
-        markStack.push(obj);
+        pushOntoMarkStack(obj);
         return true;
     }
 
@@ -489,17 +534,20 @@ final class CompactingOldGeneration extends OldGeneration {
     @Override
     void checkSanityBeforeCollection() {
         assert markStack.isEmpty();
+        assert arrayMarkStack.isEmpty();
     }
 
     @Override
     void checkSanityAfterCollection() {
         assert markStack.isEmpty();
+        assert arrayMarkStack.isEmpty();
     }
 
     @Override
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     void tearDown() {
         markStack.tearDown();
+        arrayMarkStack.tearDown();
         space.tearDown();
     }
 }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CompactingOldGeneration.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CompactingOldGeneration.java
@@ -339,6 +339,17 @@ final class CompactingOldGeneration extends OldGeneration {
             oldFixupAlignedChunksTimer.stop();
         }
 
+        /*
+         * Check each unaligned object and fix its references if the object is marked. Add the chunk
+         * to the releaser's list in case the object is not marked and therefore won't survive.
+         */
+        Timer oldFixupUnalignedChunksTimer = timers.oldFixupUnalignedChunks.start();
+        try {
+            fixupUnalignedChunkReferences(chunkReleaser);
+        } finally {
+            oldFixupUnalignedChunksTimer.stop();
+        }
+
         Timer oldFixupImageHeapTimer = timers.oldFixupImageHeap.start();
         try {
             for (ImageHeapInfo info : HeapImpl.getImageHeapInfos()) {
@@ -368,17 +379,6 @@ final class CompactingOldGeneration extends OldGeneration {
             fixupStackReferences();
         } finally {
             oldFixupStackTimer.stop();
-        }
-
-        /*
-         * Check each unaligned object and fix its references if the object is marked. Add the chunk
-         * to the releaser's list in case the object is not marked and therefore won't survive.
-         */
-        Timer oldFixupUnalignedChunksTimer = timers.oldFixupUnalignedChunks.start();
-        try {
-            fixupUnalignedChunkReferences(chunkReleaser);
-        } finally {
-            oldFixupUnalignedChunksTimer.stop();
         }
 
         Timer oldFixupRuntimeCodeCacheTimer = timers.oldFixupRuntimeCodeCache.start();

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CompactingOldGeneration.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CompactingOldGeneration.java
@@ -131,8 +131,8 @@ final class CompactingOldGeneration extends OldGeneration {
 
     @Override
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    void beginPromotion(boolean incrementalGc) {
-        if (!incrementalGc) {
+    void beginPromotion(boolean completeCollection) {
+        if (completeCollection) {
             absorb(HeapImpl.getHeapImpl().getYoungGeneration());
         }
         toGreyObjectsWalker.setScanStart(space);
@@ -160,28 +160,29 @@ final class CompactingOldGeneration extends OldGeneration {
 
     @Override
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    boolean scanGreyObjects(boolean incrementalGc) {
-        if (incrementalGc) {
+    boolean scanGreyObjects(boolean completeCollection) {
+        if (!completeCollection) {
             if (!toGreyObjectsWalker.haveGreyObjects()) {
                 return false;
             }
             toGreyObjectsWalker.walkGreyObjects();
-        } else {
-            if (markStack.isEmpty() && arrayMarkStack.isEmpty()) {
-                return false;
-            }
-            GreyToBlackObjectVisitor visitor = GCImpl.getGCImpl().getGreyToBlackObjectVisitor();
-            do {
-                while (!markStack.isEmpty()) {
-                    visitor.visitObject(markStack.popObject());
-                }
-
-                // Process array ranges one at a time to avoid bloating the marking stack
-                if (!arrayMarkStack.isEmpty()) {
-                    scanArrayRange(visitor);
-                }
-            } while (!markStack.isEmpty() || !arrayMarkStack.isEmpty());
+            return true;
         }
+
+        if (markStack.isEmpty() && arrayMarkStack.isEmpty()) {
+            return false;
+        }
+        GreyToBlackObjectVisitor visitor = GCImpl.getGCImpl().getGreyToBlackObjectVisitor();
+        do {
+            while (!markStack.isEmpty()) {
+                visitor.visitObject(markStack.popObject());
+            }
+
+            // Process array ranges one at a time to avoid bloating the marking stack
+            if (!arrayMarkStack.isEmpty()) {
+                scanArrayRange(visitor);
+            }
+        } while (!markStack.isEmpty() || !arrayMarkStack.isEmpty());
         return true;
     }
 

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CopyingOldGeneration.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CopyingOldGeneration.java
@@ -107,8 +107,8 @@ final class CopyingOldGeneration extends OldGeneration {
 
     @Override
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    void beginPromotion(boolean incrementalGc) {
-        if (incrementalGc) {
+    void beginPromotion(boolean completeCollection) {
+        if (!completeCollection) {
             emptyFromSpaceIntoToSpace();
         }
         toGreyObjectsWalker.setScanStart(getToSpace());
@@ -116,7 +116,7 @@ final class CopyingOldGeneration extends OldGeneration {
 
     @Override
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    boolean scanGreyObjects(boolean incrementalGc) {
+    boolean scanGreyObjects(boolean completeCollection) {
         if (!toGreyObjectsWalker.haveGreyObjects()) {
             return false;
         }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CopyingOldGeneration.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CopyingOldGeneration.java
@@ -39,8 +39,15 @@ import com.oracle.svm.core.log.Log;
 import jdk.graal.compiler.word.Word;
 
 /**
- * An OldGeneration has two Spaces, {@link #fromSpace} for existing objects, and {@link #toSpace}
- * for newly-allocated or promoted objects.
+ * This old generation has two spaces, {@link #fromSpace} for all objects, and {@link #toSpace}, to
+ * which live objects are copied during a collection (at the end of which, the spaces are swapped).
+ *
+ * Unlike with survivor spaces in the young generation, {@link AbstractCollectionPolicy} does not
+ * reserve half of the old generation size for {@link #toSpace}, so a collection can temporarily
+ * exceed the maximum old generation or maximum heap size by up to {@link #fromSpace}'s size.
+ *
+ * In other words, in extreme cases, memory consumption during a collection can be up to 2x of the
+ * current heap size, or even the configured maximum heap size.
  */
 final class CopyingOldGeneration extends OldGeneration {
     /* These Spaces are final and are flipped by transferring chunks from one to the other. */

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/DynamicCollectionPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/DynamicCollectionPolicy.java
@@ -32,9 +32,9 @@ import com.oracle.svm.core.heap.DynamicHeapSizeManager;
 /**
  * This class provides the implementation of a dynamic collection policy that calls into an instance
  * of {@link DynamicHeapSizeManager} if it exists, otherwise the implementation is equivalent to
- * {@link AdaptiveCollectionPolicy}.
+ * {@link AdaptiveCollectionPolicy2}.
  */
-class DynamicCollectionPolicy extends AdaptiveCollectionPolicy {
+class DynamicCollectionPolicy extends AdaptiveCollectionPolicy2 {
     @Override
     public String getName() {
         return "dynamic";

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/FillerObjectUtil.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/FillerObjectUtil.java
@@ -41,7 +41,6 @@ import com.oracle.svm.core.util.UnsignedUtils;
 
 import jdk.graal.compiler.api.replacements.Fold;
 import jdk.graal.compiler.core.common.NumUtil;
-import jdk.graal.compiler.word.Word;
 import jdk.vm.ci.meta.JavaKind;
 
 public class FillerObjectUtil {
@@ -50,8 +49,8 @@ public class FillerObjectUtil {
     private static final int ARRAY_ELEMENT_SIZE = ARRAY_ELEMENT_KIND.getByteCount();
 
     @Fold
-    public static UnsignedWord objectMinSize() {
-        return Word.unsigned(ConfigurationValues.getObjectLayout().getMinImageHeapObjectSize());
+    static int instanceMinSize() {
+        return ConfigurationValues.getObjectLayout().getMinRuntimeHeapInstanceSize();
     }
 
     @Fold
@@ -66,7 +65,7 @@ public class FillerObjectUtil {
 
     @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     public static void writeFillerObjectAt(Pointer p, UnsignedWord size, boolean rememberedSet) {
-        assert size.aboveThan(0);
+        assert size.equal(instanceMinSize()) || size.aboveOrEqual(arrayMinSize());
         if (size.aboveOrEqual(arrayMinSize())) {
             int length = UnsignedUtils.safeToInt(size.subtract(arrayBaseOffset()).unsignedDivide(ARRAY_ELEMENT_SIZE));
             FormatArrayNode.formatArray(p, ARRAY_CLASS, length, rememberedSet, false, WITH_GARBAGE_IF_ASSERTIONS_ENABLED, false);

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCAccounting.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCAccounting.java
@@ -53,7 +53,6 @@ public final class GCAccounting {
     private boolean lastIncrementalCollectionOverflowedSurvivors = false;
 
     /* Before and after measures. */
-    private UnsignedWord edenChunkBytesBefore = Word.zero();
     private UnsignedWord youngChunkBytesBefore = Word.zero();
     private UnsignedWord oldChunkBytesBefore = Word.zero();
     private UnsignedWord oldChunkBytesAfter = Word.zero();
@@ -116,10 +115,6 @@ public final class GCAccounting {
         return youngChunkBytesBefore;
     }
 
-    public UnsignedWord getEdenChunkBytesBefore() {
-        return edenChunkBytesBefore;
-    }
-
     UnsignedWord getLastIncrementalCollectionPromotedChunkBytes() {
         return lastIncrementalCollectionPromotedChunkBytes;
     }
@@ -134,7 +129,6 @@ public final class GCAccounting {
         YoungGeneration youngGen = heap.getYoungGeneration();
         OldGeneration oldGen = heap.getOldGeneration();
 
-        edenChunkBytesBefore = youngGen.getEden().getChunkBytes();
         youngChunkBytesBefore = youngGen.getChunkBytes();
         oldChunkBytesBefore = oldGen.getChunkBytes();
 

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCAccounting.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCAccounting.java
@@ -103,6 +103,10 @@ public final class GCAccounting {
         return allocatedObjectBytes;
     }
 
+    UnsignedWord getOldGenerationBeforeChunkBytes() {
+        return oldChunkBytesBefore;
+    }
+
     UnsignedWord getOldGenerationAfterChunkBytes() {
         return oldChunkBytesAfter;
     }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCAccounting.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCAccounting.java
@@ -53,6 +53,7 @@ public final class GCAccounting {
     private boolean lastIncrementalCollectionOverflowedSurvivors = false;
 
     /* Before and after measures. */
+    private UnsignedWord edenChunkBytesBefore = Word.zero();
     private UnsignedWord youngChunkBytesBefore = Word.zero();
     private UnsignedWord oldChunkBytesBefore = Word.zero();
     private UnsignedWord oldChunkBytesAfter = Word.zero();
@@ -115,6 +116,10 @@ public final class GCAccounting {
         return youngChunkBytesBefore;
     }
 
+    public UnsignedWord getEdenChunkBytesBefore() {
+        return edenChunkBytesBefore;
+    }
+
     UnsignedWord getLastIncrementalCollectionPromotedChunkBytes() {
         return lastIncrementalCollectionPromotedChunkBytes;
     }
@@ -129,6 +134,7 @@ public final class GCAccounting {
         YoungGeneration youngGen = heap.getYoungGeneration();
         OldGeneration oldGen = heap.getOldGeneration();
 
+        edenChunkBytesBefore = youngGen.getEden().getChunkBytes();
         youngChunkBytesBefore = youngGen.getChunkBytes();
         oldChunkBytesBefore = oldGen.getChunkBytes();
 

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
@@ -322,7 +322,7 @@ public final class GCImpl implements GC {
 
         ChunkBasedCommittedMemoryProvider.get().beforeGarbageCollection();
 
-        boolean incremental = !forceNoIncremental && !policy.shouldCollectCompletely(false);
+        boolean incremental = !forceNoIncremental && !policy.shouldCollectCompletely(false, forceFullGC);
         boolean outOfMemory = false;
 
         if (incremental) {
@@ -333,7 +333,7 @@ public final class GCImpl implements GC {
                 JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), "Incremental GC", startTicks);
             }
         }
-        if (!incremental || outOfMemory || forceFullGC || policy.shouldCollectCompletely(incremental)) {
+        if (!incremental || outOfMemory || forceFullGC || policy.shouldCollectCompletely(incremental, forceFullGC)) {
             long beginNanoTime = initialBeginNanoTime;
             if (incremental) {
                 beginNanoTime = System.nanoTime();

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
@@ -363,7 +363,7 @@ public final class GCImpl implements GC {
         accounting.beforeCollectOnce(completeCollection);
         policy.onCollectionBegin(completeCollection, beginNanoTime);
 
-        doCollectCore(!complete);
+        doCollectCore();
         if (complete) {
             lastWholeHeapExaminedNanos = System.nanoTime();
         }
@@ -537,7 +537,7 @@ public final class GCImpl implements GC {
     }
 
     /** Collect, either incrementally or completely, and process discovered references. */
-    private void doCollectCore(boolean incremental) {
+    private void doCollectCore() {
         GreyToBlackObjRefVisitor.Counters counters = greyToBlackObjRefVisitor.openCounters();
         long startTicks;
         try {
@@ -546,15 +546,15 @@ public final class GCImpl implements GC {
                 startTicks = JfrGCEvents.startGCPhasePause();
                 try {
                     /* Scan reachable objects and potentially already copy them once discovered. */
-                    scan(incremental);
+                    scan();
                 } finally {
-                    JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), incremental ? "Incremental Scan" : "Scan", startTicks);
+                    JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), completeCollection ? "Scan" : "Incremental Scan", startTicks);
                 }
             } finally {
                 rootScanTimer.stop();
             }
 
-            if (!incremental) {
+            if (completeCollection) {
                 /* Sweep or compact objects in the old generation unless already done by copying. */
                 HeapImpl.getHeapImpl().getOldGeneration().sweepAndCompact(timers, chunkReleaser);
             }
@@ -604,7 +604,7 @@ public final class GCImpl implements GC {
                      * chunks for copying live old objects with fewer chunk allocations. In either
                      * case, excess chunks are released later.
                      */
-                    boolean keepAllAlignedChunks = !SerialGCOptions.useCompactingOldGen() && incremental;
+                    boolean keepAllAlignedChunks = !SerialGCOptions.useCompactingOldGen() && !completeCollection;
                     chunkReleaser.release(keepAllAlignedChunks);
                 } finally {
                     JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), "Release Spaces", startTicks);
@@ -649,11 +649,11 @@ public final class GCImpl implements GC {
     }
 
     @Uninterruptible(reason = "We don't want any safepoint checks in the core part of the GC.")
-    private void scan(boolean incremental) {
-        if (incremental) {
-            scanFromDirtyRoots();
-        } else {
+    private void scan() {
+        if (completeCollection) {
             scanFromRoots();
+        } else {
+            scanFromDirtyRoots();
         }
     }
 
@@ -668,7 +668,7 @@ public final class GCImpl implements GC {
                  * When using a compacting old generation, it absorbs all chunks from the young
                  * generation at this point.
                  */
-                beginPromotion(false);
+                beginPromotion();
             } finally {
                 JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), "Snapshot Heap", startTicks);
             }
@@ -707,7 +707,7 @@ public final class GCImpl implements GC {
             startTicks = JfrGCEvents.startGCPhasePause();
             try {
                 /* Visit all the Objects promoted since the snapshot. */
-                scanGreyObjects(false);
+                scanGreyObjects();
 
                 if (RuntimeCompilation.isEnabled()) {
                     /*
@@ -716,7 +716,7 @@ public final class GCImpl implements GC {
                     walkRuntimeCodeCache();
 
                     /* Visit all objects that became reachable because of the compiled code. */
-                    scanGreyObjects(false);
+                    scanGreyObjects();
                 }
             } finally {
                 JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), "Scan From Roots", startTicks);
@@ -734,7 +734,7 @@ public final class GCImpl implements GC {
 
             try {
                 /* Snapshot the heap so that objects that are promoted afterwards can be visited. */
-                beginPromotion(true);
+                beginPromotion();
             } finally {
                 JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), "Snapshot Heap", startTicks);
             }
@@ -782,7 +782,7 @@ public final class GCImpl implements GC {
             startTicks = JfrGCEvents.startGCPhasePause();
             try {
                 /* Visit all the Objects promoted since the snapshot, transitively. */
-                scanGreyObjects(true);
+                scanGreyObjects();
 
                 if (RuntimeCompilation.isEnabled()) {
                     /*
@@ -791,7 +791,7 @@ public final class GCImpl implements GC {
                     walkRuntimeCodeCache();
 
                     /* Visit all objects that became reachable because of the compiled code. */
-                    scanGreyObjects(true);
+                    scanGreyObjects();
                 }
             } finally {
                 JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), "Scan From Roots", startTicks);
@@ -1016,22 +1016,22 @@ public final class GCImpl implements GC {
     }
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    private static void beginPromotion(boolean isIncremental) {
+    private void beginPromotion() {
         HeapImpl heap = HeapImpl.getHeapImpl();
-        heap.getOldGeneration().beginPromotion(isIncremental);
-        if (isIncremental) {
+        heap.getOldGeneration().beginPromotion(completeCollection);
+        if (!completeCollection) {
             heap.getYoungGeneration().beginPromotion();
         }
     }
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    private void scanGreyObjects(boolean isIncremental) {
+    private void scanGreyObjects() {
         Timer scanGreyObjectsTimer = timers.scanGreyObjects.start();
         try {
-            if (isIncremental) {
+            if (!completeCollection) {
                 incrementalScanGreyObjectsLoop();
             } else {
-                HeapImpl.getHeapImpl().getOldGeneration().scanGreyObjects(false);
+                HeapImpl.getHeapImpl().getOldGeneration().scanGreyObjects(true);
             }
         } finally {
             scanGreyObjectsTimer.stop();
@@ -1046,7 +1046,7 @@ public final class GCImpl implements GC {
         boolean hasGrey;
         do {
             hasGrey = youngGen.scanGreyObjects();
-            hasGrey |= oldGen.scanGreyObjects(true);
+            hasGrey |= oldGen.scanGreyObjects(false);
         } while (hasGrey);
     }
 

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
@@ -242,8 +242,23 @@ public final class GCImpl implements GC {
         assert getCollectionEpoch().equal(data.getRequestingEpoch()) ||
                         data.getForceFullGC() && GCImpl.getAccounting().getCompleteCollectionCount() == data.getCompleteCollectionCount() : "unnecessary GC?";
 
-        timers.mutator.stopAt(data.getRequestingNanoTime());
+        /*
+         * We use the time of the GC request as the beginning of the collection because it includes
+         * the delay of entering a safepoint, which we want the policy to consider for GC cost.
+         * Other VM operations can run in between, but we expect them to have insignificant impact.
+         */
+        long beginNanoTime = data.getRequestingNanoTime();
+        if (getCollectionEpoch().notEqual(data.getRequestingEpoch())) {
+            /* Another GC happened since the GC request, use the current time instead. */
+            beginNanoTime = System.nanoTime();
+        }
+        if (!timers.mutator.wasStartedAtLeastOnce()) {
+            long origin = Isolates.isStartTimeAssigned() ? Isolates.getStartTimeNanos() : beginNanoTime;
+            timers.mutator.startAt(origin);
+        }
+        timers.mutator.stopAt(beginNanoTime);
         timers.resetAllExceptMutator();
+
         /* The type of collection will be determined later on. */
         completeCollection = false;
 
@@ -260,7 +275,7 @@ public final class GCImpl implements GC {
 
             verifyHeap(Before);
 
-            boolean outOfMemory = collectImpl(cause, data.getRequestingNanoTime(), data.getForceFullGC());
+            boolean outOfMemory = collectImpl(cause, beginNanoTime, data.getForceFullGC());
             data.setOutOfMemory(outOfMemory);
 
             verifyHeap(After);
@@ -281,18 +296,17 @@ public final class GCImpl implements GC {
         timers.mutator.start();
     }
 
-    private boolean collectImpl(GCCause cause, long requestingNanoTime, boolean forceFullGC) {
+    private boolean collectImpl(GCCause cause, long beginNanoTime, boolean forceFullGC) {
         boolean outOfMemory;
         long startTicks = JfrTicks.elapsedTicks();
         try {
-            outOfMemory = doCollectImpl(cause, requestingNanoTime, forceFullGC, false);
+            outOfMemory = doCollectImpl(cause, beginNanoTime, forceFullGC, false);
             if (outOfMemory) {
-                // Avoid running out of memory with a full GC that reclaims softly reachable
-                // objects
+                // Avoid running out of memory with a full GC that reclaims softly reachable objects
                 ReferenceObjectProcessing.setSoftReferencesAreWeak(true);
                 try {
                     verifyHeap(During);
-                    outOfMemory = doCollectImpl(cause, requestingNanoTime, true, true);
+                    outOfMemory = doCollectImpl(cause, System.nanoTime(), true, true);
                 } finally {
                     ReferenceObjectProcessing.setSoftReferencesAreWeak(false);
                 }
@@ -303,7 +317,7 @@ public final class GCImpl implements GC {
         return outOfMemory;
     }
 
-    private boolean doCollectImpl(GCCause cause, long requestingNanoTime, boolean forceFullGC, boolean forceNoIncremental) {
+    private boolean doCollectImpl(GCCause cause, long initialBeginNanoTime, boolean forceFullGC, boolean forceNoIncremental) {
         checkSanityBeforeCollection();
 
         ChunkBasedCommittedMemoryProvider.get().beforeGarbageCollection();
@@ -314,19 +328,21 @@ public final class GCImpl implements GC {
         if (incremental) {
             long startTicks = JfrGCEvents.startGCPhasePause();
             try {
-                outOfMemory = doCollectOnce(cause, requestingNanoTime, false, false);
+                outOfMemory = doCollectOnce(cause, initialBeginNanoTime, false, false);
             } finally {
                 JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), "Incremental GC", startTicks);
             }
         }
         if (!incremental || outOfMemory || forceFullGC || policy.shouldCollectCompletely(incremental)) {
-            if (incremental) { // uncommit unaligned chunks
-                ChunkBasedCommittedMemoryProvider.get().uncommitUnusedMemory();
+            long beginNanoTime = initialBeginNanoTime;
+            if (incremental) {
+                beginNanoTime = System.nanoTime();
+                ChunkBasedCommittedMemoryProvider.get().uncommitUnusedMemory(); // unaligned chunks
                 verifyHeap(During);
             }
             long startTicks = JfrGCEvents.startGCPhasePause();
             try {
-                outOfMemory = doCollectOnce(cause, requestingNanoTime, true, incremental);
+                outOfMemory = doCollectOnce(cause, beginNanoTime, true, incremental);
             } finally {
                 JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), "Full GC", startTicks);
             }
@@ -339,13 +355,13 @@ public final class GCImpl implements GC {
         return outOfMemory;
     }
 
-    private boolean doCollectOnce(GCCause cause, long requestingNanoTime, boolean complete, boolean followsIncremental) {
+    private boolean doCollectOnce(GCCause cause, long beginNanoTime, boolean complete, boolean followsIncremental) {
         assert !followsIncremental || complete : "An incremental collection cannot be followed by another incremental collection";
         assert !completeCollection || complete : "After a complete collection, no further incremental collections may happen";
         completeCollection = complete;
 
         accounting.beforeCollectOnce(completeCollection);
-        policy.onCollectionBegin(completeCollection, requestingNanoTime);
+        policy.onCollectionBegin(completeCollection, beginNanoTime);
 
         doCollectCore(!complete);
         if (complete) {

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
@@ -650,154 +650,68 @@ public final class GCImpl implements GC {
 
     @Uninterruptible(reason = "We don't want any safepoint checks in the core part of the GC.")
     private void scan() {
-        if (completeCollection) {
+        Timer timer = completeCollection ? timers.scanFromRoots : timers.scanFromDirtyRoots;
+        timer.start();
+        try {
             scanFromRoots();
-        } else {
-            scanFromDirtyRoots();
+        } finally {
+            timer.stop();
         }
     }
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     private void scanFromRoots() {
-        Timer scanFromRootsTimer = timers.scanFromRoots.start();
+        long startTicks = JfrGCEvents.startGCPhasePause();
+
         try {
-            long startTicks = JfrGCEvents.startGCPhasePause();
-            try {
-                /*
-                 * Snapshot the heap so that objects that are promoted afterwards can be visited.
-                 * When using a compacting old generation, it absorbs all chunks from the young
-                 * generation at this point.
-                 */
-                beginPromotion();
-            } finally {
-                JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), "Snapshot Heap", startTicks);
-            }
-
-            startTicks = JfrGCEvents.startGCPhasePause();
-            try {
-                /*
-                 * Make sure all chunks with pinned objects are in toSpace, and any formerly pinned
-                 * objects are in fromSpace.
-                 */
-                promoteChunksWithPinnedObjects();
-            } finally {
-                JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), "Promote Pinned Objects", startTicks);
-            }
-
-            startTicks = JfrGCEvents.startGCPhasePause();
-            try {
-                /*
-                 * Stack references are grey at the beginning of a collection, so I need to blacken
-                 * them.
-                 */
-                blackenStackRoots();
-
-                /* Custom memory regions which contain object references. */
-                walkThreadLocals();
-
-                /*
-                 * Native image Objects are grey at the beginning of a collection, so I need to
-                 * blacken them.
-                 */
-                blackenImageHeapRoots();
-            } finally {
-                JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), "Scan Roots", startTicks);
-            }
-
-            startTicks = JfrGCEvents.startGCPhasePause();
-            try {
-                /* Visit all the Objects promoted since the snapshot. */
-                scanGreyObjects();
-
-                if (RuntimeCompilation.isEnabled()) {
-                    /*
-                     * Visit the runtime compiled code, now that we know all the reachable objects.
-                     */
-                    walkRuntimeCodeCache();
-
-                    /* Visit all objects that became reachable because of the compiled code. */
-                    scanGreyObjects();
-                }
-            } finally {
-                JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), "Scan From Roots", startTicks);
-            }
+            /* Snapshot the heap so that objects that are promoted afterwards can be visited. */
+            beginPromotion();
         } finally {
-            scanFromRootsTimer.stop();
+            JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), "Snapshot Heap", startTicks);
         }
-    }
 
-    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    private void scanFromDirtyRoots() {
-        Timer scanFromDirtyRootsTimer = timers.scanFromDirtyRoots.start();
+        startTicks = JfrGCEvents.startGCPhasePause();
         try {
-            long startTicks = JfrGCEvents.startGCPhasePause();
+            /*
+             * Make sure all aligned chunks with pinned objects are in To spaces so that pinned
+             * objects stay alive and cannot move.
+             */
+            promoteChunksWithPinnedObjects();
+        } finally {
+            JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), "Promote Pinned Objects", startTicks);
+        }
 
-            try {
-                /* Snapshot the heap so that objects that are promoted afterwards can be visited. */
-                beginPromotion();
-            } finally {
-                JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), "Snapshot Heap", startTicks);
-            }
-
-            startTicks = JfrGCEvents.startGCPhasePause();
-            try {
-                /*
-                 * Make sure any released objects are in toSpace (because this is an incremental
-                 * collection). I do this before blackening any roots to make sure the chunks with
-                 * pinned objects are moved entirely, as opposed to promoting the objects
-                 * individually by roots. This makes the objects in those chunks grey.
-                 */
-                promoteChunksWithPinnedObjects();
-            } finally {
-                JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), "Promote Pinned Objects", startTicks);
-            }
-
-            startTicks = JfrGCEvents.startGCPhasePause();
-            try {
+        startTicks = JfrGCEvents.startGCPhasePause();
+        try {
+            if (!completeCollection) {
                 /*
                  * Blacken Objects that are dirty roots. There are dirty cards in ToSpace. Do this
                  * early so I don't have to walk the cards of individually promoted objects, which
                  * will be visited by the grey object scanner.
                  */
                 blackenDirtyCardRoots();
-
-                /*
-                 * Stack references are grey at the beginning of a collection, so I need to blacken
-                 * them.
-                 */
-                blackenStackRoots();
-
-                /* Custom memory regions which contain object references. */
-                walkThreadLocals();
-
-                /*
-                 * Native image Objects are grey at the beginning of a collection, so I need to
-                 * blacken them.
-                 */
-                blackenDirtyImageHeapRoots();
-            } finally {
-                JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), "Scan Roots", startTicks);
             }
+            blackenStackRoots();
+            walkThreadLocals();
+            blackenImageHeapRoots();
+        } finally {
+            JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), "Scan Roots", startTicks);
+        }
 
-            startTicks = JfrGCEvents.startGCPhasePause();
-            try {
-                /* Visit all the Objects promoted since the snapshot, transitively. */
+        startTicks = JfrGCEvents.startGCPhasePause();
+        try {
+            /* Visit all the Objects promoted since the snapshot. */
+            scanGreyObjects();
+
+            if (RuntimeCompilation.isEnabled()) {
+                /* Visit the runtime compiled code, now that we know all the reachable objects. */
+                walkRuntimeCodeCache();
+
+                /* Visit all objects that became reachable because of the compiled code. */
                 scanGreyObjects();
-
-                if (RuntimeCompilation.isEnabled()) {
-                    /*
-                     * Visit the runtime compiled code, now that we know all the reachable objects.
-                     */
-                    walkRuntimeCodeCache();
-
-                    /* Visit all objects that became reachable because of the compiled code. */
-                    scanGreyObjects();
-                }
-            } finally {
-                JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), "Scan From Roots", startTicks);
             }
         } finally {
-            scanFromDirtyRootsTimer.stop();
+            JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), "Scan From Roots", startTicks);
         }
     }
 
@@ -924,22 +838,31 @@ public final class GCImpl implements GC {
     }
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    private void blackenDirtyImageHeapRoots() {
-        if (!HeapImpl.usesImageHeapCardMarking()) {
-            blackenImageHeapRoots();
-            return;
-        }
-
+    private void blackenImageHeapRoots() {
         Timer blackenImageHeapRootsTimer = timers.blackenImageHeapRoots.start();
         try {
+            /*
+             * Avoid scanning the entire image heap even for complete collections: its remembered
+             * set contains references into both the runtime heap's old and young generations.
+             */
+            boolean onlyDirty = HeapImpl.usesImageHeapCardMarking();
+
             for (ImageHeapInfo info : HeapImpl.getImageHeapInfos()) {
-                blackenDirtyImageHeapChunkRoots(info);
+                if (onlyDirty) {
+                    blackenDirtyImageHeapChunkRoots(info);
+                } else {
+                    blackenImageHeapRoots(info);
+                }
             }
 
             if (AuxiliaryImageHeap.isPresent()) {
                 ImageHeapInfo auxInfo = AuxiliaryImageHeap.singleton().getImageHeapInfo();
                 if (auxInfo != null) {
-                    blackenDirtyImageHeapChunkRoots(auxInfo);
+                    if (onlyDirty) {
+                        blackenDirtyImageHeapChunkRoots(auxInfo);
+                    } else {
+                        blackenImageHeapRoots(auxInfo);
+                    }
                 }
             }
         } finally {
@@ -960,33 +883,8 @@ public final class GCImpl implements GC {
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     static void walkDirtyImageHeapChunkRoots(ImageHeapInfo info, UninterruptibleObjectVisitor visitor, UninterruptibleObjectReferenceVisitor refVisitor, boolean clean) {
+        assert HeapImpl.usesImageHeapCardMarking();
         RememberedSet.get().walkDirtyObjects(info.getFirstWritableAlignedChunk(), info.getFirstWritableUnalignedChunk(), info.getLastWritableUnalignedChunk(), visitor, refVisitor, clean);
-    }
-
-    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    private void blackenImageHeapRoots() {
-        if (HeapImpl.usesImageHeapCardMarking()) {
-            // Avoid scanning the entire image heap even for complete collections: its remembered
-            // set contains references into both the runtime heap's old and young generations.
-            blackenDirtyImageHeapRoots();
-            return;
-        }
-
-        Timer blackenImageHeapRootsTimer = timers.blackenImageHeapRoots.start();
-        try {
-            for (ImageHeapInfo info : HeapImpl.getImageHeapInfos()) {
-                blackenImageHeapRoots(info);
-            }
-
-            if (AuxiliaryImageHeap.isPresent()) {
-                ImageHeapInfo auxImageHeapInfo = AuxiliaryImageHeap.singleton().getImageHeapInfo();
-                if (auxImageHeapInfo != null) {
-                    blackenImageHeapRoots(auxImageHeapInfo);
-                }
-            }
-        } finally {
-            blackenImageHeapRootsTimer.stop();
-        }
     }
 
     @Uninterruptible(reason = "Forced inlining (StoredContinuation objects must not move).")
@@ -1003,6 +901,7 @@ public final class GCImpl implements GC {
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     private void blackenDirtyCardRoots() {
+        assert !completeCollection : "only call for incremental collections";
         Timer blackenDirtyCardRootsTimer = timers.blackenDirtyCardRoots.start();
         try {
             /*
@@ -1028,10 +927,10 @@ public final class GCImpl implements GC {
     private void scanGreyObjects() {
         Timer scanGreyObjectsTimer = timers.scanGreyObjects.start();
         try {
-            if (!completeCollection) {
-                incrementalScanGreyObjectsLoop();
-            } else {
+            if (completeCollection) {
                 HeapImpl.getHeapImpl().getOldGeneration().scanGreyObjects(true);
+            } else {
+                incrementalScanGreyObjectsLoop();
             }
         } finally {
             scanGreyObjectsTimer.stop();
@@ -1039,7 +938,8 @@ public final class GCImpl implements GC {
     }
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    private static void incrementalScanGreyObjectsLoop() {
+    private void incrementalScanGreyObjectsLoop() {
+        assert !completeCollection;
         HeapImpl heap = HeapImpl.getHeapImpl();
         YoungGeneration youngGen = heap.getYoungGeneration();
         OldGeneration oldGen = heap.getOldGeneration();

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
@@ -133,6 +133,7 @@ public final class GCImpl implements GC {
 
     private final CollectionPolicy policy;
     private boolean completeCollection = false;
+    private boolean outOfMemoryCollection = false;
     private UnsignedWord collectionEpoch = Word.zero();
     private long lastWholeHeapExaminedNanos = -1;
 
@@ -302,13 +303,12 @@ public final class GCImpl implements GC {
         try {
             outOfMemory = doCollectImpl(cause, beginNanoTime, forceFullGC, false);
             if (outOfMemory) {
-                // Avoid running out of memory with a full GC that reclaims softly reachable objects
-                ReferenceObjectProcessing.setSoftReferencesAreWeak(true);
+                outOfMemoryCollection = true; // increase eagerness to free memory
                 try {
                     verifyHeap(During);
                     outOfMemory = doCollectImpl(cause, System.nanoTime(), true, true);
                 } finally {
-                    ReferenceObjectProcessing.setSoftReferencesAreWeak(false);
+                    outOfMemoryCollection = false;
                 }
             }
         } finally {
@@ -520,9 +520,20 @@ public final class GCImpl implements GC {
         collect(cause, true);
     }
 
+    @AlwaysInline("GC performance")
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public boolean isCompleteCollection() {
         return completeCollection;
+    }
+
+    /**
+     * Whether the current collection is intended to be more aggressive as a last resort to avoid an
+     * out of memory condition.
+     */
+    @AlwaysInline("GC performance")
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    public boolean isOutOfMemoryCollection() {
+        return outOfMemoryCollection;
     }
 
     /** Collect, either incrementally or completely, and process discovered references. */

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GreyToBlackObjectVisitor.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GreyToBlackObjectVisitor.java
@@ -24,6 +24,8 @@
  */
 package com.oracle.svm.core.genscavenge;
 
+import static com.oracle.svm.core.Uninterruptible.CALLED_FROM_UNINTERRUPTIBLE_CODE;
+
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
 
@@ -52,5 +54,10 @@ public final class GreyToBlackObjectVisitor implements UninterruptibleObjectVisi
     public void visitObject(Object o) {
         ReferenceObjectProcessing.discoverIfReference(o, objRefVisitor);
         InteriorObjRefWalker.walkObjectInline(o, objRefVisitor);
+    }
+
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+    public void visitObjectArrayRange(Object o, int firstIndex, int count) {
+        InteriorObjRefWalker.walkObjectArrayRangeInline(o, firstIndex, count, objRefVisitor);
     }
 }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapChunk.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapChunk.java
@@ -24,11 +24,13 @@
  */
 package com.oracle.svm.core.genscavenge;
 
+import static com.oracle.svm.core.Uninterruptible.CALLED_FROM_UNINTERRUPTIBLE_CODE;
+
 import java.util.function.IntUnaryOperator;
 
 import org.graalvm.nativeimage.c.struct.RawField;
-import org.graalvm.nativeimage.c.struct.RawFieldOffset;
 import org.graalvm.nativeimage.c.struct.RawFieldAddress;
+import org.graalvm.nativeimage.c.struct.RawFieldOffset;
 import org.graalvm.nativeimage.c.struct.RawStructure;
 import org.graalvm.nativeimage.c.struct.UniqueLocationIdentity;
 import org.graalvm.word.ComparableWord;
@@ -357,6 +359,7 @@ public final class HeapChunk {
         }
     }
 
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     public static HeapChunk.Header<?> getEnclosingHeapChunk(Pointer ptrToObj, UnsignedWord header) {
         if (ObjectHeaderImpl.isAlignedHeader(header)) {
             return AlignedHeapChunk.getEnclosingChunkFromObjectPointer(ptrToObj);

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/LibGraalCollectionPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/LibGraalCollectionPolicy.java
@@ -110,9 +110,9 @@ class LibGraalCollectionPolicy extends AdaptiveCollectionPolicy {
     }
 
     @Override
-    public void onCollectionBegin(boolean completeCollection, long requestingNanoTime) {
+    public void onCollectionBegin(boolean completeCollection, long beginNanoTime) {
         sizeBefore = GCImpl.getChunkBytes();
-        super.onCollectionBegin(completeCollection, requestingNanoTime);
+        super.onCollectionBegin(completeCollection, beginNanoTime);
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/LibGraalCollectionPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/LibGraalCollectionPolicy.java
@@ -42,7 +42,7 @@ import jdk.graal.compiler.word.Word;
  * less concern about defending against that. It's also expected that 16G is a reasonable limit for
  * a libgraal JIT compilation.
  */
-class LibGraalCollectionPolicy extends AdaptiveCollectionPolicy {
+final class LibGraalCollectionPolicy extends AdaptiveCollectionPolicy2 {
 
     public static final class Options {
         @Option(help = "Ratio of used bytes to total allocated bytes for eden space. Setting it to a smaller value " +
@@ -118,18 +118,15 @@ class LibGraalCollectionPolicy extends AdaptiveCollectionPolicy {
     @Override
     public void onCollectionEnd(boolean completeCollection, GCCause cause) {
         super.onCollectionEnd(completeCollection, cause);
+        // Note: this might adjust eden size after a full collection when the base policy does not.
+        maybeAdjustEdenSize(completeCollection, cause);
         sizeBefore = Word.zero();
         lastGCCause = cause;
     }
 
-    @Override
-    protected boolean shouldUpdateStats(GCCause cause) {
-        return cause == GCCause.HintedGC || super.shouldUpdateStats(cause);
-    }
-
     /**
-     * The adjusting logic are as follows:
-     * 
+     * Potentially adjust the size of the eden space, overriding decisions of the base policy.
+     *
      * 1. if we hit hinted GC twice in a row, there is no allocation failure in between. If the eden
      * space is previously expanded, we will aggressively shrink the eden space to half, such that
      * the memory footprint will be lower in subsequent execution.
@@ -138,8 +135,7 @@ class LibGraalCollectionPolicy extends AdaptiveCollectionPolicy {
      * continuously high memory consumption (e.g, a huge libgraal compilation). In such case, we
      * will double the eden space to avoid frequent GCs.
      */
-    @Override
-    protected void computeEdenSpaceSize(boolean completeCollection, GCCause cause) {
+    private void maybeAdjustEdenSize(boolean completeCollection, GCCause cause) {
         if (cause == GCCause.HintedGC) {
             if (completeCollection && lastGCCause == GCCause.HintedGC) {
                 UnsignedWord curEden = sizes.getEdenSize();
@@ -152,13 +148,16 @@ class LibGraalCollectionPolicy extends AdaptiveCollectionPolicy {
             UnsignedWord sizeAfter = GCImpl.getChunkBytes();
             if (sizeBefore.notEqual(0) && sizeBefore.belowThan(sizeAfter.multiply(2))) {
                 UnsignedWord curEden = sizes.getEdenSize();
-                UnsignedWord newEden = UnsignedUtils.min(computeEdenLimit(), alignUp(curEden.multiply(2)));
+                UnsignedWord newEden = UnsignedUtils.min(computeCurrentEdenLimit(), alignUp(curEden.multiply(2)));
                 if (curEden.belowThan(newEden)) {
                     sizes.setEdenSize(newEden);
                 }
-            } else {
-                super.computeEdenSpaceSize(completeCollection, cause);
             }
         }
+    }
+
+    /** The maximum size of eden given the current size of the survivor spaces. */
+    private UnsignedWord computeCurrentEdenLimit() {
+        return alignDown(sizes.getMaxYoungSize().subtract(sizes.getSurvivorSize().multiply(2)));
     }
 }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/LinearLeastSquareFit.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/LinearLeastSquareFit.java
@@ -27,8 +27,8 @@ package com.oracle.svm.core.genscavenge;
 import com.oracle.svm.core.util.BasedOnJDKFile;
 
 /** LinearLeastSquareFit performs linear least-squares fitting and regression estimation. */
-@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/shared/gcUtil.hpp#L185-L213")
-@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/shared/gcUtil.cpp#L110-L168")
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25-ga/src/hotspot/share/gc/shared/gcUtil.hpp#L185-L213")
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25-ga/src/hotspot/share/gc/shared/gcUtil.cpp#L110-L168")
 public class LinearLeastSquareFit {
     /** Sum of all independent data points x. */
     private double sumX = 0;

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/LinearLeastSquareFit.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/LinearLeastSquareFit.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2025, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.genscavenge;
+
+import com.oracle.svm.core.util.BasedOnJDKFile;
+
+/** LinearLeastSquareFit performs linear least-squares fitting and regression estimation. */
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/shared/gcUtil.hpp#L185-L213")
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/gc/shared/gcUtil.cpp#L110-L168")
+public class LinearLeastSquareFit {
+    /** Sum of all independent data points x. */
+    private double sumX = 0;
+    /** Sum of all independent data points x**2. */
+    private double sumXSquared = 0;
+    /** Sum of all dependent data points y. */
+    private double sumY = 0;
+    /** Sum of all x*y. */
+    private double sumXY = 0;
+    /** Constant term. */
+    private double intercept = 0;
+    /** Slope. */
+    private double slope = 0;
+
+    /*
+     * The weighted averages are not currently used but perhaps should be used to get decaying
+     * averages.
+     */
+    /** Weighted mean of independent variable. */
+    private final AdaptiveWeightedAverage meanX;
+    /** Weighted mean of dependent variable. */
+    private final AdaptiveWeightedAverage meanY;
+
+    public LinearLeastSquareFit(int weight) {
+        meanX = new AdaptiveWeightedAverage(weight);
+        meanY = new AdaptiveWeightedAverage(weight);
+    }
+
+    public void update(double x, double y) {
+        sumX += x;
+        sumXSquared += x * x;
+        sumY += y;
+        sumXY += x * y;
+        meanX.sample(x);
+        meanY.sample(y);
+
+        assert meanX.getCount() == meanY.getCount();
+        if (meanX.getCount() > 1) {
+            double slopeDenominator = (meanX.getCount() * sumXSquared - sumX * sumX);
+            // Some tolerance should be injected here. A denominator that is
+            // nearly 0 should be avoided.
+
+            if (slopeDenominator != 0.0) {
+                double slopeNumerator = meanX.getCount() * sumXY - sumX * sumY;
+                slope = slopeNumerator / slopeDenominator;
+
+                // The meanY and meanX are decaying averages and can
+                // be used to discount earlier data. If they are used,
+                // first consider whether all the quantities should be
+                // kept as decaying averages.
+                // intercept = meanY.getAverage() - slope * meanX.getAverage();
+                intercept = (sumY - slope * sumX) / meanX.getCount();
+            }
+        }
+    }
+
+    public double y(double x) {
+        if (meanX.getCount() > 1) {
+            return intercept + slope * x;
+        } else {
+            return meanY.getAverage();
+        }
+    }
+
+    /*
+     * Methods to decide if a change in the dependent variable will achieve a desired goal. Note
+     * that these methods are not complementary and both are needed.
+     *
+     * Both decrementWillDecrease() and incrementWillDecrease() return true for a slope of 0. That
+     * is because a change is necessary before a slope can be calculated and a 0 slope will, in
+     * general, indicate that no calculation of the slope has yet been done. Returning true for a
+     * slope equal to 0 reflects the intuitive expectation of the dependence on the slope. Don't use
+     * the complement of these functions since that intuitive expectation is not built into the
+     * complement.
+     */
+
+    public boolean decrementWillDecrease() {
+        return slope >= 0.0;
+    }
+
+    public boolean incrementWillDecrease() {
+        return slope <= 0.0;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/NumberSeq.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/NumberSeq.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2025, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.genscavenge;
+
+import com.oracle.svm.core.util.BasedOnJDKFile;
+import com.oracle.svm.core.util.VMError;
+
+/**
+ * Abstract superclass for classes that represent number sequences, x1, x2, x3, ..., xN, and can
+ * calculate their avg, max, and sd.
+ *
+ * This class and its subclasses are ported from HotSpot. This class is named {@code AbsSeq} there.
+ */
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/utilities/numberSeq.hpp")
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/utilities/numberSeq.cpp")
+abstract class AbstractSeq {
+    /** The number of elements in the sequence. */
+    protected int num = 0;
+    /** The sum of the elements in the sequence. */
+    protected double sum = 0.0;
+    /** The sum of squares of the elements in the sequence. */
+    protected double sumOfSquares = 0.0;
+    /** Decaying average. */
+    protected double davg = 0.0;
+    /** Decaying variance. */
+    protected double dvariance = 0.0;
+    /** Factor for the decaying average / variance. */
+    protected final double alpha;
+
+    protected AbstractSeq(double alpha) {
+        this.alpha = alpha;
+    }
+
+    /**
+     * This is what we divide with to get the average. In a standard number, this should just be the
+     * number of elements in it.
+     */
+    protected double total() {
+        return num;
+    }
+
+    /** Adds a new element to the sequence. */
+    public void add(double val) {
+        if (num == 0) {
+            // if the sequence is empty, the davg is the same as the value
+            davg = val;
+            // and the variance is 0
+            dvariance = 0.0;
+        } else {
+            // otherwise, calculate both
+            // Formula from "Incremental calculation of weighted mean and variance" by Tony Finch
+            // diff := x - mean
+            // incr := alpha * diff
+            // mean := mean + incr
+            // variance := (1 - alpha) * (variance + diff * incr)
+            // PDF available at https://fanf2.user.srcf.net/hermes/doc/antiforgery/stats.pdf
+            double diff = val - davg;
+            double incr = alpha * diff;
+            davg += incr;
+            dvariance = (1.0 - alpha) * (dvariance + diff * incr);
+        }
+    }
+
+    /** Last element added in the sequence. */
+    public abstract double last();
+
+    /** The average of the sequence. */
+    public double avg() {
+        if (num == 0) {
+            return 0.0;
+        } else {
+            return sum / total();
+        }
+    }
+
+    public double getSum() {
+        return sum;
+    }
+
+    /** The variance of the sequence. */
+    public double variance() {
+        if (num <= 1) {
+            return 0.0;
+        }
+        double xBar = avg();
+        double result = sumOfSquares / total() - xBar * xBar;
+        if (result < 0.0) {
+            // Due to loss-of-precision errors, the variance might be negative by a small bit
+            result = 0.0;
+        }
+        return result;
+    }
+
+    /** The standard deviation of the sequence. */
+    public double sd() {
+        double v = variance();
+        VMError.guarantee(v >= 0.0);
+        return Math.sqrt(v);
+    }
+
+    /** Decaying average. */
+    public double davg() {
+        return davg;
+    }
+
+    /** Decaying variance. */
+    public double dvariance() {
+        if (num <= 1) {
+            return 0.0;
+        }
+        double result = dvariance;
+        if (result < 0.0) {
+            // due to loss-of-precision errors, the variance might be negative by a small bit
+            VMError.guarantee(result > -0.1, "if variance is negative, it should be very small");
+            result = 0.0;
+        }
+        return result;
+    }
+
+    /** Decaying "standard deviation". */
+    public double dsd() {
+        double v = dvariance();
+        VMError.guarantee(v >= 0.0);
+        return Math.sqrt(v);
+    }
+}
+
+/**
+ * The sequence is assumed to be very long and the maximum, avg, sd, davg, and dsd are calculated
+ * over all its elements.
+ */
+class NumberSeq extends AbstractSeq {
+    private double last = 0.0;
+    /** keep track of maximum value. */
+    private double maximum = 0.0;
+
+    /** Constructs a NumberSeq with the specified decay factor. */
+    NumberSeq(double alpha) {
+        super(alpha);
+    }
+
+    /** Adds a new value to the sequence. */
+    @Override
+    public void add(double val) {
+        super.add(val);
+
+        last = val;
+        if (num == 0) {
+            maximum = val;
+        } else if (val > maximum) {
+            maximum = val;
+        }
+        sum += val;
+        sumOfSquares += val * val;
+        num++;
+    }
+
+    /** Returns the last element added. */
+    @Override
+    public double last() {
+        return last;
+    }
+}
+
+/**
+ * This class keeps track of the last L elements of the sequence and calculates avg, max, and sd
+ * only over them.
+ */
+class TruncatedSeq extends AbstractSeq {
+    /** Buffers the last L elements in the sequence. */
+    private final double[] sequence;
+    /** This is L. */
+    private final int length;
+    /** Oldest slot in the array, i.e. next to be overwritten. */
+    private int next = 0;
+
+    /** Constructs with buffer length and decay alpha. */
+    TruncatedSeq(int length, double alpha) {
+        super(alpha);
+        this.length = length;
+        this.sequence = new double[length];
+    }
+
+    /** Adds a value, maintaining the buffer. */
+    @Override
+    public void add(double val) {
+        super.add(val);
+
+        // get the oldest value in the sequence...
+        double oldVal = sequence[next];
+        // ...remove it from the sum and sum of squares
+        sum -= oldVal;
+        sumOfSquares -= oldVal * oldVal;
+
+        // ...and update them with the new value
+        sum += val;
+        sumOfSquares += val * val;
+
+        // now replace the old value with the new one
+        sequence[next] = val;
+        next = (next + 1) % length;
+
+        // only increase it if the buffer is not full
+        if (num < length) {
+            num++;
+        }
+
+        VMError.guarantee(variance() > -1.0);
+    }
+
+    /** Returns the last value added. */
+    @Override
+    public double last() {
+        if (num == 0) {
+            return 0.0;
+        }
+        int lastIndex = (next + length - 1) % length;
+        return sequence[lastIndex];
+    }
+
+    /* Methods maximum(), oldest() and predict_next() are currently not needed. */
+}

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/NumberSeq.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/NumberSeq.java
@@ -33,8 +33,8 @@ import com.oracle.svm.core.util.VMError;
  *
  * This class and its subclasses are ported from HotSpot. This class is named {@code AbsSeq} there.
  */
-@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/utilities/numberSeq.hpp")
-@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+25/src/hotspot/share/utilities/numberSeq.cpp")
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25-ga/src/hotspot/share/utilities/numberSeq.hpp")
+@BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-25-ga/src/hotspot/share/utilities/numberSeq.cpp")
 abstract class AbstractSeq {
     /** The number of elements in the sequence. */
     protected int num = 0;

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/OldGeneration.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/OldGeneration.java
@@ -43,13 +43,13 @@ public abstract class OldGeneration extends Generation {
     }
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    abstract void beginPromotion(boolean incrementalGc);
+    abstract void beginPromotion(boolean completeCollection);
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     abstract void blackenDirtyCardRoots(GreyToBlackObjectVisitor visitor, GreyToBlackObjRefVisitor refVisitor);
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    abstract boolean scanGreyObjects(boolean incrementalGc);
+    abstract boolean scanGreyObjects(boolean completeCollection);
 
     abstract void sweepAndCompact(Timers timers, ChunkReleaser chunkReleaser);
 

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ProportionateSpacesPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ProportionateSpacesPolicy.java
@@ -84,7 +84,7 @@ final class ProportionateSpacesPolicy extends AbstractCollectionPolicy {
     }
 
     @Override
-    public void onCollectionBegin(boolean completeCollection, long requestingNanoTime) {
+    public void onCollectionBegin(boolean completeCollection, long beginNanoTime) {
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ProportionateSpacesPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ProportionateSpacesPolicy.java
@@ -47,14 +47,13 @@ final class ProportionateSpacesPolicy extends AbstractCollectionPolicy {
     static final int MAX_HEAP_FREE_RATIO = 70;
     static final boolean SHRINK_HEAP_IN_STEPS = true;
     static final int SURVIVOR_RATIO = 8;
-    static final int MAX_TENURING_THRESHOLD = 15;
     static final int TARGET_SURVIVOR_RATIO = 50;
 
     private boolean oldSizeExceededInPreviousCollection;
     private int shrinkFactor;
 
     ProportionateSpacesPolicy() {
-        super(NEW_RATIO, MAX_TENURING_THRESHOLD);
+        super(NEW_RATIO, HeapParameters.getMaxSurvivorSpaces());
     }
 
     @Override
@@ -109,17 +108,17 @@ final class ProportionateSpacesPolicy extends AbstractCollectionPolicy {
         // AgeTable::compute_tenuring_threshold
         YoungGeneration youngGen = HeapImpl.getHeapImpl().getYoungGeneration();
         UnsignedWord total = Word.zero();
-        int i;
-        for (i = 0; i < HeapParameters.getMaxSurvivorSpaces(); i++) {
-            Space space = youngGen.getSurvivorFromSpaceAt(0);
+        int age = 1;
+        while (age <= HeapParameters.getMaxSurvivorSpaces()) {
+            Space space = youngGen.getSurvivorFromSpaceAt(age - 1);
             total = total.add(space.getChunkBytes());
             if (total.aboveThan(desiredSurvivorSize)) {
                 break;
             }
-            i++;
+            age++;
         }
 
-        tenuringThreshold = Math.min(i + 1, MAX_TENURING_THRESHOLD);
+        tenuringThreshold = Math.min(age, HeapParameters.getMaxSurvivorSpaces());
     }
 
     private void computeNewOldGenSize(boolean resizeOnlyForPromotions) { // TenuredGeneration::compute_new_size_inner
@@ -197,8 +196,8 @@ final class ProportionateSpacesPolicy extends AbstractCollectionPolicy {
         UnsignedWord desiredNewSize = sizes.getOldSize().unsignedDivide(NEW_RATIO);
         desiredNewSize = UnsignedUtils.clamp(desiredNewSize, sizes.getInitialYoungSize(), sizes.getMaxYoungSize());
 
-        // DefNewGeneration::compute_space_boundaries, DefNewGeneration::compute_survivor_size
-        UnsignedWord newSurvivorSize = minSpaceSize(alignDown(desiredNewSize.unsignedDivide(SURVIVOR_RATIO)));
+        // DefNewGeneration::compute_space_boundaries
+        UnsignedWord newSurvivorSize = computeSurvivorSize(desiredNewSize);
         sizes.setSurvivorSize(newSurvivorSize);
 
         UnsignedWord desiredEdenSize = Word.zero();
@@ -208,5 +207,11 @@ final class ProportionateSpacesPolicy extends AbstractCollectionPolicy {
         UnsignedWord newEdenSize = minSpaceSize(alignDown(desiredEdenSize));
         sizes.setEdenSize(newEdenSize);
         assert newEdenSize.aboveThan(0) && newSurvivorSize.belowOrEqual(newEdenSize);
+    }
+
+    private UnsignedWord computeSurvivorSize(UnsignedWord genSize) { // DefNewGeneration::compute_survivor_size
+        UnsignedWord targetSurvivorSize = minSpaceSize(alignDown(genSize.unsignedDivide(SURVIVOR_RATIO)));
+        // Note that maxSurvivorSize is 0 when survivor spaces are disabled.
+        return UnsignedUtils.min(targetSurvivorSize, sizes.getMaxSurvivorSize());
     }
 }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ProportionateSpacesPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ProportionateSpacesPolicy.java
@@ -63,10 +63,14 @@ final class ProportionateSpacesPolicy extends AbstractCollectionPolicy {
     }
 
     @Override
-    public boolean shouldCollectCompletely(boolean followingIncrementalCollection) {
+    public boolean shouldCollectCompletely(boolean followingIncrementalCollection, boolean forcedCompleteCollection) {
         guaranteeSizeParametersInitialized();
 
-        if (!followingIncrementalCollection && shouldCollectYoungGenSeparately(false)) {
+        boolean collectYoungSeparately = shouldCollectYoungGenSeparately(false);
+        if (forcedCompleteCollection && !collectYoungSeparately) {
+            return true;
+        }
+        if (!followingIncrementalCollection && collectYoungSeparately) {
             // Note that for non-ParallelGC, HotSpot resets the default of ScavengeBeforeFullGC to
             // false, see GCArguments::initialize.
             return false;

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ReferenceObjectProcessing.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ReferenceObjectProcessing.java
@@ -24,6 +24,7 @@
  */
 package com.oracle.svm.core.genscavenge;
 
+import static com.oracle.svm.core.Uninterruptible.CALLED_FROM_UNINTERRUPTIBLE_CODE;
 import static com.oracle.svm.core.heap.ReferenceInternals.getReferentFieldAddress;
 import static jdk.graal.compiler.nodes.extended.BranchProbabilityNode.SLOW_PATH_PROBABILITY;
 import static jdk.graal.compiler.nodes.extended.BranchProbabilityNode.probability;
@@ -251,6 +252,7 @@ final class ReferenceObjectProcessing {
         return space.isToSpace() || space.isCompactingOldSpace();
     }
 
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     static void updateForwardedRefs() {
         assert SerialGCOptions.useCompactingOldGen();
 

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ReferenceObjectProcessing.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ReferenceObjectProcessing.java
@@ -246,6 +246,7 @@ final class ReferenceObjectProcessing {
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     private static boolean willSurviveThisCollection(Object obj) {
         if (SerialGCOptions.useCompactingOldGen() && GCImpl.getGCImpl().isCompleteCollection()) {
+            // Only for discovery, during processing for enqueuing mark status is already cleared
             return ObjectHeaderImpl.isMarked(obj);
         }
         HeapChunk.Header<?> chunk = HeapChunk.getEnclosingHeapChunk(obj);

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ReferenceObjectProcessing.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ReferenceObjectProcessing.java
@@ -45,7 +45,6 @@ import com.oracle.svm.core.heap.ObjectReferenceVisitor;
 import com.oracle.svm.core.heap.ReferenceInternals;
 import com.oracle.svm.core.hub.DynamicHub;
 import com.oracle.svm.core.snippets.KnownIntrinsics;
-import com.oracle.svm.core.thread.VMOperation;
 import com.oracle.svm.core.util.UnsignedUtils;
 
 import jdk.graal.compiler.word.Word;
@@ -61,9 +60,6 @@ final class ReferenceObjectProcessing {
      */
     private static UnsignedWord maxSoftRefAccessIntervalMs = UnsignedUtils.MAX_VALUE;
 
-    /** Treat all soft references as weak, typically to reclaim space when low on memory. */
-    private static boolean softReferencesAreWeak = false;
-
     /**
      * The first timestamp that was set as {@link SoftReference} clock, for examining references
      * that were created earlier than that.
@@ -73,13 +69,14 @@ final class ReferenceObjectProcessing {
     private ReferenceObjectProcessing() { // all static
     }
 
-    /*
-     * Enables (or disables) reclaiming all objects that are softly reachable only, typically as a
-     * last resort to avoid running out of memory.
+    /**
+     * Whether to treat all soft references as weak, typically as a last resort to reclaim extra
+     * objects when running out of memory.
      */
-    public static void setSoftReferencesAreWeak(boolean enabled) {
-        assert VMOperation.isGCInProgress();
-        softReferencesAreWeak = enabled;
+    @AlwaysInline("GC performance")
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    private static boolean areAllSoftReferencesWeak() {
+        return GCImpl.getGCImpl().isOutOfMemoryCollection();
     }
 
     @AlwaysInline("GC performance")
@@ -128,7 +125,7 @@ final class ReferenceObjectProcessing {
             RememberedSet.get().dirtyCardIfNecessary(dr, refObject, getReferentFieldAddress(dr));
             return;
         }
-        if (!softReferencesAreWeak && dr instanceof SoftReference) {
+        if (!areAllSoftReferencesWeak() && dr instanceof SoftReference) {
             long clock = ReferenceInternals.getSoftReferenceClock();
             long timestamp = ReferenceInternals.getSoftReferenceTimestamp((SoftReference<?>) dr);
             if (timestamp == 0) { // created or last accessed before the clock was initialized

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/RuntimeCodeCacheReachabilityAnalyzer.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/RuntimeCodeCacheReachabilityAnalyzer.java
@@ -24,12 +24,15 @@
  */
 package com.oracle.svm.core.genscavenge;
 
+import static com.oracle.svm.core.Uninterruptible.CALLED_FROM_UNINTERRUPTIBLE_CODE;
+
 import java.io.Serial;
 
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
 import org.graalvm.word.Pointer;
 
+import com.oracle.svm.core.Uninterruptible;
 import com.oracle.svm.core.heap.ObjectReferenceVisitor;
 import com.oracle.svm.core.heap.ReferenceAccess;
 import com.oracle.svm.core.heap.RuntimeCodeCacheCleaner;
@@ -52,6 +55,7 @@ final class RuntimeCodeCacheReachabilityAnalyzer implements ObjectReferenceVisit
     }
 
     @Override
+    @Uninterruptible(reason = "Avoid unnecessary safepoint checks in GC for performance.")
     public void visitObjectReferences(Pointer firstObjRef, boolean compressed, int referenceSize, Object holderObject, int count) {
         Pointer pos = firstObjRef;
         Pointer end = firstObjRef.add(Word.unsigned(count).multiply(referenceSize));
@@ -61,6 +65,7 @@ final class RuntimeCodeCacheReachabilityAnalyzer implements ObjectReferenceVisit
         }
     }
 
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     private static void visitObjectReference(Pointer ptrPtrToObject, boolean compressed) {
         Pointer ptrToObj = ReferenceAccess.singleton().readObjectAsUntrackedPointer(ptrPtrToObject, compressed);
         if (ptrToObj.isNonNull() && !isReachable(ptrToObj)) {
@@ -68,6 +73,7 @@ final class RuntimeCodeCacheReachabilityAnalyzer implements ObjectReferenceVisit
         }
     }
 
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     public static boolean isReachable(Pointer ptrToObj) {
         assert ptrToObj.isNonNull();
         if (HeapImpl.getHeapImpl().isInImageHeap(ptrToObj)) {
@@ -93,6 +99,7 @@ final class RuntimeCodeCacheReachabilityAnalyzer implements ObjectReferenceVisit
         return isAssumedReachable(clazz);
     }
 
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     private static boolean isAssumedReachable(Class<?> clazz) {
         Class<?>[] classesAssumedReachable = RuntimeCodeCacheCleaner.CLASSES_ASSUMED_REACHABLE;
         for (Class<?> aClass : classesAssumedReachable) {

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/RuntimeCodeCacheWalker.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/RuntimeCodeCacheWalker.java
@@ -24,10 +24,13 @@
  */
 package com.oracle.svm.core.genscavenge;
 
+import static com.oracle.svm.core.Uninterruptible.CALLED_FROM_UNINTERRUPTIBLE_CODE;
+
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
 
 import com.oracle.svm.core.SubstrateGCOptions;
+import com.oracle.svm.core.Uninterruptible;
 import com.oracle.svm.core.code.CodeInfo;
 import com.oracle.svm.core.code.CodeInfoAccess;
 import com.oracle.svm.core.code.RuntimeCodeCache.CodeInfoVisitor;
@@ -59,6 +62,7 @@ final class RuntimeCodeCacheWalker implements CodeInfoVisitor {
 
     @Override
     @DuplicatedInNativeCode
+    @Uninterruptible(reason = "Avoid unnecessary safepoint checks in GC for performance.")
     public void visitCode(CodeInfo codeInfo) {
         if (RuntimeCodeInfoAccess.areAllObjectsOnImageHeap(codeInfo)) {
             return;
@@ -114,10 +118,12 @@ final class RuntimeCodeCacheWalker implements CodeInfoVisitor {
         RuntimeCodeInfoAccess.walkWeakReferences(codeInfo, greyToBlackObjectVisitor);
     }
 
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     private static boolean isReachable(Object possiblyForwardedObject) {
         return RuntimeCodeCacheReachabilityAnalyzer.isReachable(Word.objectToUntrackedPointer(possiblyForwardedObject));
     }
 
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     private boolean hasWeakReferenceToUnreachableObject(CodeInfo codeInfo) {
         try {
             RuntimeCodeInfoAccess.walkWeakReferences(codeInfo, checkForUnreachableObjectsVisitor);

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/SerialGCOptions.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/SerialGCOptions.java
@@ -42,8 +42,8 @@ import jdk.graal.compiler.options.OptionValues;
 
 /** Options that are only valid for the serial GC (and not for the epsilon GC). */
 public final class SerialGCOptions {
-    @Option(help = "The garbage collection policy, either Adaptive (default) or BySpaceAndTime. Serial GC only.", type = OptionType.User)//
-    public static final HostedOptionKey<String> InitialCollectionPolicy = new HostedOptionKey<>("Adaptive", SerialGCOptions::validateSerialHostedOption);
+    @Option(help = "The garbage collection policy. Default: 'Adaptive2'. Former default: 'Adaptive' (deprecated). Serial GC only.", type = OptionType.User)//
+    public static final HostedOptionKey<String> InitialCollectionPolicy = new HostedOptionKey<>("Adaptive2", SerialGCOptions::validateSerialHostedOption);
 
     @Option(help = "Percentage of total collection time that should be spent on young generation collections. Serial GC with collection policy 'BySpaceAndTime' only.", type = OptionType.User)//
     public static final RuntimeOptionKey<Integer> PercentTimeInIncrementalCollection = new RuntimeOptionKey<>(50, SerialGCOptions::validateSerialRuntimeOption);

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/SerialGCOptions.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/SerialGCOptions.java
@@ -127,7 +127,7 @@ public final class SerialGCOptions {
     /** Query these options only through an appropriate method. */
     public static class ConcealedOptions {
         @Option(help = "Collect old generation by compacting in-place instead of copying. Serial GC only.", type = OptionType.Expert) //
-        public static final HostedOptionKey<Boolean> CompactingOldGen = new HostedOptionKey<>(false, SerialGCOptions::validateCompactingOldGen);
+        public static final HostedOptionKey<Boolean> CompactingOldGen = new HostedOptionKey<>(true, SerialGCOptions::validateCompactingOldGen);
 
         @Option(help = "Determines if a remembered set is used, which is necessary for collecting the young and old generation independently. Serial GC only.", type = OptionType.Expert) //
         public static final HostedOptionKey<Boolean> UseRememberedSet = new HostedOptionKey<>(true, SerialGCOptions::validateSerialHostedOption);
@@ -175,10 +175,10 @@ public final class SerialGCOptions {
     }
 
     private static void validateCompactingOldGen(HostedOptionKey<Boolean> compactingOldGen) {
-        if (!compactingOldGen.getValue()) {
+        validateSerialHostedOption(compactingOldGen);
+        if (!SubstrateOptions.useSerialGC() || !compactingOldGen.getValue()) {
             return;
         }
-        validateSerialHostedOption(compactingOldGen);
         if (!useRememberedSet()) {
             throw UserError.abort("%s requires %s.", SubstrateOptionsParser.commandArgument(ConcealedOptions.CompactingOldGen, "+"),
                             SubstrateOptionsParser.commandArgument(ConcealedOptions.UseRememberedSet, "+"));

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/Space.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/Space.java
@@ -24,6 +24,7 @@
  */
 package com.oracle.svm.core.genscavenge;
 
+import static com.oracle.svm.core.Uninterruptible.CALLED_FROM_UNINTERRUPTIBLE_CODE;
 import static jdk.graal.compiler.nodes.extended.BranchProbabilityNode.SLOW_PATH_PROBABILITY;
 import static jdk.graal.compiler.nodes.extended.BranchProbabilityNode.VERY_SLOW_PATH_PROBABILITY;
 import static jdk.graal.compiler.nodes.extended.BranchProbabilityNode.probability;
@@ -173,6 +174,7 @@ public final class Space {
         }
     }
 
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     void walkAlignedHeapChunks(AlignedHeapChunk.Visitor visitor) {
         AlignedHeapChunk.AlignedHeader chunk = getFirstAlignedHeapChunk();
         while (chunk.isNonNull()) {

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/YoungGeneration.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/YoungGeneration.java
@@ -194,7 +194,12 @@ public final class YoungGeneration extends Generation {
      * include chunks that will be freed at the end of the GC.
      */
     UnsignedWord getChunkBytes() {
-        return getEden().getChunkBytes().add(getSurvivorChunkBytes());
+        return getEdenChunkBytes().add(getSurvivorChunkBytes());
+    }
+
+    /** @see #getChunkBytes() */
+    UnsignedWord getEdenChunkBytes() {
+        return getEden().getChunkBytes();
     }
 
     /**

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/YoungGeneration.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/YoungGeneration.java
@@ -194,12 +194,7 @@ public final class YoungGeneration extends Generation {
      * include chunks that will be freed at the end of the GC.
      */
     UnsignedWord getChunkBytes() {
-        return getEdenChunkBytes().add(getSurvivorChunkBytes());
-    }
-
-    /** @see #getChunkBytes() */
-    UnsignedWord getEdenChunkBytes() {
-        return getEden().getChunkBytes();
+        return getEden().getChunkBytes().add(getSurvivorChunkBytes());
     }
 
     /**

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/compacting/CompactingVisitor.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/compacting/CompactingVisitor.java
@@ -24,9 +24,12 @@
  */
 package com.oracle.svm.core.genscavenge.compacting;
 
+import static com.oracle.svm.core.Uninterruptible.CALLED_FROM_UNINTERRUPTIBLE_CODE;
+
 import org.graalvm.word.Pointer;
 import org.graalvm.word.UnsignedWord;
 
+import com.oracle.svm.core.Uninterruptible;
 import com.oracle.svm.core.UnmanagedMemoryUtil;
 import com.oracle.svm.core.genscavenge.AlignedHeapChunk;
 import com.oracle.svm.core.genscavenge.HeapChunk;
@@ -35,12 +38,14 @@ import com.oracle.svm.core.genscavenge.HeapChunk;
 public final class CompactingVisitor implements ObjectMoveInfo.Visitor {
     private AlignedHeapChunk.AlignedHeader chunk;
 
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     public void init(AlignedHeapChunk.AlignedHeader c) {
         this.chunk = c;
         HeapChunk.setTopPointer(c, AlignedHeapChunk.getObjectsStart(c));
     }
 
     @Override
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     public boolean visit(Pointer objSeq, UnsignedWord size, Pointer destAddress, Pointer nextObjSeq) {
         if (size.equal(0)) { // gap right at the chunk's start
             assert objSeq.equal(AlignedHeapChunk.getObjectsStart(chunk));

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/compacting/ObjectMoveInfo.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/compacting/ObjectMoveInfo.java
@@ -83,6 +83,7 @@ public final class ObjectMoveInfo {
      */
     public static final int MAX_CHUNK_SIZE = ~(~0xffff * 8) + 1;
 
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     static void setNewAddress(Pointer objSeqStart, Pointer newAddress) {
         if (useCompressedLayout()) {
             long offset = newAddress.subtract(objSeqStart).rawValue();
@@ -105,6 +106,7 @@ public final class ObjectMoveInfo {
         }
     }
 
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     static void setObjectSeqSize(Pointer objSeqStart, UnsignedWord nbytes) {
         if (useCompressedLayout()) {
             UnsignedWord value = nbytes.unsignedDivide(ConfigurationValues.getObjectLayout().getAlignment());
@@ -125,6 +127,7 @@ public final class ObjectMoveInfo {
         }
     }
 
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     static void setNextObjectSeqOffset(Pointer objSeqStart, UnsignedWord offset) {
         if (useCompressedLayout()) {
             UnsignedWord value = offset.unsignedDivide(ConfigurationValues.getObjectLayout().getAlignment());
@@ -241,6 +244,7 @@ public final class ObjectMoveInfo {
     }
 
     @AlwaysInline("GC performance: enables non-virtual visitor call")
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     public static void visit(AlignedHeapChunk.AlignedHeader chunk, Visitor visitor) {
         Pointer p = AlignedHeapChunk.getObjectsStart(chunk);
         UnsignedWord size = getObjectSeqSize(p);
@@ -271,6 +275,7 @@ public final class ObjectMoveInfo {
          *
          * @return {@code true} if visiting should continue, {@code false} if visiting should stop.
          */
+        @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
         boolean visit(Pointer objSeq, UnsignedWord size, Pointer newAddress, Pointer nextObjSeq);
     }
 

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/compacting/ObjectMoveInfo.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/compacting/ObjectMoveInfo.java
@@ -180,6 +180,7 @@ public final class ObjectMoveInfo {
             while (p.notEqual(objSeqEnd)) {
                 assert p.belowThan(objSeqEnd);
                 Object obj = p.toObjectNonNull();
+                ObjectHeaderImpl.unsetMarkedAndKeepRememberedSetBit(obj);
                 UnsignedWord objSize = LayoutEncoding.getSizeFromObjectInlineInGC(obj);
 
                 /*

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/compacting/ObjectRefFixupVisitor.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/compacting/ObjectRefFixupVisitor.java
@@ -71,7 +71,7 @@ public final class ObjectRefFixupVisitor implements UninterruptibleObjectReferen
                             || holderObject == null // references from CodeInfo, invalidated or weak
                             || holderObject instanceof Reference<?>; // cleared referent
 
-            Object obj = newLocation.toObjectNonNull();
+            Object obj = newLocation.toObject();
             ReferenceAccess.singleton().writeObjectAt(objRef, obj, compressed);
         }
         // Note that image heap cards have already been cleaned and re-marked during the scan

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/compacting/PlanningVisitor.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/compacting/PlanningVisitor.java
@@ -33,6 +33,7 @@ import org.graalvm.word.UnsignedWord;
 
 import com.oracle.svm.core.config.ConfigurationValues;
 import com.oracle.svm.core.genscavenge.AlignedHeapChunk;
+import com.oracle.svm.core.genscavenge.GCImpl;
 import com.oracle.svm.core.genscavenge.HeapChunk;
 import com.oracle.svm.core.genscavenge.ObjectHeaderImpl;
 import com.oracle.svm.core.genscavenge.Space;
@@ -183,6 +184,9 @@ public final class PlanningVisitor implements AlignedHeapChunk.Visitor {
 
     private static Pointer getSweptChunkAllocationPointer(AlignedHeapChunk.AlignedHeader chunk) {
         assert chunk.getShouldSweepInsteadOfCompact();
+        if (GCImpl.getGCImpl().isOutOfMemoryCollection()) {
+            return HeapChunk.getTopPointer(chunk);
+        }
         /*
          * Continue allocation for compaction in the next chunk. Moving in other objects is likely
          * to increase future fragmentation and sweeping effort until the chunk can participate in

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/compacting/PlanningVisitor.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/compacting/PlanningVisitor.java
@@ -149,18 +149,9 @@ public final class PlanningVisitor implements AlignedHeapChunk.Visitor {
             ObjectMoveInfo.setObjectSeqSize(objSeq, objSeqSize);
         }
 
-        if (sweeping) {
-            /*
-             * Continue allocating for compaction after the swept memory. Note that this forfeits
-             * unused memory in the chunks before, but the order of objects must stay the same
-             * across all chunks. If chunks end up completely empty however, they will be released
-             * after compaction.
-             *
-             * GR-54021: it should be possible to avoid this limitation by sweeping chunks without
-             * ObjectMoveInfo and brick tables and potentially even do the sweeping right here.
-             */
-            this.allocChunk = chunk;
-            this.allocPointer = HeapChunk.getTopPointer(chunk);
+        if (sweeping && chunk.equal(allocChunk)) {
+            /* Continue allocating for compaction after the swept memory. */
+            allocPointer = HeapChunk.getTopPointer(chunk);
         }
 
         /* Set remaining brick table entries at chunk end. */
@@ -174,14 +165,17 @@ public final class PlanningVisitor implements AlignedHeapChunk.Visitor {
     }
 
     private Pointer allocate(UnsignedWord size) {
+        assert size.belowOrEqual(AlignedHeapChunk.getUsableSizeForObjects());
         Pointer p = allocPointer;
-        allocPointer = allocPointer.add(size);
-        if (allocPointer.aboveThan(AlignedHeapChunk.getObjectsEnd(allocChunk))) {
+        allocPointer = p.add(size);
+        while (allocPointer.aboveThan(AlignedHeapChunk.getObjectsEnd(allocChunk))) {
             allocChunk = HeapChunk.getNext(allocChunk);
             assert allocChunk.isNonNull();
-            assert !allocChunk.getShouldSweepInsteadOfCompact();
-
-            p = AlignedHeapChunk.getObjectsStart(allocChunk);
+            if (allocChunk.getShouldSweepInsteadOfCompact()) {
+                p = HeapChunk.getTopPointer(allocChunk); // use any free memory at the end
+            } else {
+                p = AlignedHeapChunk.getObjectsStart(allocChunk);
+            }
             allocPointer = p.add(size);
         }
         return p;

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/compacting/PlanningVisitor.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/compacting/PlanningVisitor.java
@@ -99,8 +99,6 @@ public final class PlanningVisitor implements AlignedHeapChunk.Visitor {
             }
 
             if (ObjectHeaderImpl.isMarkedHeader(header)) {
-                ObjectHeaderImpl.unsetMarkedAndKeepRememberedSetBit(p.toObjectNonNull());
-
                 /*
                  * Adding the optional identity hash field would increase an object's size, so we
                  * should have copied all objects that need one during marking instead.

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/compacting/RuntimeCodeCacheFixupWalker.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/compacting/RuntimeCodeCacheFixupWalker.java
@@ -27,6 +27,7 @@ package com.oracle.svm.core.genscavenge.compacting;
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
 
+import com.oracle.svm.core.Uninterruptible;
 import com.oracle.svm.core.code.CodeInfo;
 import com.oracle.svm.core.code.RuntimeCodeCache.CodeInfoVisitor;
 import com.oracle.svm.core.code.RuntimeCodeInfoAccess;
@@ -43,6 +44,7 @@ public final class RuntimeCodeCacheFixupWalker implements CodeInfoVisitor {
     }
 
     @Override
+    @Uninterruptible(reason = "Avoid unnecessary safepoint checks in GC for performance.")
     public void visitCode(CodeInfo codeInfo) {
         if (RuntimeCodeInfoAccess.areAllObjectsOnImageHeap(codeInfo)) {
             return;

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/compacting/SweepingVisitor.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/compacting/SweepingVisitor.java
@@ -24,9 +24,12 @@
  */
 package com.oracle.svm.core.genscavenge.compacting;
 
+import static com.oracle.svm.core.Uninterruptible.CALLED_FROM_UNINTERRUPTIBLE_CODE;
+
 import org.graalvm.word.Pointer;
 import org.graalvm.word.UnsignedWord;
 
+import com.oracle.svm.core.Uninterruptible;
 import com.oracle.svm.core.genscavenge.AlignedHeapChunk;
 import com.oracle.svm.core.genscavenge.FillerObjectUtil;
 import com.oracle.svm.core.genscavenge.HeapChunk;
@@ -38,6 +41,7 @@ import com.oracle.svm.core.genscavenge.HeapChunk;
 public final class SweepingVisitor implements ObjectMoveInfo.Visitor {
 
     @Override
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     public boolean visit(Pointer objSeq, UnsignedWord size, Pointer newAddress, Pointer nextObjSeq) {
         assert objSeq.equal(newAddress);
         if (nextObjSeq.isNonNull()) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/Isolates.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/Isolates.java
@@ -74,6 +74,7 @@ public class Isolates {
     /* Only used if SpawnIsolates is disabled. */
     private static final CGlobalData<Pointer> SINGLE_ISOLATE_ALREADY_CREATED = CGlobalDataFactory.createWord();
 
+    private static boolean startTimesAssigned;
     private static long startTimeNanos;
     private static long initDoneTimeMillis;
     private static long isolateId = -1;
@@ -108,29 +109,33 @@ public class Isolates {
     }
 
     public static void assignStartTime() {
-        assert startTimeNanos == 0 : startTimeNanos;
-        assert initDoneTimeMillis == 0 : initDoneTimeMillis;
+        assert !startTimesAssigned;
         startTimeNanos = System.nanoTime();
         initDoneTimeMillis = TimeUtils.currentTimeMillis();
+        startTimesAssigned = true;
     }
 
     /** Epoch-based timestamp. If possible, {@link #getStartTimeNanos()} should be used instead. */
     @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     public static long getInitDoneTimeMillis() {
-        assert initDoneTimeMillis != 0;
+        assert startTimesAssigned;
         return initDoneTimeMillis;
     }
 
     @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     public static long getUptimeMillis() {
-        assert startTimeNanos != 0;
-        return TimeUtils.millisSinceNanos(startTimeNanos);
+        return TimeUtils.millisSinceNanos(getStartTimeNanos());
     }
 
     @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     public static long getStartTimeNanos() {
-        assert startTimeNanos != 0;
+        assert startTimesAssigned;
         return startTimeNanos;
+    }
+
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+    public static boolean isStartTimeAssigned() {
+        return startTimesAssigned;
     }
 
     /**

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/code/RuntimeCodeInfoAccess.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/code/RuntimeCodeInfoAccess.java
@@ -192,6 +192,7 @@ public final class RuntimeCodeInfoAccess {
      * This method only visits a very specific subset of all the references, so you typically want
      * to use {@link #walkStrongReferences} and/or {@link #walkWeakReferences} instead.
      */
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     public static void walkObjectFields(CodeInfo info, ObjectReferenceVisitor visitor) {
         NonmovableArrays.walkUnmanagedObjectArray(cast(info).getObjectFields(), visitor);
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/code/RuntimeCodeInfoAccess.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/code/RuntimeCodeInfoAccess.java
@@ -24,6 +24,8 @@
  */
 package com.oracle.svm.core.code;
 
+import static com.oracle.svm.core.Uninterruptible.CALLED_FROM_UNINTERRUPTIBLE_CODE;
+
 import org.graalvm.nativeimage.c.function.CodePointer;
 import org.graalvm.word.Pointer;
 import org.graalvm.word.UnsignedWord;
@@ -146,6 +148,7 @@ public final class RuntimeCodeInfoAccess {
         return objectFields;
     }
 
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     public static boolean areAllObjectsOnImageHeap(CodeInfo info) {
         return cast(info).getAllObjectsAreInImageHeap();
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/config/ObjectLayout.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/config/ObjectLayout.java
@@ -293,9 +293,17 @@ public final class ObjectLayout {
         return alignUp(size);
     }
 
+    public int getMinRuntimeHeapInstanceSize() {
+        return getMinInstanceSize(false);
+    }
+
     public int getMinImageHeapInstanceSize() {
+        return getMinInstanceSize(true);
+    }
+
+    private int getMinInstanceSize(boolean withOptionalIdHashField) {
         int unalignedSize = firstFieldOffset; // assumes no always-present "synthetic fields"
-        if (isIdentityHashFieldAtTypeSpecificOffset() || isIdentityHashFieldOptional()) {
+        if (isIdentityHashFieldAtTypeSpecificOffset() || (withOptionalIdHashField && isIdentityHashFieldOptional())) {
             int idHashOffset = NumUtil.roundUp(unalignedSize, Integer.BYTES);
             unalignedSize = idHashOffset + Integer.BYTES;
         }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/ReferenceInternals.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/ReferenceInternals.java
@@ -24,6 +24,7 @@
  */
 package com.oracle.svm.core.heap;
 
+import static com.oracle.svm.core.Uninterruptible.CALLED_FROM_UNINTERRUPTIBLE_CODE;
 import static jdk.graal.compiler.nodes.extended.BranchProbabilityNode.EXTREMELY_FAST_PATH_PROBABILITY;
 import static jdk.graal.compiler.nodes.extended.BranchProbabilityNode.probability;
 
@@ -127,6 +128,7 @@ public final class ReferenceInternals {
     }
 
     /** Read {@link Target_java_lang_ref_Reference#discovered}. */
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     public static <T> Reference<?> getNextDiscovered(Reference<T> instance) {
         return uncast(cast(instance).discovered);
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/hub/LayoutEncoding.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/hub/LayoutEncoding.java
@@ -24,6 +24,8 @@
  */
 package com.oracle.svm.core.hub;
 
+import static com.oracle.svm.core.Uninterruptible.CALLED_FROM_UNINTERRUPTIBLE_CODE;
+
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
 import org.graalvm.word.Pointer;
@@ -355,6 +357,7 @@ public class LayoutEncoding {
     }
 
     @AlwaysInline("GC performance")
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     public static UnsignedWord getSizeFromObjectWithoutOptionalIdHashFieldInGC(Object obj) {
         return getSizeFromObjectInline(obj, false);
     }


### PR DESCRIPTION
**This PR backports:**
(https://github.com/oracle/graal/commit/c17094a31a472f85c133a6dc9aca357014a06034)
(https://github.com/oracle/graal/commit/4c4a8d891798c2b2cac4774a45f1e5f9c54442fe)
(https://github.com/oracle/graal/commit/f590caa82f279863dbba65c3d7e064b111c450d5)
(https://github.com/oracle/graal/commit/5329f84785319bfea0fb80aba74d2fda0fcab9e9)
(https://github.com/oracle/graal/commit/003c1093045b89962f906c1c13db914eecd8e77c)
(https://github.com/oracle/graal/commit/1a7d4e4a8b0e61d7fc71868bb44c4994aec3c110)
(https://github.com/oracle/graal/commit/cf5dd9440d2882d9ff098e6505c363db97679e3b)
(https://github.com/oracle/graal/commit/18c0240103cdf6f40cdd7241b72524f6bd3ec0b1)
(https://github.com/oracle/graal/commit/bfdd845913d92bf3aefbf11902d71e680ec5845e)
(https://github.com/oracle/graal/commit/332a9d8ff447955342a4f172670e0085a63391ad)
(https://github.com/oracle/graal/commit/60e01c3e52026bcfbac898377c0207e72a0afb8e)
(https://github.com/oracle/graal/commit/f1d31192431568d2c03445407584093e7b50e931)
(https://github.com/oracle/graal/commit/63100e46986ec777ef520d8c18d2770a49e1b98e)
(https://github.com/oracle/graal/commit/28c2335c3bbfc7635972680630ddfb9636248b07)
(https://github.com/oracle/graal/commit/6203edab1771b55f8abbdc226a4bbafd1643a3ef)
(https://github.com/oracle/graal/commit/f11bb0521cf027a4da636c17d4372f88fcfff216)
(https://github.com/oracle/graal/commit/df07ca3f625deed970aaa92da9d9b29fc8ee893a)
(https://github.com/oracle/graal/commit/c8182c17e2e3c2d149264a760599c25ec33e05b4)
(https://github.com/oracle/graal/commit/1f7a5d29e2e356e8c8091f9efa781b51f3090fa2)
(https://github.com/oracle/graal/commit/5537ce91ec02d8065afd2b2bb4d1d18e5e960c44)
(https://github.com/oracle/graal/commit/e5604024e2075770b4bc403b66d048f2b97391dc)
(https://github.com/oracle/graal/commit/59eb933596aa6f943f2e6d0146171a6642541072)

**Conflicts:**

<details>

### https://github.com/oracle/graal/commit/4c4a8d891798c2b2cac4774a45f1e5f9c54442fe - Base LibGraalCollectionPolicy on the new Adaptive2 policy.

substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/LibGraalCollectionPolicy.java
```cpp
<<<<<<< HEAD
import jdk.graal.compiler.word.Word;
=======
>>>>>>> 4c4a8d89179 (Base LibGraalCollectionPolicy on the new Adaptive2 policy.)
```
- resolution: dropped that one as we already have one (org.graalvm.word.impl.Word, added elsewhere in the same diff, duplicates it)
```cpp
<<<<<<< HEAD
     * The adjusting logic are as follows:
     *
=======
     * Potentially adjust the size of the eden space, overriding decisions of the base policy.
     *
>>>>>>> 4c4a8d89179 (Base LibGraalCollectionPolicy on the new Adaptive2 policy.)
```
- resolution: use theirs

### https://github.com/oracle/graal/commit/e5604024e2075770b4bc403b66d048f2b97391dc - Fix GC policy timers and enable timer assertions.

substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AbstractCollectionPolicy.java
```cpp
<<<<<<< HEAD
    public void onCollectionBegin(boolean completeCollection, long requestingNanoTime) {
        sizes.freeUnusedSizeParameters();

=======
    public void onCollectionBegin(boolean completeCollection, long beginNanoTime) {
>>>>>>> e5604024e20 (Fix GC policy timers and enable timer assertions.)
```
- resolution: renamed the param to beginNanoTime (all other overrides already use that name), kept our freeUnusedSizeParameters() call - the commit only renames the param, doesn't touch that line
substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AdaptiveCollectionPolicy.java
```cpp
<<<<<<< HEAD
=======
import com.oracle.svm.core.Isolates;
import com.oracle.svm.core.Uninterruptible;
>>>>>>> e5604024e20 (Fix GC policy timers and enable timer assertions.)
```
- resolution: keep both imports - used by this same commit's non-conflicting changes to onCollectionBegin() (Isolates.isStartTimeAssigned()/getStartTimeNanos(), new @Uninterruptible helper)
```cpp
<<<<<<< HEAD
                            cause, latestMajorMutatorIntervalNanos, timer.totalNanos(), sizes.getPromoSize());
=======
                            cause, latestMajorMutatorIntervalNanos, timer.lastIntervalNanos(), promoSize);
>>>>>>> e5604024e20 (Fix GC policy timers and enable timer assertions.)
```
- resolution: take timer.lastIntervalNanos() from theirs (the actual bug fix), keep sizes.getPromoSize() from ours (unrelated pre-existing refactor, not touched by this commit's diff)
```cpp
<<<<<<< HEAD
                            cause, latestMinorMutatorIntervalNanos, timer.totalNanos(), sizes.getEdenSize());
=======
                            cause, latestMinorMutatorIntervalNanos, timer.lastIntervalNanos(), edenSize);
>>>>>>> e5604024e20 (Fix GC policy timers and enable timer assertions.)
```
- resolution: same as above - timer.lastIntervalNanos() from theirs, sizes.getEdenSize() from ours

### https://github.com/oracle/graal/commit/f1d31192431568d2c03445407584093e7b50e931 - Unify redundant code paths.

substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
```cpp
<<<<<<< HEAD
            long startTicks = JfrGCEvents.startGCPhasePause();
            try {
                /*
                 * Snapshot the heap so that objects that are promoted afterwards can be visited.
                 * When using a compacting old generation, it absorbs all chunks from the young
                 * generation at this point.
                 */
                beginPromotion();
            } finally {
                JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), "Snapshot Heap", startTicks);
            }

            startTicks = JfrGCEvents.startGCPhasePause();
            try {
                /*
                 * Make sure all chunks with pinned objects are in toSpace, and any formerly pinned
                 * objects are in fromSpace.
                 */
                promoteChunksWithPinnedObjects();
            } finally {
                JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), "Promote Pinned Objects", startTicks);
            }

            startTicks = JfrGCEvents.startGCPhasePause();
            try {
                /*
                 * Stack references are grey at the beginning of a collection, so I need to blacken
                 * them.
                 */
                blackenStackRoots();

                /* Custom memory regions which contain object references. */
                walkThreadLocals();

                /*
                 * Native image Objects are grey at the beginning of a collection, so I need to
                 * blacken them.
                 */
                blackenImageHeapRoots();
            } finally {
                JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), "Scan Roots", startTicks);
            }

            startTicks = JfrGCEvents.startGCPhasePause();
            try {
                /* Visit all the Objects promoted since the snapshot. */
                scanGreyObjects();

                if (RuntimeCompilation.isEnabled()) {
                    /*
                     * Visit the runtime compiled code, now that we know all the reachable objects.
                     */
                    walkRuntimeCodeCache();

                    /* Visit all objects that became reachable because of the compiled code. */
                    scanGreyObjects();
                }
            } finally {
                JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), "Scan From Roots", startTicks);
            }
=======
            /* Snapshot the heap so that objects that are promoted afterwards can be visited. */
            beginPromotion();
>>>>>>> f1d31192431 (Unify redundant code paths.)
```
-  resolution: took theirs - the rest of HEAD's block (promotion, blackening, scanGreyObjects) already runs later in this method
```cpp
<<<<<<< HEAD

                /*
                 * Stack references are grey at the beginning of a collection, so I need to blacken
                 * them.
                 */
                blackenStackRoots();

                /* Custom memory regions which contain object references. */
                walkThreadLocals();

                /*
                 * Native image Objects are grey at the beginning of a collection, so I need to
                 * blacken them.
                 */
                blackenDirtyImageHeapRoots();
            } finally {
                JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), "Scan Roots", startTicks);
=======
>>>>>>> f1d31192431 (Unify redundant code paths.)
```
- resolution: took theirs (empty - just closes the `if (!completeCollection)` block right after blackenDirtyCardRoots()). The lines right after the conflict marker (not part of the conflict) already read: `blackenStackRoots(); blackenThreadLocals(); blackenImageHeapRoots(); blackenMetaspace();` - renamed blackenThreadLocals() -> walkThreadLocals() there (this codebase's method name) and dropped blackenMetaspace() (Metaspace GC feature not present here)

### https://github.com/oracle/graal/commit/59eb933596aa6f943f2e6d0146171a6642541072 - Split object arrays in ranges for marking.

substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CompactingOldGeneration.java
```cpp
<<<<<<< HEAD
=======
import com.oracle.svm.core.metaspace.Metaspace;
import com.oracle.svm.core.snippets.KnownIntrinsics;
>>>>>>> 59eb933596a (Split object arrays in ranges for marking.)
```
- resolution: kept KnownIntrinsics (needed for KnownIntrinsics.readHub() added elsewhere in this same commit), dropped Metaspace (unused - it's only needed by fixupMetaspace(), a method from a GC feature not present in this codebase)
### https://github.com/oracle/graal/commit/60e01c3e52026bcfbac898377c0207e72a0afb8e - Avoid unnecessary safepoint checks in CompactingOldGen.
substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/ReferenceInternals.java
```cpp
<<<<<<< HEAD
=======
import static com.oracle.svm.core.NeverInline.CALLER_CATCHES_IMPLICIT_EXCEPTIONS;
import static com.oracle.svm.core.Uninterruptible.CALLED_FROM_UNINTERRUPTIBLE_CODE;
>>>>>>> 60e01c3e520 (Avoid unnecessary safepoint checks in CompactingOldGen.)
```
- resolution: kept CALLED_FROM_UNINTERRUPTIBLE_CODE (used by a new @Uninterruptible annotation this commit adds elsewhere in the file), dropped CALLER_CATCHES_IMPLICIT_EXCEPTIONS - unused here, the existing @NeverInline annotations in this file use a string literal instead
substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CompactingOldGeneration.java
```cpp
<<<<<<< HEAD
    @Uninterruptible(reason = "Avoid unnecessary safepoint checks in GC for performance.")
=======
    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
    private void fixupMetaspace() {
        if (!Metaspace.isSupported()) {
            return;
        }

        if (SerialGCOptions.useRememberedSet()) {
            /* Cards have been cleaned and roots re-marked during the initial scan. */
            MetaspaceImpl.singleton().walkDirtyObjects(fixupVisitor, refFixupVisitor, false);
        } else {
            MetaspaceImpl.singleton().walkObjects(fixupVisitor);
        }
    }

    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
>>>>>>> 60e01c3e520 (Avoid unnecessary safepoint checks in CompactingOldGen.)
```
- resolution: kept only the annotation swap to CALLED_FROM_UNINTERRUPTIBLE_CODE for fixupUnalignedChunkReferences (the commit's actual point - swapping the string-literal reason for the constant on several existing methods). Dropped fixupMetaspace() entirely - Metaspace GC feature not present in this codebase.

### https://github.com/oracle/graal/commit/bfdd845913d92bf3aefbf11902d71e680ec5845e - Improvements to existing policy code.

substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AdaptiveCollectionPolicy.java
```cpp
<<<<<<< HEAD

import jdk.graal.compiler.word.Word;
=======
>>>>>>> bfdd845913d (Improvements to existing policy code.)
```
- resolution: kept jdk.graal.compiler.word.Word - dropped the org.graalvm.word.impl.Word added elsewhere in the same diff instead (duplicate name; Word.unsigned() calls in this file resolve against jdk.graal.compiler.word.Word, consistent with every sibling policy file)
substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CopyingOldGeneration.java
```cpp
<<<<<<< HEAD

import jdk.graal.compiler.word.Word;
=======
>>>>>>> bfdd845913d (Improvements to existing policy code.)
```
- resolution: same as above - kept jdk.graal.compiler.word.Word, dropped the duplicate org.graalvm.word.impl.Word added elsewhere in the diff

### https://github.com/oracle/graal/commit/18c0240103cdf6f40cdd7241b72524f6bd3ec0b1 - Initial port of new Adaptive policy.

substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CollectionPolicy.java
```cpp
<<<<<<< HEAD

import jdk.graal.compiler.word.Word;
=======
>>>>>>> 18c0240103c (Initial port of new Adaptive policy.)
```
- resolution: kept jdk.graal.compiler.word.Word (used at `Word.unsigned(-1L)`, consistent with every sibling policy file), dropped the org.graalvm.word.impl.Word added elsewhere in the same diff (duplicate name)

Note: this commit also adds three brand-new files (AdaptiveCollectionPolicy2.java,
LinearLeastSquareFit.java, NumberSeq.java) - those applied as clean additions,
no conflicts. AdaptiveCollectionPolicy2.java still imports org.graalvm.word.impl.Word
internally - left untouched there since it's a new, self-contained file, not a
modification of a file this repo already had.

### https://github.com/oracle/graal/commit/f590caa82f279863dbba65c3d7e064b111c450d5 - Enable compacting old generation by default.

sdk/mx.sdk/mx_sdk_benchmark.py
```cpp
<<<<<<< HEAD
        rule = r'^(?P<native_architecture>native-architecture-)?(?P<string_inlining>string-inlining-)?(?P<otw>otw-)?(?P<compacting_gc>compacting-gc-)?(?P<preserve_all>preserve-all-)?(?P<preserve_classpath>preserve-classpath-)?' \
               r'(?P<future_defaults_all>future-defaults-all-)?(?P<gate>gate-)?(?P<upx>upx-)?(?P<quickbuild>quickbuild-)?(?P<layered>layered-)?(?P<graalos>graalos-)?(?P<gc>g1gc-)?' \
               r'(?P<llvm>llvm-)?(?P<pgo>pgo-|pgo-sampler-)?(?P<inliner>inline-)?' \
=======
        rule = r'^(?P<native_architecture>native-architecture-)?(?P<string_inlining>string-inlining-)?(?P<otw>otw-)?(?P<copyingoldgen_oldpolicy>copyingoldgen-oldpolicy-)?(?P<crema>crema-)?(?P<preserve_all>preserve-all-)?(?P<preserve_classpath>preserve-classpath-)?' \
               r'(?P<graalos>graalos-)?(?P<graalhost_graalos>graalhost-graalos-)?(?P<pie>pie-)?(?P<layered>layered-)?' \
               r'(?P<future_defaults_all>future-defaults-all-)?(?P<gate>gate-)?(?P<upx>upx-)?(?P<quickbuild>quickbuild-)?(?P<gc>g1gc-)?' \
               r'(?P<llvm>llvm-)?(?P<pgo>pgo-|pgo-sampler-|pgo-perf-sampler-invoke-multiple-|pgo-perf-sampler-invoke-|pgo-perf-sampler-)?(?P<inliner>inline-)?' \
>>>>>>> f590caa82f2 (Enable compacting old generation by default.)
```
- resolution: kept our group set/order, applied only the rename this commit actually makes.
 
</details>

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk25u/issues/65