### PR TITLE
[Backport] [Oracle GraalVM] [GR-72141] Backport to 25.0: Available memory should never exceed total memory.

### DIFF
--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/MemoryUtil.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/MemoryUtil.java
@@ -122,7 +122,7 @@ class MemoryUtil {
         if (isDedicatedMemoryUsage) {
             reasonableMaxMemorySize = dedicatedMemorySize;
         } else {
-            reasonableMaxMemorySize = getAvailableMemorySize();
+            reasonableMaxMemorySize = Math.min(getAvailableMemorySize(), totalMemorySize);
             if (reasonableMaxMemorySize >= MIN_AVAILABLE_MEMORY_THRESHOLD_GB * GiB_TO_BYTES) {
                 memoryUsageReason = "using available memory";
             } else { // fall back to dedicated mode


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/12720

**Conflicts:**
```cpp
<<<<<<< HEAD
            reasonableMaxMemorySize = getAvailableMemorySize();
            if (reasonableMaxMemorySize >= MIN_AVAILABLE_MEMORY_THRESHOLD_GB * GiB_TO_BYTES) {
                memoryUsageReason = "using available memory";
=======
            long availableMemorySize = Math.min(getAvailableMemorySize.get(), totalMemorySize);
            if (availableMemorySize >= MIN_AVAILABLE_MEMORY_THRESHOLD_GB * GiB_TO_BYTES) {
                reason = percentageOfSystemMemoryText(availableMemorySize, totalMemorySize) + ", using all available memory";
                maxMemory = availableMemorySize;
>>>>>>> baf76292b72 (Available memory should never exceed total memory
```
- mainline change is based on the additional rework: https://github.com/oracle/graal/commit/dff3f6437686b0563841af90a1949a165db0a9fb
- solution: manually add Math.min

Closes: https://github.com/graalvm/graalvm-community-jdk25u/issues/83