### PR TITLE
[Backport] [Oracle GraalVM] [GR-74781] Backport to 25.0: Add declaration for pread.

### DIFF
--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Unistd.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Unistd.java
@@ -142,5 +142,8 @@ public class Unistd {
 
         @CFunction(transition = Transition.NO_TRANSITION)
         public static native int geteuid();
+
+        @CFunction(transition = Transition.NO_TRANSITION)
+        public static native SignedWord pread(int fd, PointerBase buf, UnsignedWord nbytes, SignedWord offset);
     }
 }


### PR DESCRIPTION
**This PR backports:**
- https://github.com/oracle/graal/pull/13276

<!-- Mention any conflicts and their resolution or that the backport applied cleanly -->
**Conflicts:**
- minor conflict: mainline contains one more declaration: `public static native int fsync(int fd);`
- solution: skip the additional declaration, follow the change

<!-- Add the backport issue that this PR closes -->
Closes: https://github.com/graalvm/graalvm-community-jdk25u/issues/82