### PR TITLE
[Backport] [Oracle GraalVM] [GR-73830] Backport to 25.0: Don't execute recurring callbacks while holding the thread mutex.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/RecurringCallbackSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/RecurringCallbackSupport.java
@@ -435,7 +435,16 @@ public class RecurringCallbackSupport {
 
         @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
         private boolean isCallbackDisabled() {
-            return isExecuting || isCallbackTimerSuspended();
+            /*
+             * When a thread holds the THREAD_MUTEX, safepoint checks are typically either
+             * disallowed or recurring callbacks are explicitly disabled. However, if a thread
+             * acquires the THREAD_MUTEX while in STATUS_IN_NATIVE, it is possible to enter the
+             * safepoint slowpath when doing the transition back to STATUS_IN_JAVA.
+             *
+             * Recurring callbacks may trigger VM operations such as GCs. So. deadlocks could happen
+             * if we tried to execute a recurring callback while holding the THREAD_MUTEX.
+             */
+            return isExecuting || isCallbackTimerSuspended() || VMThreads.THREAD_MUTEX.isOwner();
         }
 
         /**


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/13075
  - [commit#2](https://github.com/oracle/graal/pull/13075/changes/d42acf7a91ebda9f4635c540ab1df3394e1f473b)

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:**
- minor import header section conflict
- solution: skip the import update

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk25u/issues/81